### PR TITLE
feat: add internal/shaper package with Shaper interface and NoopShaper

### DIFF
--- a/internal/shaper/noop.go
+++ b/internal/shaper/noop.go
@@ -1,0 +1,49 @@
+package shaper
+
+import "time"
+
+// NoopShaper is a passthrough Shaper: it imposes no sizing, delay or
+// fragmentation. It exists so the pipeline can always hold a non-nil Shaper
+// and so tests have a deterministic baseline.
+type NoopShaper struct{}
+
+// NewNoopShaper returns a passthrough shaper. The zero value is also usable;
+// the constructor exists for symmetry with future shapers that take config.
+func NewNoopShaper() *NoopShaper {
+	return &NoopShaper{}
+}
+
+// NextPacketSize returns len(payload)-equivalent semantics by returning 0,
+// which callers interpret as "use whatever size the payload already has".
+// Direction is ignored.
+func (NoopShaper) NextPacketSize(_ Direction) int {
+	return 0
+}
+
+// NextDelay always returns zero — passthrough never throttles.
+func (NoopShaper) NextDelay(_ Direction) time.Duration {
+	return 0
+}
+
+// Wrap returns the payload as a single frame without copying. Callers must
+// not mutate payload after the call until the returned frames are consumed.
+func (NoopShaper) Wrap(payload []byte) [][]byte {
+	return [][]byte{payload}
+}
+
+// Unwrap concatenates frames in order. A nil/empty input yields nil to keep
+// roundtrip semantics with Wrap(nil).
+func (NoopShaper) Unwrap(frames [][]byte) []byte {
+	if len(frames) == 0 {
+		return nil
+	}
+	total := 0
+	for _, f := range frames {
+		total += len(f)
+	}
+	out := make([]byte, 0, total)
+	for _, f := range frames {
+		out = append(out, f...)
+	}
+	return out
+}

--- a/internal/shaper/shaper.go
+++ b/internal/shaper/shaper.go
@@ -1,0 +1,42 @@
+// Package shaper defines the behavioral traffic-shaping abstraction used to
+// decouple TLS transport from anti-DPI shaping. Concrete shapers can mimic
+// browsing patterns, video streams, etc.; tests and the default pipeline use
+// NoopShaper to keep traffic unchanged.
+package shaper
+
+import "time"
+
+// Direction distinguishes upstream (client→server) from downstream traffic so
+// shapers can produce asymmetric profiles (e.g. video: small up, large down).
+type Direction int
+
+const (
+	// DirectionUp is client→server traffic.
+	DirectionUp Direction = iota
+	// DirectionDown is server→client traffic.
+	DirectionDown
+)
+
+// Shaper drives packet sizing, inter-packet delays and frame fragmentation to
+// reshape a raw byte stream into a traffic profile that resists DPI behavioral
+// fingerprinting. Implementations must be safe for concurrent use only when
+// documented; the default is per-direction single-goroutine usage.
+type Shaper interface {
+	// NextPacketSize returns the target size in bytes for the next packet
+	// emitted in direction d. The caller may use this as a hint when batching
+	// or padding; returning len(payload) means "no preference".
+	NextPacketSize(d Direction) int
+
+	// NextDelay returns how long the caller should sleep before emitting the
+	// next packet in direction d. Zero means "send immediately".
+	NextDelay(d Direction) time.Duration
+
+	// Wrap fragments/pads payload into one or more frames ready for the wire.
+	// Implementations must preserve byte order so Unwrap can reconstruct the
+	// original payload.
+	Wrap(payload []byte) [][]byte
+
+	// Unwrap reassembles frames produced by Wrap (possibly across calls) into
+	// the original payload bytes.
+	Unwrap(frames [][]byte) []byte
+}

--- a/internal/shaper/shaper_test.go
+++ b/internal/shaper/shaper_test.go
@@ -1,0 +1,86 @@
+package shaper
+
+import (
+	"bytes"
+	"testing"
+	"time"
+)
+
+func TestNoopShaper_ImplementsInterface(t *testing.T) {
+	var _ Shaper = NoopShaper{}
+	var _ Shaper = NewNoopShaper()
+}
+
+func TestNoopShaper_NextPacketSize_Deterministic(t *testing.T) {
+	s := NewNoopShaper()
+	for _, d := range []Direction{DirectionUp, DirectionDown} {
+		for range 5 {
+			if got := s.NextPacketSize(d); got != 0 {
+				t.Fatalf("NextPacketSize(%v) = %d, want 0", d, got)
+			}
+		}
+	}
+}
+
+func TestNoopShaper_NextDelay_Zero(t *testing.T) {
+	s := NewNoopShaper()
+	for _, d := range []Direction{DirectionUp, DirectionDown} {
+		for range 5 {
+			if got := s.NextDelay(d); got != time.Duration(0) {
+				t.Fatalf("NextDelay(%v) = %v, want 0", d, got)
+			}
+		}
+	}
+}
+
+func TestNoopShaper_WrapUnwrap_Roundtrip(t *testing.T) {
+	s := NewNoopShaper()
+	cases := [][]byte{
+		nil,
+		{},
+		[]byte("hello"),
+		bytes.Repeat([]byte{0xAB}, 4096),
+	}
+	for _, in := range cases {
+		frames := s.Wrap(in)
+		out := s.Unwrap(frames)
+		if len(in) == 0 && len(out) == 0 {
+			continue
+		}
+		if !bytes.Equal(in, out) {
+			t.Fatalf("roundtrip mismatch: in=%d bytes out=%d bytes", len(in), len(out))
+		}
+	}
+}
+
+func TestNoopShaper_Wrap_SingleFrame(t *testing.T) {
+	s := NewNoopShaper()
+	payload := []byte("packet")
+	frames := s.Wrap(payload)
+	if len(frames) != 1 {
+		t.Fatalf("Wrap returned %d frames, want 1", len(frames))
+	}
+	if !bytes.Equal(frames[0], payload) {
+		t.Fatalf("Wrap altered payload: got %q want %q", frames[0], payload)
+	}
+}
+
+func TestNoopShaper_Unwrap_ConcatenatesInOrder(t *testing.T) {
+	s := NewNoopShaper()
+	frames := [][]byte{[]byte("foo"), []byte("bar"), []byte("baz")}
+	got := s.Unwrap(frames)
+	want := []byte("foobarbaz")
+	if !bytes.Equal(got, want) {
+		t.Fatalf("Unwrap = %q, want %q", got, want)
+	}
+}
+
+func TestNoopShaper_Unwrap_EmptyInput(t *testing.T) {
+	s := NewNoopShaper()
+	if got := s.Unwrap(nil); got != nil {
+		t.Fatalf("Unwrap(nil) = %v, want nil", got)
+	}
+	if got := s.Unwrap([][]byte{}); got != nil {
+		t.Fatalf("Unwrap([]) = %v, want nil", got)
+	}
+}


### PR DESCRIPTION
## Summary
- New `internal/shaper` package introducing the `Shaper` interface (`NextPacketSize`, `NextDelay`, `Wrap`, `Unwrap`) plus `Direction` enum so future shapers can produce asymmetric up/down profiles.
- `NoopShaper` passthrough implementation so the pipeline can always hold a non-nil shaper while concrete strategies land in later tasks.
- Unit tests cover determinism of `NextPacketSize`/`NextDelay`, single-frame `Wrap`, in-order `Unwrap` concatenation, and `Wrap`/`Unwrap` roundtrip across nil, empty, small and 4 KiB payloads.

This is the foundation step for issue #6 (decouple TLS from behavioral shaping). It does not touch `internal/strategy/` and is not yet wired into the main pipeline — those land in follow-up tasks `tiredvpn-oss-gsd` and `tiredvpn-oss-5wm`.

Refs: beads `tiredvpn-oss-umd`, issue #6

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/shaper/...`
- [x] `golangci-lint run ./internal/shaper/...` (govet + staticcheck per `.golangci.yml`)