### PR TITLE
feat: add probability distribution engines for traffic shaper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,4 @@ Thumbs.db
 .aider/
 
 # Build
-dist/
+/dist/

--- a/internal/shaper/dist/dist.go
+++ b/internal/shaper/dist/dist.go
@@ -1,0 +1,16 @@
+// Package dist provides probability distribution engines used by the traffic
+// shaper to generate randomized packet sizes and inter-arrival delays. The
+// goal is to avoid fixed statistical signatures that DPI middleboxes can
+// fingerprint.
+package dist
+
+// Distribution is the common interface implemented by every sampler in this
+// package. Implementations are deterministic given a seed and must support a
+// Reset that rewinds the internal RNG to the original seed.
+type Distribution interface {
+	// Next returns the next sample from the distribution.
+	Next() float64
+	// Reset rewinds the internal RNG so that subsequent samples reproduce
+	// the exact sequence emitted right after construction.
+	Reset()
+}

--- a/internal/shaper/dist/histogram.go
+++ b/internal/shaper/dist/histogram.go
@@ -1,0 +1,94 @@
+package dist
+
+import (
+	"fmt"
+	"math/rand/v2"
+)
+
+// HistogramBin describes a single bucket of a discrete weighted distribution.
+type HistogramBin struct {
+	Value  float64
+	Weight float64
+}
+
+// Histogram is a discrete weighted distribution. Each Next call picks a bin
+// proportionally to its weight and returns the bin's Value, optionally jittered
+// by ±RandomizationRange (a fraction in [0, 1)).
+type Histogram struct {
+	bins   []HistogramBin
+	cdf    []float64
+	totalW float64
+	jitter float64
+	seed1  uint64
+	seed2  uint64
+	pcg    *rand.PCG
+	rng    *rand.Rand
+}
+
+// NewHistogram constructs a Histogram from a non-empty slice of bins. All
+// weights must be non-negative and at least one must be strictly positive.
+func NewHistogram(bins []HistogramBin, seed int64) (*Histogram, error) {
+	if len(bins) == 0 {
+		return nil, fmt.Errorf("dist: histogram requires at least one bin")
+	}
+
+	cdf := make([]float64, len(bins))
+	var total float64
+	for i, b := range bins {
+		if b.Weight < 0 {
+			return nil, fmt.Errorf("dist: bin %d has negative weight %v", i, b.Weight)
+		}
+		total += b.Weight
+		cdf[i] = total
+	}
+	if total == 0 {
+		return nil, fmt.Errorf("dist: histogram total weight is zero")
+	}
+
+	binsCopy := make([]HistogramBin, len(bins))
+	copy(binsCopy, bins)
+
+	s1, s2 := splitSeed(seed)
+	pcg := rand.NewPCG(s1, s2)
+	return &Histogram{
+		bins:   binsCopy,
+		cdf:    cdf,
+		totalW: total,
+		seed1:  s1,
+		seed2:  s2,
+		pcg:    pcg,
+		rng:    rand.New(pcg),
+	}, nil
+}
+
+// SetRandomizationRange enables ±r jitter on the emitted value. r must be in
+// [0, 1).
+func (h *Histogram) SetRandomizationRange(r float64) error {
+	if r < 0 || r >= 1 {
+		return fmt.Errorf("dist: randomization range must be in [0,1), got %v", r)
+	}
+	h.jitter = r
+	return nil
+}
+
+// Next returns the next sample.
+func (h *Histogram) Next() float64 {
+	u := h.rng.Float64() * h.totalW
+	idx := len(h.cdf) - 1
+	for i, c := range h.cdf {
+		if u <= c {
+			idx = i
+			break
+		}
+	}
+	v := h.bins[idx].Value
+	if h.jitter > 0 {
+		v *= 1 + (h.rng.Float64()*2-1)*h.jitter
+	}
+	return v
+}
+
+// Reset rewinds the RNG to the initial seed state.
+func (h *Histogram) Reset() {
+	h.pcg.Seed(h.seed1, h.seed2)
+}

--- a/internal/shaper/dist/histogram_test.go
+++ b/internal/shaper/dist/histogram_test.go
@@ -1,0 +1,124 @@
+package dist
+
+import (
+	"math"
+	"testing"
+)
+
+func sampleHistogram() []HistogramBin {
+	return []HistogramBin{
+		{Value: 64, Weight: 0.2},
+		{Value: 256, Weight: 0.5},
+		{Value: 1024, Weight: 0.3},
+	}
+}
+
+func TestHistogramDeterminism(t *testing.T) {
+	const n = 1000
+	a, err := NewHistogram(sampleHistogram(), 42)
+	if err != nil {
+		t.Fatalf("NewHistogram: %v", err)
+	}
+	b, err := NewHistogram(sampleHistogram(), 42)
+	if err != nil {
+		t.Fatalf("NewHistogram: %v", err)
+	}
+	for i := 0; i < n; i++ {
+		x, y := a.Next(), b.Next()
+		if x != y {
+			t.Fatalf("sample %d differs: %v vs %v", i, x, y)
+		}
+	}
+}
+
+func TestHistogramReset(t *testing.T) {
+	h, err := NewHistogram(sampleHistogram(), 7)
+	if err != nil {
+		t.Fatalf("NewHistogram: %v", err)
+	}
+	first := make([]float64, 200)
+	for i := range first {
+		first[i] = h.Next()
+	}
+	h.Reset()
+	for i := range first {
+		if got := h.Next(); got != first[i] {
+			t.Fatalf("after reset sample %d differs: got %v want %v", i, got, first[i])
+		}
+	}
+}
+
+func TestHistogramFrequencies(t *testing.T) {
+	bins := sampleHistogram()
+	h, err := NewHistogram(bins, 1)
+	if err != nil {
+		t.Fatalf("NewHistogram: %v", err)
+	}
+	const N = 100_000
+	counts := make(map[float64]int)
+	for i := 0; i < N; i++ {
+		counts[h.Next()]++
+	}
+	var total float64
+	for _, b := range bins {
+		total += b.Weight
+	}
+	for _, b := range bins {
+		expected := b.Weight / total
+		actual := float64(counts[b.Value]) / float64(N)
+		if math.Abs(actual-expected) > 0.02 {
+			t.Errorf("bin value=%v: actual freq %v deviates from expected %v by more than 2%%",
+				b.Value, actual, expected)
+		}
+	}
+}
+
+func TestHistogramRandomizationRange(t *testing.T) {
+	bins := []HistogramBin{{Value: 1000, Weight: 1}}
+	h, err := NewHistogram(bins, 99)
+	if err != nil {
+		t.Fatalf("NewHistogram: %v", err)
+	}
+	if err := h.SetRandomizationRange(0.1); err != nil {
+		t.Fatalf("SetRandomizationRange: %v", err)
+	}
+	for i := 0; i < 1000; i++ {
+		v := h.Next()
+		if v < 900 || v > 1100 {
+			t.Fatalf("sample %v outside ±10%% jitter window", v)
+		}
+	}
+}
+
+func TestHistogramErrors(t *testing.T) {
+	if _, err := NewHistogram(nil, 0); err == nil {
+		t.Errorf("expected error for empty bins")
+	}
+	if _, err := NewHistogram([]HistogramBin{{Value: 1, Weight: -1}}, 0); err == nil {
+		t.Errorf("expected error for negative weight")
+	}
+	if _, err := NewHistogram([]HistogramBin{{Value: 1, Weight: 0}}, 0); err == nil {
+		t.Errorf("expected error for zero total weight")
+	}
+	h, err := NewHistogram(sampleHistogram(), 0)
+	if err != nil {
+		t.Fatalf("NewHistogram: %v", err)
+	}
+	if err := h.SetRandomizationRange(1.5); err == nil {
+		t.Errorf("expected error for r>=1")
+	}
+	if err := h.SetRandomizationRange(-0.1); err == nil {
+		t.Errorf("expected error for r<0")
+	}
+}
+
+func BenchmarkHistogramNext(b *testing.B) {
+	h, err := NewHistogram(sampleHistogram(), 1)
+	if err != nil {
+		b.Fatalf("NewHistogram: %v", err)
+	}
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = h.Next()
+	}
+}

--- a/internal/shaper/dist/lognormal.go
+++ b/internal/shaper/dist/lognormal.go
@@ -1,0 +1,42 @@
+package dist
+
+import (
+	"math"
+	"math/rand/v2"
+)
+
+// LogNormal samples X = exp(Mu + Sigma*Z) where Z ~ N(0, 1).
+type LogNormal struct {
+	Mu    float64
+	Sigma float64
+
+	seed1 uint64
+	seed2 uint64
+	pcg   *rand.PCG
+	rng   *rand.Rand
+}
+
+// NewLogNormal constructs a LogNormal sampler. Sigma must be non-negative.
+func NewLogNormal(mu, sigma float64, seed int64) *LogNormal {
+	s1, s2 := splitSeed(seed)
+	pcg := rand.NewPCG(s1, s2)
+	return &LogNormal{
+		Mu:    mu,
+		Sigma: sigma,
+		seed1: s1,
+		seed2: s2,
+		pcg:   pcg,
+		rng:   rand.New(pcg),
+	}
+}
+
+// Next returns the next sample.
+func (l *LogNormal) Next() float64 {
+	z := l.rng.NormFloat64()
+	return math.Exp(l.Mu + l.Sigma*z)
+}
+
+// Reset rewinds the RNG to the initial seed state.
+func (l *LogNormal) Reset() {
+	l.pcg.Seed(l.seed1, l.seed2)
+}

--- a/internal/shaper/dist/lognormal_test.go
+++ b/internal/shaper/dist/lognormal_test.go
@@ -1,0 +1,63 @@
+package dist
+
+import (
+	"math"
+	"testing"
+)
+
+func TestLogNormalDeterminism(t *testing.T) {
+	a := NewLogNormal(0, 1, 123)
+	b := NewLogNormal(0, 1, 123)
+	for i := 0; i < 1000; i++ {
+		x, y := a.Next(), b.Next()
+		if x != y {
+			t.Fatalf("sample %d differs: %v vs %v", i, x, y)
+		}
+	}
+}
+
+func TestLogNormalReset(t *testing.T) {
+	l := NewLogNormal(1, 0.5, 8)
+	first := make([]float64, 200)
+	for i := range first {
+		first[i] = l.Next()
+	}
+	l.Reset()
+	for i := range first {
+		if got := l.Next(); got != first[i] {
+			t.Fatalf("after reset sample %d differs: got %v want %v", i, got, first[i])
+		}
+	}
+}
+
+func TestLogNormalMoments(t *testing.T) {
+	mu, sigma := 1.0, 0.5
+	l := NewLogNormal(mu, sigma, 42)
+	const N = 100_000
+	var sum, sumSq float64
+	for i := 0; i < N; i++ {
+		v := l.Next()
+		sum += v
+		sumSq += v * v
+	}
+	mean := sum / N
+	variance := sumSq/N - mean*mean
+
+	expectedMean := math.Exp(mu + sigma*sigma/2)
+	expectedVar := (math.Exp(sigma*sigma) - 1) * math.Exp(2*mu+sigma*sigma)
+
+	if math.Abs(mean-expectedMean)/expectedMean > 0.05 {
+		t.Errorf("mean %v deviates from theoretical %v by more than 5%%", mean, expectedMean)
+	}
+	if math.Abs(variance-expectedVar)/expectedVar > 0.15 {
+		t.Errorf("variance %v deviates from theoretical %v by more than 15%%", variance, expectedVar)
+	}
+}
+
+func BenchmarkLogNormalNext(b *testing.B) {
+	l := NewLogNormal(1, 0.5, 1)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = l.Next()
+	}
+}

--- a/internal/shaper/dist/markov.go
+++ b/internal/shaper/dist/markov.go
@@ -1,0 +1,103 @@
+package dist
+
+import (
+	"fmt"
+	"math/rand/v2"
+)
+
+// MarkovState is a single state of a Markov burst process. The Value is what
+// Next returns whenever the chain occupies this state.
+type MarkovState struct {
+	Name  string
+	Value float64
+}
+
+// MarkovBurst is a discrete-time Markov chain. Each Next call advances the
+// chain by one step using the supplied transition matrix and returns the
+// current state's Value.
+type MarkovBurst struct {
+	states  []MarkovState
+	cumRows [][]float64
+	current int
+	initial int
+	seed1   uint64
+	seed2   uint64
+	pcg     *rand.PCG
+	rng     *rand.Rand
+}
+
+// NewMarkovBurst constructs a Markov chain. transitions must be a square
+// matrix sized len(states)×len(states); each row must sum to 1 (within a small
+// tolerance) and have non-negative entries. The chain starts in state 0.
+func NewMarkovBurst(states []MarkovState, transitions [][]float64, seed int64) (*MarkovBurst, error) {
+	n := len(states)
+	if n == 0 {
+		return nil, fmt.Errorf("dist: markov requires at least one state")
+	}
+	if len(transitions) != n {
+		return nil, fmt.Errorf("dist: transition matrix has %d rows, want %d", len(transitions), n)
+	}
+
+	cum := make([][]float64, n)
+	for i, row := range transitions {
+		if len(row) != n {
+			return nil, fmt.Errorf("dist: row %d has %d entries, want %d", i, len(row), n)
+		}
+		cumRow := make([]float64, n)
+		var sum float64
+		for j, p := range row {
+			if p < 0 {
+				return nil, fmt.Errorf("dist: transitions[%d][%d] is negative", i, j)
+			}
+			sum += p
+			cumRow[j] = sum
+		}
+		if sum < 0.999 || sum > 1.001 {
+			return nil, fmt.Errorf("dist: row %d sums to %v, want 1", i, sum)
+		}
+		cumRow[n-1] = 1
+		cum[i] = cumRow
+	}
+
+	statesCopy := make([]MarkovState, n)
+	copy(statesCopy, states)
+
+	s1, s2 := splitSeed(seed)
+	pcg := rand.NewPCG(s1, s2)
+	return &MarkovBurst{
+		states:  statesCopy,
+		cumRows: cum,
+		current: 0,
+		initial: 0,
+		seed1:   s1,
+		seed2:   s2,
+		pcg:     pcg,
+		rng:     rand.New(pcg),
+	}, nil
+}
+
+// Next advances the chain by one step and returns the new state's Value.
+func (m *MarkovBurst) Next() float64 {
+	u := m.rng.Float64()
+	row := m.cumRows[m.current]
+	next := len(row) - 1
+	for j, c := range row {
+		if u <= c {
+			next = j
+			break
+		}
+	}
+	m.current = next
+	return m.states[m.current].Value
+}
+
+// State returns the name of the current state.
+func (m *MarkovBurst) State() string {
+	return m.states[m.current].Name
+}
+
+// Reset rewinds the RNG and returns the chain to its initial state.
+func (m *MarkovBurst) Reset() {
+	m.pcg.Seed(m.seed1, m.seed2)
+	m.current = m.initial
+}

--- a/internal/shaper/dist/markov_test.go
+++ b/internal/shaper/dist/markov_test.go
@@ -1,0 +1,116 @@
+package dist
+
+import (
+	"math"
+	"testing"
+)
+
+func sampleMarkov() ([]MarkovState, [][]float64) {
+	states := []MarkovState{
+		{Name: "idle", Value: 0},
+		{Name: "burst", Value: 1500},
+	}
+	transitions := [][]float64{
+		{0.8, 0.2},
+		{0.4, 0.6},
+	}
+	return states, transitions
+}
+
+func TestMarkovDeterminism(t *testing.T) {
+	states, tr := sampleMarkov()
+	a, err := NewMarkovBurst(states, tr, 5)
+	if err != nil {
+		t.Fatalf("NewMarkovBurst: %v", err)
+	}
+	b, err := NewMarkovBurst(states, tr, 5)
+	if err != nil {
+		t.Fatalf("NewMarkovBurst: %v", err)
+	}
+	for i := 0; i < 1000; i++ {
+		x, y := a.Next(), b.Next()
+		if x != y {
+			t.Fatalf("sample %d differs: %v vs %v", i, x, y)
+		}
+	}
+}
+
+func TestMarkovReset(t *testing.T) {
+	states, tr := sampleMarkov()
+	m, err := NewMarkovBurst(states, tr, 17)
+	if err != nil {
+		t.Fatalf("NewMarkovBurst: %v", err)
+	}
+	first := make([]float64, 500)
+	for i := range first {
+		first[i] = m.Next()
+	}
+	m.Reset()
+	for i := range first {
+		if got := m.Next(); got != first[i] {
+			t.Fatalf("after reset sample %d differs: got %v want %v", i, got, first[i])
+		}
+	}
+}
+
+// Stationary distribution for the 2-state chain
+//
+//	P = [[0.8, 0.2], [0.4, 0.6]]
+//
+// solves π = πP and is π = (2/3, 1/3).
+func TestMarkovStationary(t *testing.T) {
+	states, tr := sampleMarkov()
+	m, err := NewMarkovBurst(states, tr, 99)
+	if err != nil {
+		t.Fatalf("NewMarkovBurst: %v", err)
+	}
+	const N = 200_000
+	const burn = 5_000
+	for i := 0; i < burn; i++ {
+		m.Next()
+	}
+	counts := make(map[string]int)
+	for i := 0; i < N; i++ {
+		m.Next()
+		counts[m.State()]++
+	}
+	expected := map[string]float64{"idle": 2.0 / 3.0, "burst": 1.0 / 3.0}
+	for name, want := range expected {
+		got := float64(counts[name]) / float64(N)
+		if math.Abs(got-want) > 0.02 {
+			t.Errorf("state %q frequency %v deviates from stationary %v by more than 2%%",
+				name, got, want)
+		}
+	}
+}
+
+func TestMarkovErrors(t *testing.T) {
+	if _, err := NewMarkovBurst(nil, nil, 0); err == nil {
+		t.Errorf("expected error for empty states")
+	}
+	states := []MarkovState{{Name: "a", Value: 1}, {Name: "b", Value: 2}}
+	if _, err := NewMarkovBurst(states, [][]float64{{1, 0}}, 0); err == nil {
+		t.Errorf("expected error for wrong row count")
+	}
+	if _, err := NewMarkovBurst(states, [][]float64{{1, 0}, {0.5}}, 0); err == nil {
+		t.Errorf("expected error for ragged row")
+	}
+	if _, err := NewMarkovBurst(states, [][]float64{{1, 0}, {0.4, 0.4}}, 0); err == nil {
+		t.Errorf("expected error for row not summing to 1")
+	}
+	if _, err := NewMarkovBurst(states, [][]float64{{1, 0}, {-0.1, 1.1}}, 0); err == nil {
+		t.Errorf("expected error for negative probability")
+	}
+}
+
+func BenchmarkMarkovNext(b *testing.B) {
+	states, tr := sampleMarkov()
+	m, err := NewMarkovBurst(states, tr, 1)
+	if err != nil {
+		b.Fatalf("NewMarkovBurst: %v", err)
+	}
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = m.Next()
+	}
+}

--- a/internal/shaper/dist/pareto.go
+++ b/internal/shaper/dist/pareto.go
@@ -1,0 +1,43 @@
+package dist
+
+import (
+	"math"
+	"math/rand/v2"
+)
+
+// Pareto samples a Type-I Pareto distribution with scale Xm > 0 and shape
+// Alpha > 0 via inverse CDF: X = Xm / U^(1/Alpha) where U ~ Uniform(0, 1].
+type Pareto struct {
+	Xm    float64
+	Alpha float64
+
+	seed1 uint64
+	seed2 uint64
+	pcg   *rand.PCG
+	rng   *rand.Rand
+}
+
+// NewPareto constructs a Pareto sampler.
+func NewPareto(xm, alpha float64, seed int64) *Pareto {
+	s1, s2 := splitSeed(seed)
+	pcg := rand.NewPCG(s1, s2)
+	return &Pareto{
+		Xm:    xm,
+		Alpha: alpha,
+		seed1: s1,
+		seed2: s2,
+		pcg:   pcg,
+		rng:   rand.New(pcg),
+	}
+}
+
+// Next returns the next sample.
+func (p *Pareto) Next() float64 {
+	u := 1.0 - p.rng.Float64()
+	return p.Xm / math.Pow(u, 1.0/p.Alpha)
+}
+
+// Reset rewinds the RNG to the initial seed state.
+func (p *Pareto) Reset() {
+	p.pcg.Seed(p.seed1, p.seed2)
+}

--- a/internal/shaper/dist/pareto_test.go
+++ b/internal/shaper/dist/pareto_test.go
@@ -1,0 +1,65 @@
+package dist
+
+import (
+	"math"
+	"testing"
+)
+
+func TestParetoDeterminism(t *testing.T) {
+	a := NewPareto(1, 3, 7)
+	b := NewPareto(1, 3, 7)
+	for i := 0; i < 1000; i++ {
+		x, y := a.Next(), b.Next()
+		if x != y {
+			t.Fatalf("sample %d differs: %v vs %v", i, x, y)
+		}
+	}
+}
+
+func TestParetoReset(t *testing.T) {
+	p := NewPareto(1, 2.5, 11)
+	first := make([]float64, 200)
+	for i := range first {
+		first[i] = p.Next()
+	}
+	p.Reset()
+	for i := range first {
+		if got := p.Next(); got != first[i] {
+			t.Fatalf("after reset sample %d differs: got %v want %v", i, got, first[i])
+		}
+	}
+}
+
+func TestParetoMean(t *testing.T) {
+	xm, alpha := 2.0, 3.0
+	p := NewPareto(xm, alpha, 13)
+	const N = 200_000
+	var sum float64
+	for i := 0; i < N; i++ {
+		sum += p.Next()
+	}
+	mean := sum / N
+	expected := alpha * xm / (alpha - 1)
+
+	if math.Abs(mean-expected)/expected > 0.05 {
+		t.Errorf("mean %v deviates from theoretical %v by more than 5%%", mean, expected)
+	}
+}
+
+func TestParetoLowerBound(t *testing.T) {
+	xm := 100.0
+	p := NewPareto(xm, 2, 1)
+	for i := 0; i < 10_000; i++ {
+		if v := p.Next(); v < xm {
+			t.Fatalf("sample %v below scale %v", v, xm)
+		}
+	}
+}
+
+func BenchmarkParetoNext(b *testing.B) {
+	p := NewPareto(1, 2.5, 1)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = p.Next()
+	}
+}

--- a/internal/shaper/dist/seed.go
+++ b/internal/shaper/dist/seed.go
@@ -1,0 +1,9 @@
+package dist
+
+// splitSeed derives two 64-bit seeds from a single int64 input so that PCG
+// receives distinct stream identifiers even when the caller passes 0.
+func splitSeed(seed int64) (uint64, uint64) {
+	s1 := uint64(seed)
+	s2 := uint64(seed) ^ 0x9E3779B97F4A7C15
+	return s1, s2
+}


### PR DESCRIPTION
## Summary

Self-contained low-level `internal/shaper/dist` package with four
randomized samplers used by the upcoming traffic shaper to break
fixed statistical signatures detectable by DPI:

- `Histogram` — discrete weighted distribution with optional ±N% jitter
- `LogNormal` — `exp(mu + sigma*Z)` sampler via `NormFloat64`
- `Pareto` — inverse-CDF Type-I sampler `(Xm, Alpha)`
- `MarkovBurst` — discrete-time chain with arbitrary transition matrix

All samplers expose a common `Distribution` interface (`Next`, `Reset`),
are deterministic per seed, use `math/rand/v2` PCG, and rewind via
`PCG.Seed` on `Reset`. The package has no dependency on the rest of
the future `internal/shaper`.

Also anchored `dist/` in `.gitignore` to repo root (`/dist/`) so the
new package directory is no longer silently excluded.

Tracking: tiredvpn-oss-qmy
Issue: #6

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/shaper/dist/...` (16 tests, including determinism, Reset, empirical frequency at ±2% over 100k samples, theoretical mean/variance for LogNormal/Pareto, stationary distribution for MarkovBurst)
- [x] `golangci-lint run ./internal/shaper/dist/...` (govet + staticcheck)
- [x] Benchmarks: 16–80 ns/op, 0 allocs/op