### PR TITLE
refactor(strategy): decouple behavioral shaping from morph TLS layer

### DIFF
--- a/internal/strategy/morph.go
+++ b/internal/strategy/morph.go
@@ -25,7 +25,17 @@ type TrafficMorphStrategy struct {
 	secret    []byte   // Secret for authentication
 }
 
-// TrafficProfile defines statistical properties of traffic to mimic
+// TrafficProfile defines statistical properties of traffic to mimic.
+//
+// Fields BurstSize, BurstInterval and DownUpRatio that previously lived here
+// were declared but never read by the runtime (writeScheduler was disabled,
+// fragmentToProfile was unused). They are intentionally absent so the profile
+// only exposes parameters that actually drive behaviour today: packet size
+// distribution (used by dummy generation) and padding ranges (used by Write).
+//
+// Inter-arrival parameters remain because they are part of the documented
+// shape of each profile and will become inputs to the future shaper layer
+// (see internal/shaper, task I2). They have no runtime effect right now.
 type TrafficProfile struct {
 	Name string
 
@@ -33,18 +43,12 @@ type TrafficProfile struct {
 	PacketSizes     []int     // Bucket centers
 	PacketSizeProbs []float64 // Probability for each bucket
 
-	// Inter-arrival time distribution (milliseconds)
+	// Inter-arrival time distribution (milliseconds).
+	// Currently informational; will drive timing once shaper is wired in.
 	InterArrivalMean   float64
 	InterArrivalStdDev float64
 
-	// Burst patterns
-	BurstSize     int           // Packets per burst
-	BurstInterval time.Duration // Time between bursts
-
-	// Direction ratio (download/upload)
-	DownUpRatio float64
-
-	// Padding behavior
+	// Padding behavior (applied per Write)
 	MinPadding int
 	MaxPadding int
 }
@@ -58,9 +62,6 @@ var (
 		PacketSizeProbs:    []float64{0.10, 0.20, 0.35, 0.35},
 		InterArrivalMean:   8.0,
 		InterArrivalStdDev: 20.0,
-		BurstSize:          30,
-		BurstInterval:      150 * time.Millisecond,
-		DownUpRatio:        15.0,
 		MinPadding:         50,
 		MaxPadding:         200,
 	}
@@ -73,9 +74,6 @@ var (
 		PacketSizeProbs:    []float64{0.12, 0.18, 0.30, 0.40},
 		InterArrivalMean:   10.0,
 		InterArrivalStdDev: 25.0,
-		BurstSize:          25,
-		BurstInterval:      180 * time.Millisecond,
-		DownUpRatio:        12.0,
 		MinPadding:         60,
 		MaxPadding:         250,
 	}
@@ -87,9 +85,6 @@ var (
 		PacketSizeProbs:    []float64{0.15, 0.25, 0.30, 0.30},
 		InterArrivalMean:   12.0,
 		InterArrivalStdDev: 30.0,
-		BurstSize:          20,
-		BurstInterval:      200 * time.Millisecond,
-		DownUpRatio:        10.0,
 		MinPadding:         40,
 		MaxPadding:         180,
 	}
@@ -100,9 +95,6 @@ var (
 		PacketSizeProbs:    []float64{0.08, 0.15, 0.32, 0.45},
 		InterArrivalMean:   6.0,
 		InterArrivalStdDev: 18.0,
-		BurstSize:          40,
-		BurstInterval:      120 * time.Millisecond,
-		DownUpRatio:        18.0,
 		MinPadding:         20,
 		MaxPadding:         150,
 	}
@@ -114,9 +106,6 @@ var (
 		PacketSizeProbs:    []float64{0.30, 0.25, 0.25, 0.20},
 		InterArrivalMean:   50.0,
 		InterArrivalStdDev: 100.0,
-		BurstSize:          10,
-		BurstInterval:      500 * time.Millisecond,
-		DownUpRatio:        5.0,
 		MinPadding:         0,
 		MaxPadding:         50,
 	}
@@ -128,9 +117,6 @@ var (
 		PacketSizeProbs:    []float64{0.40, 0.40, 0.20},
 		InterArrivalMean:   20.0, // Regular intervals
 		InterArrivalStdDev: 5.0,  // Low variance
-		BurstSize:          1,
-		BurstInterval:      20 * time.Millisecond,
-		DownUpRatio:        1.0, // Symmetric
 		MinPadding:         0,
 		MaxPadding:         20,
 	}

--- a/internal/strategy/morph.go
+++ b/internal/strategy/morph.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"crypto/tls"
 	"io"
-	"math"
 	mathrand "math/rand"
 	"net"
 	"sync"
@@ -302,16 +301,17 @@ func (s *TrafficMorphStrategy) Connect(ctx context.Context, target string) (net.
 	return NewMorphedConn(baseConn, s.profile, s.secret), nil
 }
 
-// MorphedConn wraps a connection with traffic morphing
+// MorphedConn wraps a connection with traffic morphing.
+//
+// Behavioural shaping is intentionally minimal here: per-Write padding plus
+// a 6-byte length/padding framing header. Burst scheduling, dummy cover
+// traffic and Gaussian inter-arrival jitter previously lived in a
+// writeScheduler goroutine that conflicted with TLS framing and is removed.
+// Those behaviours are planned for re-introduction via internal/shaper
+// (task I2).
 type MorphedConn struct {
 	net.Conn
 	profile *TrafficProfile
-
-	// Write scheduling
-	writeMu     sync.Mutex
-	writeQueue  [][]byte
-	writeTicker *time.Ticker
-	writeStop   chan struct{}
 
 	// Read buffer for partial reads
 	readBuf []byte
@@ -322,10 +322,6 @@ type MorphedConn struct {
 	packetsSent int64
 	packetsRecv int64
 
-	// Burst control
-	burstCounter int
-	lastBurst    time.Time
-
 	// Rate limiting for TSPU evasion
 	rateLimiter *evasion.AdaptiveRateLimiter
 }
@@ -335,18 +331,18 @@ func (mc *MorphedConn) NetConn() net.Conn {
 	return mc.Conn
 }
 
-// NewMorphedConn creates a morphed connection
+// NewMorphedConn creates a morphed connection.
+// It performs the application-layer Morph handshake over the underlying
+// (typically TLS) conn before returning.
 func NewMorphedConn(conn net.Conn, profile *TrafficProfile, secret []byte) *MorphedConn {
 	mc := &MorphedConn{
-		Conn:       conn,
-		profile:    profile,
-		writeQueue: make([][]byte, 0),
-		writeStop:  make(chan struct{}),
-		lastBurst:  time.Now(),
+		Conn:    conn,
+		profile: profile,
 		// Rate limiter disabled - was causing 80 KB/s bottleneck
 		rateLimiter: nil,
 	}
 
+	// --- TLS / handshake (do not touch in shaper migration) ---
 	// Send magic handshake so server recognizes Morph protocol
 	// Format: "MRPH" + profile name length (1 byte) + profile name + auth token (32 bytes)
 	magic := []byte("MRPH")
@@ -364,50 +360,7 @@ func NewMorphedConn(conn net.Conn, profile *TrafficProfile, secret []byte) *Morp
 	log.Debug("Morph: sending handshake, secret_prefix=%x..., token=%x...", secret[:min(8, len(secret))], authToken[:8])
 	conn.Write(handshake)
 
-	// NOTE: writeScheduler disabled for TUN mode compatibility
-	// TUN mode uses synchronous Write() directly without queue/scheduler
-	// The scheduler's dummy packets interfere with TLS causing "bad record MAC" errors
-
 	return mc
-}
-
-// writeScheduler sends packets according to profile timing
-func (mc *MorphedConn) writeScheduler() {
-	for {
-		select {
-		case <-mc.writeStop:
-			return
-		case <-mc.writeTicker.C:
-			mc.writeMu.Lock()
-			if len(mc.writeQueue) > 0 {
-				// Send next packet
-				packet := mc.writeQueue[0]
-				mc.writeQueue = mc.writeQueue[1:]
-				mc.writeMu.Unlock()
-
-				mc.Conn.Write(packet)
-				mc.packetsSent++
-				mc.bytesSent += int64(len(packet))
-			} else {
-				mc.writeMu.Unlock()
-
-				// Send dummy packet to maintain pattern
-				if mc.shouldSendDummy() {
-					dummy := mc.generateDummy()
-					mc.Conn.Write(dummy)
-					mc.packetsSent++
-				}
-			}
-
-			// Adjust timing with jitter
-			jitter := mc.gaussianRandom(0, mc.profile.InterArrivalStdDev)
-			nextInterval := mc.profile.InterArrivalMean + jitter
-			if nextInterval < 1 {
-				nextInterval = 1
-			}
-			mc.writeTicker.Reset(time.Duration(nextInterval) * time.Millisecond)
-		}
-	}
 }
 
 // Write sends data immediately with morph framing (for TUN mode compatibility)
@@ -496,54 +449,6 @@ func (mc *MorphedConn) Write(p []byte) (int, error) {
 	mc.bytesSent += int64(len(packet))
 
 	return len(p), nil
-}
-
-// fragmentToProfile splits data into packets matching size distribution
-func (mc *MorphedConn) fragmentToProfile(data []byte) [][]byte {
-	var packets [][]byte
-	offset := 0
-
-	for offset < len(data) {
-		// Select packet size based on profile distribution
-		targetSize := mc.selectPacketSize()
-
-		// Add padding
-		padding := mc.randomInt(mc.profile.MinPadding, mc.profile.MaxPadding)
-
-		// Calculate actual data size
-		// Header is 6 bytes: [dataLen:4][paddingLen:2]
-		dataSize := targetSize - padding - 6
-		if dataSize < 1 {
-			dataSize = 1
-		}
-		if offset+dataSize > len(data) {
-			dataSize = len(data) - offset
-		}
-
-		// Build packet: [dataLen:4][paddingLen:2][data:N][padding:M]
-		packet := make([]byte, 6+dataSize+padding)
-
-		// Data length header
-		packet[0] = byte(dataSize >> 24)
-		packet[1] = byte(dataSize >> 16)
-		packet[2] = byte(dataSize >> 8)
-		packet[3] = byte(dataSize)
-
-		// Padding length header
-		packet[4] = byte(padding >> 8)
-		packet[5] = byte(padding)
-
-		// Data
-		copy(packet[6:6+dataSize], data[offset:offset+dataSize])
-
-		// Random padding
-		rand.Read(packet[6+dataSize:])
-
-		packets = append(packets, packet)
-		offset += dataSize
-	}
-
-	return packets
 }
 
 // selectPacketSize returns a packet size based on profile distribution
@@ -650,12 +555,6 @@ func (mc *MorphedConn) Read(p []byte) (int, error) {
 	return copied, nil
 }
 
-// shouldSendDummy decides if a dummy packet should be sent
-func (mc *MorphedConn) shouldSendDummy() bool {
-	// Maintain minimum packet rate
-	return mc.randomFloat() < 0.1 // 10% chance
-}
-
 // generateDummy creates a dummy packet
 func (mc *MorphedConn) generateDummy() []byte {
 	size := mc.selectPacketSize()
@@ -678,22 +577,8 @@ func (mc *MorphedConn) generateDummy() []byte {
 	return packet
 }
 
-// gaussianRandom generates a random number with Gaussian distribution
-func (mc *MorphedConn) gaussianRandom(mean, stddev float64) float64 {
-	// Box-Muller transform
-	u1 := mc.randomFloat()
-	u2 := mc.randomFloat()
-
-	if u1 == 0 {
-		u1 = 0.0001
-	}
-
-	z := math.Sqrt(-2*math.Log(u1)) * math.Cos(2*math.Pi*u2)
-	return mean + z*stddev
-}
-
-// randomFloat returns a random float64 in [0, 1)
-// OPTIMIZED: Uses fast math/rand instead of crypto/rand
+// randomFloat returns a random float64 in [0, 1).
+// Uses fast math/rand (non-cryptographic) — only feeds shaping decisions.
 func (mc *MorphedConn) randomFloat() float64 {
 	fastRandMu.Lock()
 	f := fastRand.Float64()
@@ -701,26 +586,8 @@ func (mc *MorphedConn) randomFloat() float64 {
 	return f
 }
 
-// randomInt returns a random int in [min, max]
-// OPTIMIZED: Uses fast math/rand instead of crypto/rand
-func (mc *MorphedConn) randomInt(min, max int) int {
-	if max <= min {
-		return min
-	}
-	return fastRandInt(min, max)
-}
-
-// Close stops the scheduler and closes connection
+// Close closes the underlying connection.
 func (mc *MorphedConn) Close() error {
-	select {
-	case <-mc.writeStop:
-		// Already closed
-	default:
-		close(mc.writeStop)
-	}
-	if mc.writeTicker != nil {
-		mc.writeTicker.Stop()
-	}
 	return mc.Conn.Close()
 }
 

--- a/internal/strategy/morph.go
+++ b/internal/strategy/morph.go
@@ -249,6 +249,7 @@ func (s *TrafficMorphStrategy) Connect(ctx context.Context, target string) (net.
 	if s.baseStrat != nil {
 		baseConn, err = s.baseStrat.Connect(ctx, target)
 	} else {
+		// --- TLS / handshake (do not touch in shaper migration) ---
 		// Get server address (IPv6/IPv4 with automatic fallback)
 		serverAddr := s.manager.GetServerAddr(ctx)
 		log.Debug("Traffic Morph: Using server address: %s", serverAddr)
@@ -363,14 +364,122 @@ func NewMorphedConn(conn net.Conn, profile *TrafficProfile, secret []byte) *Morp
 	return mc
 }
 
-// Write sends data immediately with morph framing (for TUN mode compatibility)
-// Note: This bypasses the async queue for immediate delivery
-// OPTIMIZED: Uses buffer pool, fast RNG, single write syscall
+// --- Behavioral shaping (replaceable by internal/shaper) ---
+//
+// Everything in this section is the "shaping layer" that decides packet
+// sizes, padding amounts and dummy/cover frames. Task I2 will replace this
+// with a generic shaper.Shaper while keeping the wire format below stable.
+
+// morphHeaderLen is the size of the 6-byte morph framing header
+// laid out as [dataLen:4 BE][paddingLen:2 BE].
+const morphHeaderLen = 6
+
+// pickPaddingLen returns a random padding length within the profile's
+// configured [MinPadding, MaxPadding] range. Non-cryptographic by design —
+// padding only obscures size, it does not need to be unpredictable to an
+// attacker who already sees ciphertext sizes.
+func (mc *MorphedConn) pickPaddingLen() int {
+	return fastRandInt(mc.profile.MinPadding, mc.profile.MaxPadding)
+}
+
+// selectPacketSize returns a packet size drawn from the profile's discrete
+// size distribution (CDF lookup over PacketSizeProbs).
+func (mc *MorphedConn) selectPacketSize() int {
+	r := mc.randomFloat()
+	cumulative := 0.0
+
+	for i, prob := range mc.profile.PacketSizeProbs {
+		cumulative += prob
+		if r < cumulative {
+			return mc.profile.PacketSizes[i]
+		}
+	}
+
+	return mc.profile.PacketSizes[len(mc.profile.PacketSizes)-1]
+}
+
+// randomFloat returns a random float64 in [0, 1).
+// Uses fast math/rand (non-cryptographic) — only feeds shaping decisions.
+func (mc *MorphedConn) randomFloat() float64 {
+	fastRandMu.Lock()
+	f := fastRand.Float64()
+	fastRandMu.Unlock()
+	return f
+}
+
+// --- Wire format helpers (do not change without bumping protocol) ---
+//
+// These helpers encode/decode the 6-byte Morph framing header. The wire
+// format is shared with already-deployed servers and must stay byte-stable
+// across the shaper migration.
+
+// writeFrameHeader serialises [dataLen:4 BE][paddingLen:2 BE] into dst[:6].
+// dst must have length >= morphHeaderLen.
+func writeFrameHeader(dst []byte, dataLen, paddingLen int) {
+	dst[0] = byte(dataLen >> 24)
+	dst[1] = byte(dataLen >> 16)
+	dst[2] = byte(dataLen >> 8)
+	dst[3] = byte(dataLen)
+	dst[4] = byte(paddingLen >> 8)
+	dst[5] = byte(paddingLen)
+}
+
+// readFrameHeader parses the 6-byte header from src[:6].
+func readFrameHeader(src []byte) (dataLen, paddingLen int) {
+	dataLen = int(src[0])<<24 | int(src[1])<<16 | int(src[2])<<8 | int(src[3])
+	paddingLen = int(src[4])<<8 | int(src[5])
+	return dataLen, paddingLen
+}
+
+// buildFrame allocates (or borrows from packetPool) a buffer holding a fully
+// framed packet: [header:6][data:N][padding:M] with random padding bytes.
+// fromPool indicates whether the returned slice must be released via
+// packetPool.Put after use.
+func buildFrame(data []byte, padLen int) (packet []byte, fromPool bool) {
+	totalLen := morphHeaderLen + len(data) + padLen
+	if totalLen <= 2048 {
+		packet = packetPool.Get().([]byte)
+		packet = packet[:totalLen]
+		fromPool = true
+	} else {
+		packet = make([]byte, totalLen)
+	}
+
+	writeFrameHeader(packet, len(data), padLen)
+	copy(packet[morphHeaderLen:morphHeaderLen+len(data)], data)
+	if padLen > 0 {
+		fastRandBytes(packet[morphHeaderLen+len(data):])
+	}
+	return packet, fromPool
+}
+
+// buildDummyFrame produces a [header:6][padding:M] frame with dataLen=0.
+// Used both as a keepalive response and (historically) as cover traffic.
+func (mc *MorphedConn) buildDummyFrame() []byte {
+	size := mc.selectPacketSize()
+	paddingLen := size - morphHeaderLen
+	if paddingLen < 0 {
+		paddingLen = 0
+	}
+
+	packet := make([]byte, morphHeaderLen+paddingLen)
+	writeFrameHeader(packet, 0, paddingLen)
+	if paddingLen > 0 {
+		// Crypto-quality randomness for dummies — they go on the wire
+		// without surrounding plaintext, so any bias would be observable.
+		_, _ = rand.Read(packet[morphHeaderLen:])
+	}
+	return packet
+}
+
+// Write sends data immediately with morph framing (for TUN mode compatibility).
+// Behaviour: one Write call -> one framed packet on the wire. The 4-zero-byte
+// keepalive sentinel from the TUN layer is converted into a Morph dummy frame.
 func (mc *MorphedConn) Write(p []byte) (int, error) {
 	// Handle keepalive packet (4 zero bytes = length prefix for zero-length packet)
 	// Send as Morph dummy packet which server echoes back
 	if len(p) == 4 && p[0] == 0 && p[1] == 0 && p[2] == 0 && p[3] == 0 {
-		dummy := mc.generateDummy()
+		dummy := mc.buildDummyFrame()
 		_, err := mc.Conn.Write(dummy)
 		if err != nil {
 			return 0, err
@@ -382,42 +491,9 @@ func (mc *MorphedConn) Write(p []byte) (int, error) {
 		return 0, nil
 	}
 
-	// Send immediately with morph framing (don't fragment for TUN mode)
-	// Format: [dataLen:4][paddingLen:2][data:N][padding:M]
-
-	// OPTIMIZATION 1: Use fast math/rand instead of crypto/rand (10× faster)
-	padLen := fastRandInt(mc.profile.MinPadding, mc.profile.MaxPadding)
-
-	totalLen := 6 + len(p) + padLen
-
-	// OPTIMIZATION 2: Use buffer pool to reduce GC pressure
-	var packet []byte
-	var fromPool bool
-	if totalLen <= 2048 {
-		packet = packetPool.Get().([]byte)
-		packet = packet[:totalLen]
-		fromPool = true
-	} else {
-		packet = make([]byte, totalLen)
-	}
-
-	// Data length header
-	packet[0] = byte(len(p) >> 24)
-	packet[1] = byte(len(p) >> 16)
-	packet[2] = byte(len(p) >> 8)
-	packet[3] = byte(len(p))
-
-	// Padding length header
-	packet[4] = byte(padLen >> 8)
-	packet[5] = byte(padLen)
-
-	// Data
-	copy(packet[6:6+len(p)], p)
-
-	// OPTIMIZATION 3: Fast random padding (non-cryptographic is fine for padding)
-	if padLen > 0 {
-		fastRandBytes(packet[6+len(p):])
-	}
+	// Build framed packet [header:6][data:N][padding:M]
+	padLen := mc.pickPaddingLen()
+	packet, fromPool := buildFrame(p, padLen)
 
 	// Apply rate limiting to evade TSPU bulk transfer detection
 	// This adds jitter and micro-pauses to mimic legitimate streaming
@@ -451,24 +527,9 @@ func (mc *MorphedConn) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-// selectPacketSize returns a packet size based on profile distribution
-func (mc *MorphedConn) selectPacketSize() int {
-	r := mc.randomFloat()
-	cumulative := 0.0
-
-	for i, prob := range mc.profile.PacketSizeProbs {
-		cumulative += prob
-		if r < cumulative {
-			return mc.profile.PacketSizes[i]
-		}
-	}
-
-	return mc.profile.PacketSizes[len(mc.profile.PacketSizes)-1]
-}
-
-// Read reads and unpacks morphed data with buffering support
-// OPTIMIZED: Reads header+data+padding in fewer syscalls
-// NOTE: Rate limiting on Read creates TCP backpressure to slow down server
+// Read reads and unpacks morphed data with buffering support.
+// Reads header+data+padding in fewer syscalls; padding is silently dropped.
+// NOTE: Rate limiting on Read creates TCP backpressure to slow down server.
 func (mc *MorphedConn) Read(p []byte) (int, error) {
 	// If we have buffered data, return from buffer first
 	if len(mc.readBuf) > 0 {
@@ -482,16 +543,13 @@ func (mc *MorphedConn) Read(p []byte) (int, error) {
 		return n, nil
 	}
 
-	// OPTIMIZATION: Read packet header: [dataLen:4][paddingLen:2]
-	header := make([]byte, 6)
+	// Read packet header: [dataLen:4][paddingLen:2]
+	header := make([]byte, morphHeaderLen)
 	_, err := io.ReadFull(mc.Conn, header)
 	if err != nil {
 		return 0, err
 	}
-
-	// Parse lengths
-	dataLen := int(header[0])<<24 | int(header[1])<<16 | int(header[2])<<8 | int(header[3])
-	paddingLen := int(header[4])<<8 | int(header[5])
+	dataLen, paddingLen := readFrameHeader(header)
 
 	// Handle dummy packets (dataLen = 0) - these are keepalive responses
 	if dataLen == 0 {
@@ -508,7 +566,7 @@ func (mc *MorphedConn) Read(p []byte) (int, error) {
 		return mc.Read(p) // Buffer too small, read next packet
 	}
 
-	// OPTIMIZATION 4: Read data+padding in single syscall to reduce latency
+	// Read data+padding in single syscall to reduce latency
 	totalPayload := dataLen + paddingLen
 	var payload []byte
 	var fromPool bool
@@ -553,37 +611,6 @@ func (mc *MorphedConn) Read(p []byte) (int, error) {
 	}
 
 	return copied, nil
-}
-
-// generateDummy creates a dummy packet
-func (mc *MorphedConn) generateDummy() []byte {
-	size := mc.selectPacketSize()
-	paddingLen := size - 6 // Header is 6 bytes
-	if paddingLen < 0 {
-		paddingLen = 0
-	}
-
-	packet := make([]byte, 6+paddingLen)
-
-	// Data length = 0 (dummy)
-	packet[0], packet[1], packet[2], packet[3] = 0, 0, 0, 0
-
-	// Padding length
-	packet[4] = byte(paddingLen >> 8)
-	packet[5] = byte(paddingLen)
-
-	// Random padding
-	rand.Read(packet[6:])
-	return packet
-}
-
-// randomFloat returns a random float64 in [0, 1).
-// Uses fast math/rand (non-cryptographic) — only feeds shaping decisions.
-func (mc *MorphedConn) randomFloat() float64 {
-	fastRandMu.Lock()
-	f := fastRand.Float64()
-	fastRandMu.Unlock()
-	return f
 }
 
 // Close closes the underlying connection.

--- a/internal/strategy/morph_test.go
+++ b/internal/strategy/morph_test.go
@@ -3,7 +3,6 @@ package strategy
 import (
 	"math"
 	"testing"
-	"time"
 )
 
 // TestTrafficProfilePacketSizes tests packet size distribution
@@ -79,90 +78,6 @@ func TestTrafficProfileInterArrival(t *testing.T) {
 	}
 }
 
-// TestTrafficProfileBurstParameters tests burst behavior
-func TestTrafficProfileBurstParameters(t *testing.T) {
-	profiles := []*TrafficProfile{
-		YandexVideoProfile,
-		VKVideoProfile,
-		WebBrowsingProfile,
-		VoIPProfile,
-	}
-
-	for _, profile := range profiles {
-		t.Run(profile.Name, func(t *testing.T) {
-			// Burst size should be positive
-			if profile.BurstSize <= 0 {
-				t.Errorf("BurstSize %d should be > 0", profile.BurstSize)
-			}
-
-			// Burst size shouldn't be too large (sanity check)
-			if profile.BurstSize > 1000 {
-				t.Errorf("BurstSize %d seems too large", profile.BurstSize)
-			}
-
-			// Burst interval should be positive
-			if profile.BurstInterval <= 0 {
-				t.Errorf("BurstInterval %v should be > 0", profile.BurstInterval)
-			}
-
-			// Burst interval should be reasonable (< 10 seconds)
-			if profile.BurstInterval > 10*time.Second {
-				t.Errorf("BurstInterval %v seems too large", profile.BurstInterval)
-			}
-		})
-	}
-}
-
-// TestTrafficProfileDownUpRatio tests download/upload ratio
-func TestTrafficProfileDownUpRatio(t *testing.T) {
-	tests := []struct {
-		profile     *TrafficProfile
-		minRatio    float64
-		maxRatio    float64
-		description string
-	}{
-		{
-			profile:     YandexVideoProfile,
-			minRatio:    10.0,
-			maxRatio:    20.0,
-			description: "Video streaming should be heavily asymmetric",
-		},
-		{
-			profile:     VKVideoProfile,
-			minRatio:    10.0,
-			maxRatio:    25.0,
-			description: "Video streaming should be heavily asymmetric",
-		},
-		{
-			profile:     WebBrowsingProfile,
-			minRatio:    3.0,
-			maxRatio:    10.0,
-			description: "Web browsing moderately asymmetric",
-		},
-		{
-			profile:     VoIPProfile,
-			minRatio:    0.8,
-			maxRatio:    1.2,
-			description: "VoIP should be nearly symmetric",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.profile.Name, func(t *testing.T) {
-			ratio := tt.profile.DownUpRatio
-
-			if ratio < 0 {
-				t.Errorf("DownUpRatio %f should be >= 0", ratio)
-			}
-
-			if ratio < tt.minRatio || ratio > tt.maxRatio {
-				t.Errorf("DownUpRatio %f outside expected range [%f, %f]: %s",
-					ratio, tt.minRatio, tt.maxRatio, tt.description)
-			}
-		})
-	}
-}
-
 // TestTrafficProfilePadding tests padding parameters
 func TestTrafficProfilePadding(t *testing.T) {
 	profiles := []*TrafficProfile{
@@ -208,18 +123,6 @@ func TestYandexVideoProfileCharacteristics(t *testing.T) {
 		t.Error("Yandex Video should have packets >= 1200 bytes")
 	}
 
-	// Should be download-heavy
-	if profile.DownUpRatio < 10.0 {
-		t.Errorf("Yandex Video DownUpRatio %f should be >= 10.0 (streaming is asymmetric)",
-			profile.DownUpRatio)
-	}
-
-	// Should have bursty behavior
-	if profile.BurstSize < 20 {
-		t.Errorf("Yandex Video BurstSize %d should be >= 20 (video buffering)",
-			profile.BurstSize)
-	}
-
 	// Inter-arrival should be low (high throughput)
 	if profile.InterArrivalMean > 20.0 {
 		t.Errorf("Yandex Video InterArrivalMean %f should be <= 20ms (streaming)",
@@ -239,22 +142,10 @@ func TestVoIPProfileCharacteristics(t *testing.T) {
 		}
 	}
 
-	// Should be nearly symmetric
-	if profile.DownUpRatio < 0.8 || profile.DownUpRatio > 1.2 {
-		t.Errorf("VoIP DownUpRatio %f should be near 1.0 (symmetric)",
-			profile.DownUpRatio)
-	}
-
 	// Should have regular intervals (low variance)
 	if profile.InterArrivalStdDev > profile.InterArrivalMean {
 		t.Errorf("VoIP should have low variance: StdDev %f > Mean %f",
 			profile.InterArrivalStdDev, profile.InterArrivalMean)
-	}
-
-	// VoIP sends packets regularly, not in bursts
-	if profile.BurstSize > 1 {
-		t.Logf("Note: VoIP BurstSize %d (expected 1 for regular packets)",
-			profile.BurstSize)
 	}
 }
 
@@ -271,12 +162,6 @@ func TestWebBrowsingProfileCharacteristics(t *testing.T) {
 	if profile.InterArrivalMean < 30.0 {
 		t.Errorf("Web browsing InterArrivalMean %f should be >= 30ms (bursty)",
 			profile.InterArrivalMean)
-	}
-
-	// Should be moderately asymmetric (more downloads)
-	if profile.DownUpRatio < 3.0 || profile.DownUpRatio > 10.0 {
-		t.Errorf("Web browsing DownUpRatio %f should be in [3.0, 10.0]",
-			profile.DownUpRatio)
 	}
 }
 
@@ -384,9 +269,6 @@ func TestProfileConsistency(t *testing.T) {
 			}
 			if profile.InterArrivalMean == 0 {
 				t.Error("InterArrivalMean is zero")
-			}
-			if profile.BurstInterval == 0 {
-				t.Error("BurstInterval is zero")
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Prepares `internal/strategy/morph.go` for the upcoming `shaper.Shaper`
integration (task I2 = `tiredvpn-oss-5wm`) by removing dead code and
clearly delineating the TLS/handshake layer from the behavioural shaping
layer. **No functional change. No wire-format change.**

Refs: beads task `tiredvpn-oss-gsd`, issue #6.

## What changed

### Removed (dead code, never reached at runtime)

- `TrafficProfile.BurstSize`, `BurstInterval`, `DownUpRatio` fields and
  their values in all six profile literals. None were read outside the
  disabled `writeScheduler` and test assertions. (`RTTProfile` in
  `rtt.go` has its own independent `BurstSize/BurstInterval` — those are
  untouched.)
- `MorphedConn.writeScheduler` goroutine and its supporting state
  (`writeMu`, `writeQueue`, `writeTicker`, `writeStop`, `burstCounter`,
  `lastBurst`). The goroutine was never spawned (its dummy writes broke
  TLS records with "bad record MAC"), so removing it is a no-op.
- `MorphedConn.fragmentToProfile` — packet-distribution-shaped fragmentation
  that was never invoked.
- Helpers `shouldSendDummy`, `gaussianRandom`, `randomInt` — only called
  from the removed scheduler.
- The matching test assertions in `morph_test.go` for the removed
  profile fields, plus the corresponding unused `time` import.

### Renamed / extracted (organisational only)

- `morphHeaderLen` constant replaces hardcoded `6`.
- `writeFrameHeader` / `readFrameHeader` — pure header codec.
- `buildFrame(data, padLen)` — produces `[header:6][data][padding]` with
  pool reuse + fast random padding. Replaces the inline body inside
  `Write`.
- `buildDummyFrame()` — replaces `generateDummy`, uses the same header
  codec, comment now explains why crypto/rand stays for dummy padding.
- `pickPaddingLen()` — names the `fastRandInt(min, max)` call inside
  `Write`.
- Section markers added to the file:
  - `// --- TLS / handshake (do not touch in shaper migration) ---`
    around the dialer/`tls.Client`/kTLS block and around the MRPH
    handshake in `NewMorphedConn`.
  - `// --- Behavioral shaping (replaceable by internal/shaper) ---`
    around the RNG-driven helpers (`selectPacketSize`, `pickPaddingLen`,
    `randomFloat`).
  - `// --- Wire format helpers (do not change without bumping protocol) ---`
    around the header codec + frame builders.

### Untouched (intentionally)

- ALPN `tired-morph`, `evasion.FragmentationConfig` for ClientHello,
  kTLS enable, magic `MRPH` handshake (4-byte magic + name-len + name +
  32-byte auth token), 6-byte framing header layout.
- `internal/tls`, `internal/server`, `internal/client`.
- Profiles Yandex/VK/Baidu/Aparat (still registered as
  `morph_<ProfileName>` strategies). Web/VoIP profile literals also
  preserved for the I3 preset migration.

## Test plan

- [x] `go build ./...` — green
- [x] `go test ./...` — 498/498 across 24 packages
- [x] `golangci-lint run ./internal/strategy/...` — same 5 pre-existing
      findings (2 errcheck, 3 SA6002), no new ones introduced
- [x] Diff against deployed wire format: header codec verified bit-identical