### PR TITLE
feat(config): add CLI override layer with TOML+flags+defaults precedence

### DIFF
--- a/internal/config/toml/MIGRATION.md
+++ b/internal/config/toml/MIGRATION.md
@@ -1,0 +1,111 @@
+# tiredvpn — CLI to TOML migration
+
+tiredvpn is moving its primary configuration surface from CLI flags to TOML
+(`client.toml` / `server.toml`). The `internal/config/toml` package now provides
+a layered resolver so the transition stays backwards-compatible:
+
+```
+defaults  <  TOML file  <  CLI flags
+```
+
+A flag wins only when it was explicitly passed on the command line. A flag left
+at its default value never silently overwrites a TOML field.
+
+## Flag → TOML mapping
+
+### Client (`tiredvpn client ...`)
+
+| Old CLI flag                  | New TOML location              | Notes                              |
+|-------------------------------|--------------------------------|------------------------------------|
+| `--server=host:port`          | `[server] address` + `port`    | host:port string is split          |
+| `--strategy=NAME`             | `[strategy] mode`              |                                    |
+| `--debug`                     | `[logging] level = "debug"`    | flag forces level only when `true` |
+
+Flags not yet represented in the TOML schema (`--listen`, `--secret`,
+`--tun-*`, benchmark/probe knobs, `--list`, etc.) continue to be read directly
+from the FlagSet by `cmd/tiredvpn`. They will be migrated in follow-up issues.
+
+### Server (`tiredvpn server ...`)
+
+| Old CLI flag                  | New TOML location              | Notes                                |
+|-------------------------------|--------------------------------|--------------------------------------|
+| `--listen=host:port`          | `[listen] address` + `port`    | host:port string is split            |
+| `--cert=PATH`                 | `[tls] cert_file`              |                                      |
+| `--key=PATH`                  | `[tls] key_file`               |                                      |
+| `--debug`                     | `[logging] level = "debug"`    | flag forces level only when `true`   |
+
+## Example
+
+Before:
+
+```
+tiredvpn client \
+  --server=vpn.example.com:443 \
+  --strategy=reality \
+  --debug
+```
+
+After (`client.toml`):
+
+```toml
+[server]
+address = "vpn.example.com"
+port = 443
+
+[strategy]
+mode = "reality"
+
+[logging]
+level = "debug"
+```
+
+Run with:
+
+```
+tiredvpn client --config=client.toml
+```
+
+## How precedence works
+
+Given this `client.toml`:
+
+```toml
+[server]
+address = "vpn.example.com"
+port = 443
+
+[strategy]
+mode = "reality"
+```
+
+and the invocation:
+
+```
+tiredvpn client --config=client.toml --server=staging.example.com:8443
+```
+
+`ResolveClient` produces:
+
+| Field             | Value                  | Source        |
+|-------------------|------------------------|---------------|
+| `server.address`  | `staging.example.com`  | CLI flag      |
+| `server.port`     | `8443`                 | CLI flag      |
+| `strategy.mode`   | `reality`              | TOML          |
+| `logging.level`   | `info`                 | default       |
+| `logging.format`  | `text`                 | default       |
+| `tls.alpn`        | `["h2","http/1.1"]`    | default       |
+
+If `--strategy` is omitted, the TOML value sticks. If it is passed (even with a
+value identical to the default), it overrides TOML — explicit user intent wins.
+
+## Compatibility timeline
+
+- **v1.x (current)**: every legacy flag still works exactly as before. The TOML
+  loader is opt-in via `--config=PATH`.
+- **v2.0**: the TOML resolver becomes the canonical entry point. Flags listed
+  in the table above continue to function as overrides; non-mapped flags will
+  emit a deprecation warning.
+- **v3.0**: only flags in the override mapping remain. All other configuration
+  must come from TOML.
+
+Concrete version numbers are tracked in issue #6.

--- a/internal/config/toml/defaults.go
+++ b/internal/config/toml/defaults.go
@@ -1,0 +1,49 @@
+package toml
+
+// DefaultClient returns a ClientConfig populated with sensible defaults.
+// These defaults align with the legacy CLI flag defaults declared in cmd/tiredvpn.
+// They alone are NOT guaranteed to pass Validate (e.g. server.address is empty);
+// the caller is expected to layer TOML and/or CLI overrides on top before validating.
+func DefaultClient() *ClientConfig {
+	return &ClientConfig{
+		Server: ClientServer{
+			Address: "",
+			Port:    443,
+		},
+		Strategy: Strategy{
+			Mode: "",
+		},
+		TLS: ClientTLS{
+			ALPN: []string{"h2", "http/1.1"},
+		},
+		Logging: Logging{
+			Level:  "info",
+			Format: "text",
+			Output: "stderr",
+		},
+	}
+}
+
+// DefaultServer returns a ServerConfig populated with sensible defaults.
+func DefaultServer() *ServerConfig {
+	return &ServerConfig{
+		Listen: ServerListen{
+			Address: "0.0.0.0",
+			Port:    443,
+		},
+		Strategy: Strategy{
+			Mode: "",
+		},
+		TLS: ServerTLS{
+			ALPN: []string{"h2", "http/1.1"},
+		},
+		Auth: ServerAuth{
+			Mode: "token",
+		},
+		Logging: Logging{
+			Level:  "info",
+			Format: "text",
+			Output: "stderr",
+		},
+	}
+}

--- a/internal/config/toml/override.go
+++ b/internal/config/toml/override.go
@@ -1,0 +1,252 @@
+package toml
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"net"
+	"strconv"
+)
+
+// ApplyClientFlags overlays explicitly-set CLI flags from fs onto cfg.
+// Only flags actually passed by the user (flag.Visit, not VisitAll) cause writes,
+// so flag defaults never silently overwrite TOML values.
+//
+// Mapping (flag → TOML field):
+//
+//	-server      → server.address + server.port  (host:port split)
+//	-strategy    → strategy.mode
+//	-debug       → logging.level = "debug" (when true)
+//
+// Flags absent from this mapping are ignored — they belong to subsystems
+// not yet represented in the TOML schema, and the caller continues to read
+// them from the FlagSet directly.
+func ApplyClientFlags(cfg *ClientConfig, fs *flag.FlagSet) error {
+	if cfg == nil {
+		return errors.New("ApplyClientFlags: nil config")
+	}
+	if fs == nil {
+		return nil
+	}
+	var visitErr error
+	fs.Visit(func(f *flag.Flag) {
+		if visitErr != nil {
+			return
+		}
+		switch f.Name {
+		case "server":
+			host, port, err := splitHostPort(f.Value.String())
+			if err != nil {
+				visitErr = fmt.Errorf("flag -server: %w", err)
+				return
+			}
+			cfg.Server.Address = host
+			if port != 0 {
+				cfg.Server.Port = port
+			}
+		case "strategy":
+			cfg.Strategy.Mode = f.Value.String()
+		case "debug":
+			if f.Value.String() == "true" {
+				cfg.Logging.Level = "debug"
+			}
+		}
+	})
+	return visitErr
+}
+
+// ApplyServerFlags overlays explicitly-set CLI flags from fs onto cfg.
+//
+// Mapping (flag → TOML field):
+//
+//	-listen → listen.address + listen.port  (host:port split)
+//	-cert   → tls.cert_file
+//	-key    → tls.key_file
+//	-debug  → logging.level = "debug" (when true)
+func ApplyServerFlags(cfg *ServerConfig, fs *flag.FlagSet) error {
+	if cfg == nil {
+		return errors.New("ApplyServerFlags: nil config")
+	}
+	if fs == nil {
+		return nil
+	}
+	var visitErr error
+	fs.Visit(func(f *flag.Flag) {
+		if visitErr != nil {
+			return
+		}
+		switch f.Name {
+		case "listen":
+			host, port, err := splitHostPort(f.Value.String())
+			if err != nil {
+				visitErr = fmt.Errorf("flag -listen: %w", err)
+				return
+			}
+			cfg.Listen.Address = host
+			if port != 0 {
+				cfg.Listen.Port = port
+			}
+		case "cert":
+			cfg.TLS.CertFile = f.Value.String()
+		case "key":
+			cfg.TLS.KeyFile = f.Value.String()
+		case "debug":
+			if f.Value.String() == "true" {
+				cfg.Logging.Level = "debug"
+			}
+		}
+	})
+	return visitErr
+}
+
+// ResolveClient computes the final ClientConfig with precedence
+// CLI > TOML > defaults. tomlPath may be empty to skip TOML loading.
+// fs may be nil to skip CLI overrides. The returned config is validated.
+func ResolveClient(tomlPath string, fs *flag.FlagSet) (*ClientConfig, error) {
+	cfg := DefaultClient()
+	if tomlPath != "" {
+		var fromFile ClientConfig
+		if err := decodeStrict(tomlPath, &fromFile); err != nil {
+			return nil, err
+		}
+		mergeClient(cfg, &fromFile)
+	}
+	if err := ApplyClientFlags(cfg, fs); err != nil {
+		return nil, err
+	}
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("config: %w", err)
+	}
+	return cfg, nil
+}
+
+// ResolveServer computes the final ServerConfig with precedence
+// CLI > TOML > defaults.
+func ResolveServer(tomlPath string, fs *flag.FlagSet) (*ServerConfig, error) {
+	cfg := DefaultServer()
+	if tomlPath != "" {
+		var fromFile ServerConfig
+		if err := decodeStrict(tomlPath, &fromFile); err != nil {
+			return nil, err
+		}
+		mergeServer(cfg, &fromFile)
+	}
+	if err := ApplyServerFlags(cfg, fs); err != nil {
+		return nil, err
+	}
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("config: %w", err)
+	}
+	return cfg, nil
+}
+
+// mergeClient overlays non-zero fields from src onto dst.
+// We intentionally enumerate fields rather than reflect: the schema is small
+// and an explicit map keeps merge semantics auditable (e.g. ALPN replaces
+// rather than appends — slices are treated atomically).
+func mergeClient(dst, src *ClientConfig) {
+	if src.Server.Address != "" {
+		dst.Server.Address = src.Server.Address
+	}
+	if src.Server.Port != 0 {
+		dst.Server.Port = src.Server.Port
+	}
+	if src.Strategy.Mode != "" {
+		dst.Strategy.Mode = src.Strategy.Mode
+	}
+	if len(src.Strategy.Options) > 0 {
+		dst.Strategy.Options = src.Strategy.Options
+	}
+	if src.Shaper != nil {
+		dst.Shaper = src.Shaper
+	}
+	if src.TLS.ServerName != "" {
+		dst.TLS.ServerName = src.TLS.ServerName
+	}
+	if src.TLS.Fingerprint != "" {
+		dst.TLS.Fingerprint = src.TLS.Fingerprint
+	}
+	if len(src.TLS.ALPN) > 0 {
+		dst.TLS.ALPN = src.TLS.ALPN
+	}
+	if src.TLS.InsecureSkipVerify {
+		dst.TLS.InsecureSkipVerify = true
+	}
+	if src.TLS.CACert != "" {
+		dst.TLS.CACert = src.TLS.CACert
+	}
+	mergeLogging(&dst.Logging, &src.Logging)
+}
+
+func mergeServer(dst, src *ServerConfig) {
+	if src.Listen.Address != "" {
+		dst.Listen.Address = src.Listen.Address
+	}
+	if src.Listen.Port != 0 {
+		dst.Listen.Port = src.Listen.Port
+	}
+	if src.Strategy.Mode != "" {
+		dst.Strategy.Mode = src.Strategy.Mode
+	}
+	if len(src.Strategy.Options) > 0 {
+		dst.Strategy.Options = src.Strategy.Options
+	}
+	if src.Shaper != nil {
+		dst.Shaper = src.Shaper
+	}
+	if src.TLS.CertFile != "" {
+		dst.TLS.CertFile = src.TLS.CertFile
+	}
+	if src.TLS.KeyFile != "" {
+		dst.TLS.KeyFile = src.TLS.KeyFile
+	}
+	if len(src.TLS.ALPN) > 0 {
+		dst.TLS.ALPN = src.TLS.ALPN
+	}
+	if src.TLS.ClientCAFile != "" {
+		dst.TLS.ClientCAFile = src.TLS.ClientCAFile
+	}
+	if src.Auth.Mode != "" {
+		dst.Auth.Mode = src.Auth.Mode
+	}
+	if len(src.Auth.Tokens) > 0 {
+		dst.Auth.Tokens = src.Auth.Tokens
+	}
+	if src.Auth.TokensFile != "" {
+		dst.Auth.TokensFile = src.Auth.TokensFile
+	}
+	mergeLogging(&dst.Logging, &src.Logging)
+}
+
+func mergeLogging(dst, src *Logging) {
+	if src.Level != "" {
+		dst.Level = src.Level
+	}
+	if src.Format != "" {
+		dst.Format = src.Format
+	}
+	if src.Output != "" {
+		dst.Output = src.Output
+	}
+}
+
+// splitHostPort accepts "host:port" or bare ":port" and returns parts.
+// An empty port slot returns 0 so the caller keeps the existing value.
+func splitHostPort(s string) (string, int, error) {
+	if s == "" {
+		return "", 0, errors.New("empty address")
+	}
+	host, portStr, err := net.SplitHostPort(s)
+	if err != nil {
+		return "", 0, err
+	}
+	if portStr == "" {
+		return host, 0, nil
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return "", 0, fmt.Errorf("invalid port %q: %w", portStr, err)
+	}
+	return host, port, nil
+}
+

--- a/internal/config/toml/override_test.go
+++ b/internal/config/toml/override_test.go
@@ -1,0 +1,241 @@
+package toml
+
+import (
+	"flag"
+	"strings"
+	"testing"
+)
+
+// newClientFlagSet replicates the subset of cmd/tiredvpn client flags that
+// participate in the TOML mapping, so tests exercise the real surface.
+func newClientFlagSet() *flag.FlagSet {
+	fs := flag.NewFlagSet("client", flag.ContinueOnError)
+	fs.String("server", "", "Remote server address (host:port)")
+	fs.String("strategy", "", "Force specific strategy")
+	fs.Bool("debug", false, "Enable debug logging")
+	return fs
+}
+
+func newServerFlagSet() *flag.FlagSet {
+	fs := flag.NewFlagSet("server", flag.ContinueOnError)
+	fs.String("listen", ":443", "Listen address")
+	fs.String("cert", "server.crt", "TLS certificate file")
+	fs.String("key", "server.key", "TLS key file")
+	fs.Bool("debug", false, "Enable debug logging")
+	return fs
+}
+
+func TestResolveClient_DefaultsOnly(t *testing.T) {
+	fs := newClientFlagSet()
+	// No TOML, no flags parsed → defaults must surface, but Validate fails
+	// because required fields (server.address, strategy.mode) are unset.
+	_, err := ResolveClient("", fs)
+	if err == nil {
+		t.Fatal("expected validation error from bare defaults")
+	}
+	if !strings.Contains(err.Error(), "server.address") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDefaultClient_Shape(t *testing.T) {
+	d := DefaultClient()
+	if d.Server.Port != 443 {
+		t.Fatalf("default port: %d", d.Server.Port)
+	}
+	if d.Logging.Level != "info" {
+		t.Fatalf("default level: %q", d.Logging.Level)
+	}
+	if len(d.TLS.ALPN) != 2 {
+		t.Fatalf("default ALPN: %+v", d.TLS.ALPN)
+	}
+}
+
+func TestDefaultServer_Shape(t *testing.T) {
+	d := DefaultServer()
+	if d.Listen.Address != "0.0.0.0" || d.Listen.Port != 443 {
+		t.Fatalf("default listen: %+v", d.Listen)
+	}
+	if d.Auth.Mode != "token" {
+		t.Fatalf("default auth: %+v", d.Auth)
+	}
+}
+
+func TestResolveClient_TOMLOnly(t *testing.T) {
+	fs := newClientFlagSet()
+	cfg, err := ResolveClient(testdata(t, "client_minimal.toml"), fs)
+	if err != nil {
+		t.Fatalf("ResolveClient: %v", err)
+	}
+	if cfg.Server.Address != "vpn.example.org" || cfg.Server.Port != 443 {
+		t.Fatalf("server: %+v", cfg.Server)
+	}
+	if cfg.Strategy.Mode != "reality" {
+		t.Fatalf("strategy: %+v", cfg.Strategy)
+	}
+	// Defaults preserved where TOML is silent.
+	if cfg.Logging.Level != "info" {
+		t.Fatalf("logging level should default to info, got %q", cfg.Logging.Level)
+	}
+}
+
+func TestResolveClient_FlagOverridesTOML(t *testing.T) {
+	fs := newClientFlagSet()
+	if err := fs.Parse([]string{
+		"-server", "alt.example.com:8443",
+		"-strategy", "morph",
+	}); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	cfg, err := ResolveClient(testdata(t, "client_minimal.toml"), fs)
+	if err != nil {
+		t.Fatalf("ResolveClient: %v", err)
+	}
+	if cfg.Server.Address != "alt.example.com" || cfg.Server.Port != 8443 {
+		t.Fatalf("flag did not override server: %+v", cfg.Server)
+	}
+	if cfg.Strategy.Mode != "morph" {
+		t.Fatalf("flag did not override strategy: %q", cfg.Strategy.Mode)
+	}
+}
+
+func TestResolveClient_DefaultFlagDoesNotOverrideTOML(t *testing.T) {
+	fs := newClientFlagSet()
+	// Parse with no args — flags retain defaults but fs.Visit yields nothing.
+	if err := fs.Parse([]string{}); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	cfg, err := ResolveClient(testdata(t, "client_minimal.toml"), fs)
+	if err != nil {
+		t.Fatalf("ResolveClient: %v", err)
+	}
+	if cfg.Server.Address != "vpn.example.org" {
+		t.Fatalf("flag default leaked over TOML: %+v", cfg.Server)
+	}
+}
+
+func TestResolveClient_DebugFlagSetsLogLevel(t *testing.T) {
+	fs := newClientFlagSet()
+	if err := fs.Parse([]string{"-debug"}); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	cfg, err := ResolveClient(testdata(t, "client_preset.toml"), fs)
+	if err != nil {
+		t.Fatalf("ResolveClient: %v", err)
+	}
+	if cfg.Logging.Level != "debug" {
+		t.Fatalf("expected debug, got %q", cfg.Logging.Level)
+	}
+}
+
+func TestResolveClient_InvalidPortFromFlag(t *testing.T) {
+	fs := newClientFlagSet()
+	if err := fs.Parse([]string{"-server", "host:99999"}); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	_, err := ResolveClient(testdata(t, "client_minimal.toml"), fs)
+	if err == nil || !strings.Contains(err.Error(), "port") {
+		t.Fatalf("expected port validation error, got: %v", err)
+	}
+}
+
+func TestResolveClient_BadHostPortFlag(t *testing.T) {
+	fs := newClientFlagSet()
+	if err := fs.Parse([]string{"-server", "no-port-here"}); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	_, err := ResolveClient(testdata(t, "client_minimal.toml"), fs)
+	if err == nil {
+		t.Fatal("expected error parsing -server without port")
+	}
+}
+
+func TestResolveServer_TOMLOnly(t *testing.T) {
+	fs := newServerFlagSet()
+	cfg, err := ResolveServer(testdata(t, "server_minimal.toml"), fs)
+	if err != nil {
+		t.Fatalf("ResolveServer: %v", err)
+	}
+	if cfg.Listen.Port != 443 {
+		t.Fatalf("listen.port: %d", cfg.Listen.Port)
+	}
+	if cfg.TLS.CertFile != "/etc/tiredvpn/server.crt" {
+		t.Fatalf("cert_file: %q", cfg.TLS.CertFile)
+	}
+}
+
+func TestResolveServer_FlagOverridesTOML(t *testing.T) {
+	fs := newServerFlagSet()
+	if err := fs.Parse([]string{
+		"-listen", "127.0.0.1:9443",
+		"-cert", "/tmp/c.pem",
+		"-key", "/tmp/k.pem",
+		"-debug",
+	}); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	cfg, err := ResolveServer(testdata(t, "server_minimal.toml"), fs)
+	if err != nil {
+		t.Fatalf("ResolveServer: %v", err)
+	}
+	if cfg.Listen.Address != "127.0.0.1" || cfg.Listen.Port != 9443 {
+		t.Fatalf("listen override: %+v", cfg.Listen)
+	}
+	if cfg.TLS.CertFile != "/tmp/c.pem" || cfg.TLS.KeyFile != "/tmp/k.pem" {
+		t.Fatalf("tls override: %+v", cfg.TLS)
+	}
+	if cfg.Logging.Level != "debug" {
+		t.Fatalf("debug flag did not set log level: %q", cfg.Logging.Level)
+	}
+}
+
+func TestResolveServer_NoTOML_NeedsFlags(t *testing.T) {
+	fs := newServerFlagSet()
+	if err := fs.Parse([]string{
+		"-cert", "/tmp/c.pem",
+		"-key", "/tmp/k.pem",
+	}); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	// Defaults set listen, auth.mode, cert/key from flags. strategy.mode still missing.
+	_, err := ResolveServer("", fs)
+	if err == nil || !strings.Contains(err.Error(), "strategy.mode") {
+		t.Fatalf("expected strategy.mode validation error, got: %v", err)
+	}
+}
+
+func TestApplyClientFlags_NilGuards(t *testing.T) {
+	if err := ApplyClientFlags(nil, nil); err == nil {
+		t.Fatal("expected error on nil cfg")
+	}
+	if err := ApplyClientFlags(DefaultClient(), nil); err != nil {
+		t.Fatalf("nil flagset must be tolerated: %v", err)
+	}
+}
+
+func TestApplyServerFlags_NilGuards(t *testing.T) {
+	if err := ApplyServerFlags(nil, nil); err == nil {
+		t.Fatal("expected error on nil cfg")
+	}
+	if err := ApplyServerFlags(DefaultServer(), nil); err != nil {
+		t.Fatalf("nil flagset must be tolerated: %v", err)
+	}
+}
+
+func TestResolveClient_StrictRejectsBadTOML(t *testing.T) {
+	fs := newClientFlagSet()
+	_, err := ResolveClient(testdata(t, "invalid_unknown_field.toml"), fs)
+	if err == nil {
+		t.Fatal("strict decode should have rejected unknown field")
+	}
+}
+
+func TestSplitHostPort_OnlyPort(t *testing.T) {
+	host, port, err := splitHostPort(":443")
+	if err != nil {
+		t.Fatalf("splitHostPort: %v", err)
+	}
+	if host != "" || port != 443 {
+		t.Fatalf("got host=%q port=%d", host, port)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `DefaultClient`/`DefaultServer`, `ApplyClientFlags`/`ApplyServerFlags`, and top-level `ResolveClient`/`ResolveServer` to `internal/config/toml`.
- Precedence is **CLI > TOML > defaults**: only flags that the user explicitly passed (`flag.Visit`, not `VisitAll`) override TOML values, so defaults never silently leak through.
- Includes deep-merge helpers (slices replace atomically) and a migration doc covering the flag→TOML mapping plus the deprecation timeline.
- No changes to `cmd/tiredvpn/main.go`; integration is a follow-up task.

Initial mapping:

| Side   | CLI flag          | TOML field                            |
|--------|-------------------|---------------------------------------|
| client | `--server`        | `[server] address` + `port`           |
| client | `--strategy`      | `[strategy] mode`                     |
| client | `--debug`         | `[logging] level = "debug"`           |
| server | `--listen`        | `[listen] address` + `port`           |
| server | `--cert`          | `[tls] cert_file`                     |
| server | `--key`           | `[tls] key_file`                      |
| server | `--debug`         | `[logging] level = "debug"`           |

Tracking: beads `tiredvpn-oss-vsi`, issue #6.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/config/toml/...`
- [x] `go test -cover ./internal/config/toml/` — 88.4% (threshold 75%)
- [x] `golangci-lint run ./internal/config/toml/...`
- [ ] CI green