### PR TITLE
feat: add traffic shaper presets (chrome/youtube/bittorrent/random)

### DIFF
--- a/internal/shaper/presets/bittorrent_idle.go
+++ b/internal/shaper/presets/bittorrent_idle.go
@@ -1,0 +1,56 @@
+package presets
+
+import (
+	"github.com/tiredvpn/tiredvpn/internal/shaper"
+	"github.com/tiredvpn/tiredvpn/internal/shaper/dist"
+)
+
+// PresetBitTorrentIdle is the registry name for an idle BT swarm participant.
+const PresetBitTorrentIdle = "bittorrent_idle"
+
+// bittorrent_idle models a BT client that has joined a swarm but is mostly
+// idle: occasional short PEX/keepalive/handshake exchanges separated by
+// long pauses. The size histogram is sparse and small; inter-arrival is a
+// LogNormal with large sigma to reproduce minutes-scale gaps.
+//
+// Packet size histogram (bytes):
+//
+//	| value | weight | rationale                                   |
+//	|-------|--------|---------------------------------------------|
+//	|    68 |   0.40 | BitTorrent KEEPALIVE / CHOKE                |
+//	|   144 |   0.25 | HAVE / PEX small message                    |
+//	|   320 |   0.20 | EXTENDED / handshake                        |
+//	|   600 |   0.10 | small piece request batch                   |
+//	|  1200 |   0.05 | rare bitfield exchange                      |
+//
+// Inter-arrival: LogNormal(mu=2, sigma=2.5) → median ~7 s, with tail to
+// minutes — matching observed idle-swarm telemetry.
+func init() {
+	register(PresetBitTorrentIdle, buildBitTorrentIdle)
+}
+
+func buildBitTorrentIdle(seed int64) (shaper.Shaper, error) {
+	bins := []dist.HistogramBin{
+		{Value: 68, Weight: 0.40},
+		{Value: 144, Weight: 0.25},
+		{Value: 320, Weight: 0.20},
+		{Value: 600, Weight: 0.10},
+		{Value: 1200, Weight: 0.05},
+	}
+	sizeUp, err := dist.NewHistogram(bins, seed^seedSaltSizeUp)
+	if err != nil {
+		return nil, err
+	}
+	sizeDown, err := dist.NewHistogram(bins, seed^seedSaltSizeDown)
+	if err != nil {
+		return nil, err
+	}
+	// Delay is in milliseconds; LogNormal(mu=2,sigma=2.5) -> median ~7400 ms.
+	return &distShaper{
+		sizeUp:    sizeUp,
+		sizeDown:  sizeDown,
+		delayUp:   dist.NewLogNormal(8.9, 2.5, seed^seedSaltDelayUp),
+		delayDown: dist.NewLogNormal(8.9, 2.5, seed^seedSaltDelayDown),
+		mtu:       defaultMTU,
+	}, nil
+}

--- a/internal/shaper/presets/chrome_browsing.go
+++ b/internal/shaper/presets/chrome_browsing.go
@@ -1,0 +1,59 @@
+package presets
+
+import (
+	"github.com/tiredvpn/tiredvpn/internal/shaper"
+	"github.com/tiredvpn/tiredvpn/internal/shaper/dist"
+)
+
+// PresetChromeBrowsing is the registry name for general HTTPS web browsing.
+const PresetChromeBrowsing = "chrome_browsing"
+
+// chrome_browsing models a typical desktop Chrome session over HTTPS:
+// many small TLS-record-sized requests with bursty mid-size responses,
+// long pauses between user clicks. Numbers are derived from morph-audit
+// (`Web Browsing` profile) plus inspection of typical TLS record histograms.
+//
+// Packet size histogram (bytes):
+//
+//	| value | weight | rationale                                              |
+//	|-------|--------|--------------------------------------------------------|
+//	|    60 |   0.20 | TCP/TLS keepalive, ACKs                                |
+//	|   180 |   0.25 | typical request line + headers                         |
+//	|   500 |   0.20 | small JSON / favicons                                  |
+//	|   900 |   0.15 | mid-size XHR responses                                 |
+//	|  1300 |   0.15 | full TLS record, near-MTU                              |
+//	|  1400 |   0.05 | jumbo, MSS-aligned                                     |
+//
+// Inter-arrival: LogNormal(mu=-7, sigma=1) → median ~0.9 ms, tail to ~50 ms,
+// matches HTTP/2 multiplexed bursts followed by rendering pauses.
+//
+// No burst engine — browsing is request/response, not steady-state.
+func init() {
+	register(PresetChromeBrowsing, buildChromeBrowsing)
+}
+
+func buildChromeBrowsing(seed int64) (shaper.Shaper, error) {
+	bins := []dist.HistogramBin{
+		{Value: 60, Weight: 0.20},
+		{Value: 180, Weight: 0.25},
+		{Value: 500, Weight: 0.20},
+		{Value: 900, Weight: 0.15},
+		{Value: 1300, Weight: 0.15},
+		{Value: 1400, Weight: 0.05},
+	}
+	sizeUp, err := dist.NewHistogram(bins, seed^seedSaltSizeUp)
+	if err != nil {
+		return nil, err
+	}
+	sizeDown, err := dist.NewHistogram(bins, seed^seedSaltSizeDown)
+	if err != nil {
+		return nil, err
+	}
+	return &distShaper{
+		sizeUp:    sizeUp,
+		sizeDown:  sizeDown,
+		delayUp:   dist.NewLogNormal(-7, 1, seed^seedSaltDelayUp),
+		delayDown: dist.NewLogNormal(-7, 1, seed^seedSaltDelayDown),
+		mtu:       defaultMTU,
+	}, nil
+}

--- a/internal/shaper/presets/dist_shaper.go
+++ b/internal/shaper/presets/dist_shaper.go
@@ -1,0 +1,151 @@
+package presets
+
+import (
+	"encoding/binary"
+	"time"
+
+	"github.com/tiredvpn/tiredvpn/internal/shaper"
+	"github.com/tiredvpn/tiredvpn/internal/shaper/dist"
+)
+
+// Default constants applied across presets unless overridden.
+const (
+	defaultMTU        = 1500
+	defaultPacketSize = 1200
+
+	// Domain separators used when deriving per-feature seeds from a single
+	// preset seed. They keep size/delay/burst RNG streams independent.
+	seedSaltSizeUp    = int64(0x5A1751756553697A) // "SALTsizeUp" mash
+	seedSaltSizeDown  = int64(0x5A1753697A65446F) // "SALTsizeDown"
+	seedSaltDelayUp   = int64(0x5A1744656C617955) // "SALTDelayU"
+	seedSaltDelayDown = int64(0x5A1744656C617944) // "SALTDelayD"
+	seedSaltDelay     = int64(0x5A1744656C617900) // "SALTDelay"
+	seedSaltBurst     = int64(0x5A1742757273746D) // "SALTBurstm"
+)
+
+// distShaper is a Shaper backed by four Distribution engines (size and delay
+// for each direction). The unit of NextDelay output is milliseconds: the
+// underlying Distribution.Next() is interpreted as a number of millis.
+type distShaper struct {
+	sizeUp    dist.Distribution
+	sizeDown  dist.Distribution
+	delayUp   dist.Distribution
+	delayDown dist.Distribution
+	mtu       int
+}
+
+// constDist is a degenerate Distribution that always returns the same value;
+// used as a placeholder when a custom-config field is omitted.
+type constDist float64
+
+func (c constDist) Next() float64 { return float64(c) }
+func (constDist) Reset()          {}
+
+// applyRandomization configures jitter on any histogram-based engine. Engines
+// that do not support jitter (LogNormal, Pareto, Markov) intrinsically have
+// continuous variance, so this is a no-op for them.
+func (d *distShaper) applyRandomization(r float64) {
+	for _, e := range []dist.Distribution{d.sizeUp, d.sizeDown, d.delayUp, d.delayDown} {
+		if h, ok := e.(*dist.Histogram); ok {
+			_ = h.SetRandomizationRange(r)
+		}
+	}
+}
+
+// NextPacketSize returns the next target packet size, clamped to [1, mtu].
+func (d *distShaper) NextPacketSize(dir shaper.Direction) int {
+	src := d.sizeUp
+	if dir == shaper.DirectionDown {
+		src = d.sizeDown
+	}
+	v := src.Next()
+	n := int(v + 0.5)
+	if n < 1 {
+		n = 1
+	}
+	if n > d.mtu {
+		n = d.mtu
+	}
+	return n
+}
+
+// NextDelay returns the next inter-packet delay. The Distribution value is
+// treated as milliseconds.
+func (d *distShaper) NextDelay(dir shaper.Direction) time.Duration {
+	src := d.delayUp
+	if dir == shaper.DirectionDown {
+		src = d.delayDown
+	}
+	v := src.Next()
+	if v < 0 {
+		v = 0
+	}
+	return time.Duration(v * float64(time.Millisecond))
+}
+
+// frameHeader is a 4-byte little-endian uvarint-style length prefix that
+// records the **payload** length carried by a single frame. The remainder of
+// the frame, up to NextPacketSize, is zero-padding.
+const frameHeaderLen = 4
+
+// Wrap fragments payload into one or more frames sized by NextPacketSize and
+// pads each with zero bytes to reach the target. Each frame is laid out as:
+//
+//	| len:uint32-le | payload[len] | padding |
+//
+// where len is the actual payload byte count. Empty payload produces a single
+// header-only frame so that Wrap/Unwrap is a total roundtrip.
+func (d *distShaper) Wrap(payload []byte) [][]byte {
+	if len(payload) == 0 {
+		return [][]byte{make([]byte, frameHeaderLen)}
+	}
+
+	var frames [][]byte
+	pos := 0
+	for pos < len(payload) {
+		target := d.NextPacketSize(shaper.DirectionUp)
+		// Reserve space for the header.
+		capacity := target - frameHeaderLen
+		if capacity < 1 {
+			capacity = 1
+			target = capacity + frameHeaderLen
+		}
+		take := capacity
+		if remaining := len(payload) - pos; remaining < take {
+			take = remaining
+		}
+		frame := make([]byte, target)
+		binary.LittleEndian.PutUint32(frame[:frameHeaderLen], uint32(take)) //nolint:gosec // bounded by mtu
+		copy(frame[frameHeaderLen:], payload[pos:pos+take])
+		frames = append(frames, frame)
+		pos += take
+	}
+	return frames
+}
+
+// Unwrap reverses Wrap by stripping the length prefix and any trailing padding
+// from each frame and concatenating the payload bytes.
+func (d *distShaper) Unwrap(frames [][]byte) []byte {
+	if len(frames) == 0 {
+		return nil
+	}
+	var total int
+	for _, f := range frames {
+		if len(f) < frameHeaderLen {
+			continue
+		}
+		total += int(binary.LittleEndian.Uint32(f[:frameHeaderLen]))
+	}
+	out := make([]byte, 0, total)
+	for _, f := range frames {
+		if len(f) < frameHeaderLen {
+			continue
+		}
+		n := int(binary.LittleEndian.Uint32(f[:frameHeaderLen]))
+		if n > len(f)-frameHeaderLen {
+			n = len(f) - frameHeaderLen
+		}
+		out = append(out, f[frameHeaderLen:frameHeaderLen+n]...)
+	}
+	return out
+}

--- a/internal/shaper/presets/presets.go
+++ b/internal/shaper/presets/presets.go
@@ -1,0 +1,175 @@
+// Package presets provides ready-to-use Shaper profiles built on top of
+// internal/shaper/dist primitives. Presets are referenced by name from the
+// TOML config (`shaper.preset = "..."`) and constructed via ByName.
+//
+// Each preset bundles two Distribution engines per direction (size + delay)
+// driven by a single seed, so that two Shapers built with the same name and
+// seed reproduce the same packet/delay sequence — a property exercised by
+// tests and required by the Hybrid handshake design (see ADR shaper-handshake).
+package presets
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"slices"
+
+	"github.com/tiredvpn/tiredvpn/internal/config/toml"
+	"github.com/tiredvpn/tiredvpn/internal/shaper"
+	"github.com/tiredvpn/tiredvpn/internal/shaper/dist"
+)
+
+// ErrUnknownPreset is returned by ByName when the requested preset is not
+// registered.
+var ErrUnknownPreset = errors.New("presets: unknown preset")
+
+// presetBuilder is the constructor signature every preset file registers.
+type presetBuilder func(seed int64) (shaper.Shaper, error)
+
+// registry holds all built-in presets. It is populated by init() in each
+// preset file so that adding a new preset is a single-file change.
+var registry = map[string]presetBuilder{}
+
+func register(name string, b presetBuilder) {
+	if _, exists := registry[name]; exists {
+		panic(fmt.Sprintf("presets: duplicate registration for %q", name))
+	}
+	registry[name] = b
+}
+
+// ByName returns a Shaper configured for the named preset.
+// Returns ErrUnknownPreset if name is not registered.
+func ByName(name string, seed int64) (shaper.Shaper, error) {
+	b, ok := registry[name]
+	if !ok {
+		return nil, fmt.Errorf("%w: %q", ErrUnknownPreset, name)
+	}
+	return b(seed)
+}
+
+// List returns all available preset names in deterministic (sorted) order.
+func List() []string {
+	names := make([]string, 0, len(registry))
+	for k := range registry {
+		names = append(names, k)
+	}
+	slices.Sort(names)
+	return names
+}
+
+// FromConfig builds a Shaper from a parsed TOML [shaper] section. Either
+// cfg.Preset or cfg.Custom must be set, not both. cfg.RandomizationRange is
+// applied to histogram bins where supported. cfg.Seed, when nil, is replaced
+// by a freshly drawn cryptographic seed.
+func FromConfig(cfg toml.ShaperConfig) (shaper.Shaper, error) {
+	if cfg.Preset != "" && cfg.Custom != nil {
+		return nil, errors.New("presets: preset and custom are mutually exclusive")
+	}
+	if cfg.Preset == "" && cfg.Custom == nil {
+		return nil, errors.New("presets: either preset or custom must be set")
+	}
+
+	seed := resolveSeed(cfg.Seed)
+
+	if cfg.Preset != "" {
+		s, err := ByName(cfg.Preset, seed)
+		if err != nil {
+			return nil, err
+		}
+		if cfg.RandomizationRange > 0 {
+			if ds, ok := s.(*distShaper); ok {
+				ds.applyRandomization(cfg.RandomizationRange)
+			}
+		}
+		return s, nil
+	}
+
+	return buildCustom(cfg.Custom, seed, cfg.RandomizationRange)
+}
+
+func resolveSeed(s *int64) int64 {
+	if s != nil {
+		return *s
+	}
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// crypto/rand failure on Linux is essentially impossible; fall back
+		// to a fixed sentinel so behavior remains deterministic for tests
+		// that intercept this path.
+		return 0
+	}
+	return int64(binary.LittleEndian.Uint64(b[:])) //nolint:gosec // intentional cast
+}
+
+func buildCustom(c *toml.ShaperCustom, seed int64, rr float64) (shaper.Shaper, error) {
+	ds := &distShaper{mtu: defaultMTU}
+
+	if c.PacketSize != nil {
+		d, err := buildDistribution(c.PacketSize, seed, rr)
+		if err != nil {
+			return nil, fmt.Errorf("packet_size: %w", err)
+		}
+		ds.sizeUp = d
+		ds.sizeDown = d
+	} else {
+		ds.sizeUp = constDist(defaultPacketSize)
+		ds.sizeDown = constDist(defaultPacketSize)
+	}
+
+	if c.InterArrival != nil {
+		d, err := buildDistribution(c.InterArrival, seed^seedSaltDelay, rr)
+		if err != nil {
+			return nil, fmt.Errorf("inter_arrival: %w", err)
+		}
+		ds.delayUp = d
+		ds.delayDown = d
+	} else {
+		ds.delayUp = constDist(0)
+		ds.delayDown = constDist(0)
+	}
+
+	// Burst is currently treated as an additional size mixer; if present, it
+	// overrides per-direction size on Down (downloads tend to burst).
+	if c.Burst != nil {
+		d, err := buildDistribution(c.Burst, seed^seedSaltBurst, rr)
+		if err != nil {
+			return nil, fmt.Errorf("burst: %w", err)
+		}
+		ds.sizeDown = d
+	}
+
+	return ds, nil
+}
+
+func buildDistribution(d *toml.DistConfig, seed int64, rr float64) (dist.Distribution, error) {
+	switch d.Type {
+	case toml.DistHistogram:
+		bins := make([]dist.HistogramBin, len(d.Histogram.Bins))
+		for i, b := range d.Histogram.Bins {
+			bins[i] = dist.HistogramBin{Value: b.Value, Weight: b.Weight}
+		}
+		h, err := dist.NewHistogram(bins, seed)
+		if err != nil {
+			return nil, err
+		}
+		if rr > 0 {
+			if err := h.SetRandomizationRange(rr); err != nil {
+				return nil, err
+			}
+		}
+		return h, nil
+	case toml.DistLogNormal:
+		return dist.NewLogNormal(d.LogNormal.Mu, d.LogNormal.Sigma, seed), nil
+	case toml.DistPareto:
+		return dist.NewPareto(d.Pareto.Xm, d.Pareto.Alpha, seed), nil
+	case toml.DistMarkov:
+		states := make([]dist.MarkovState, len(d.Markov.States))
+		for i, s := range d.Markov.States {
+			states[i] = dist.MarkovState{Name: s.Name, Value: s.Value}
+		}
+		return dist.NewMarkovBurst(states, d.Markov.Transitions, seed)
+	default:
+		return nil, fmt.Errorf("unknown distribution type %q", d.Type)
+	}
+}

--- a/internal/shaper/presets/presets_test.go
+++ b/internal/shaper/presets/presets_test.go
@@ -1,0 +1,427 @@
+package presets
+
+import (
+	"bytes"
+	"errors"
+	"math"
+	"math/rand/v2"
+	"testing"
+
+	"github.com/tiredvpn/tiredvpn/internal/config/toml"
+	"github.com/tiredvpn/tiredvpn/internal/shaper"
+)
+
+func TestList_NotEmpty(t *testing.T) {
+	names := List()
+	if len(names) < 4 {
+		t.Fatalf("expected >=4 presets, got %v", names)
+	}
+	want := map[string]bool{
+		PresetChromeBrowsing:   false,
+		PresetYouTubeStreaming: false,
+		PresetBitTorrentIdle:   false,
+		PresetRandomPerSession: false,
+	}
+	for _, n := range names {
+		if _, ok := want[n]; ok {
+			want[n] = true
+		}
+	}
+	for n, seen := range want {
+		if !seen {
+			t.Errorf("missing preset %q", n)
+		}
+	}
+}
+
+func TestByName_Unknown(t *testing.T) {
+	_, err := ByName("does_not_exist", 1)
+	if !errors.Is(err, ErrUnknownPreset) {
+		t.Fatalf("want ErrUnknownPreset, got %v", err)
+	}
+}
+
+func TestByName_AllPresets_Determinism(t *testing.T) {
+	for _, name := range List() {
+		t.Run(name, func(t *testing.T) {
+			a, err := ByName(name, 42)
+			if err != nil {
+				t.Fatal(err)
+			}
+			b, err := ByName(name, 42)
+			if err != nil {
+				t.Fatal(err)
+			}
+			const N = 1000
+			for i := range N {
+				sa := a.NextPacketSize(shaper.DirectionUp)
+				sb := b.NextPacketSize(shaper.DirectionUp)
+				if sa != sb {
+					t.Fatalf("step %d size mismatch: %d != %d", i, sa, sb)
+				}
+				da := a.NextDelay(shaper.DirectionDown)
+				db := b.NextDelay(shaper.DirectionDown)
+				if da != db {
+					t.Fatalf("step %d delay mismatch: %v != %v", i, da, db)
+				}
+			}
+		})
+	}
+}
+
+// TestByName_DifferentPresetsDiffer compares mean packet size of chrome and
+// youtube. youtube must dominate (preferentially full-MTU).
+func TestByName_DifferentPresetsDiffer(t *testing.T) {
+	chrome, err := ByName(PresetChromeBrowsing, 7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	yt, err := ByName(PresetYouTubeStreaming, 7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const N = 5000
+	var chromeMean, ytMean float64
+	for range N {
+		chromeMean += float64(chrome.NextPacketSize(shaper.DirectionDown))
+		ytMean += float64(yt.NextPacketSize(shaper.DirectionDown))
+	}
+	chromeMean /= N
+	ytMean /= N
+	if ytMean-chromeMean < 200 {
+		t.Fatalf("expected youtube mean ≫ chrome mean, got chrome=%v youtube=%v", chromeMean, ytMean)
+	}
+	t.Logf("chrome mean=%.1f youtube mean=%.1f delta=%.1f", chromeMean, ytMean, ytMean-chromeMean)
+}
+
+func TestRandomPerSession_Variation(t *testing.T) {
+	const N = 2000
+	signature := func(seed int64) (mean float64) {
+		s, err := ByName(PresetRandomPerSession, seed)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var sum float64
+		for range N {
+			sum += float64(s.NextPacketSize(shaper.DirectionDown))
+		}
+		return sum / N
+	}
+	// Try several seeds; at least two should differ noticeably.
+	means := make([]float64, 8)
+	for i := range means {
+		means[i] = signature(int64(i + 1))
+	}
+	maxDelta := 0.0
+	for i := range means {
+		for j := i + 1; j < len(means); j++ {
+			d := math.Abs(means[i] - means[j])
+			if d > maxDelta {
+				maxDelta = d
+			}
+		}
+	}
+	if maxDelta < 50 {
+		t.Fatalf("random_per_session shows insufficient cross-seed variation: maxDelta=%.1f means=%v", maxDelta, means)
+	}
+}
+
+func TestFromConfig_PresetAndCustomMutuallyExclusive(t *testing.T) {
+	cfg := toml.ShaperConfig{
+		Preset: PresetChromeBrowsing,
+		Custom: &toml.ShaperCustom{},
+	}
+	if _, err := FromConfig(cfg); err == nil {
+		t.Fatal("expected error for both preset and custom set")
+	}
+	cfg = toml.ShaperConfig{}
+	if _, err := FromConfig(cfg); err == nil {
+		t.Fatal("expected error for neither preset nor custom set")
+	}
+}
+
+func TestFromConfig_Preset_WithRandomization(t *testing.T) {
+	rr := 0.3
+	cfg := toml.ShaperConfig{
+		Preset:             PresetChromeBrowsing,
+		RandomizationRange: rr,
+		Seed:               int64Ptr(123),
+	}
+	s, err := FromConfig(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Just ensure it works and returns sensible values.
+	for range 100 {
+		n := s.NextPacketSize(shaper.DirectionUp)
+		if n < 1 || n > defaultMTU {
+			t.Fatalf("size %d out of range", n)
+		}
+	}
+}
+
+func TestFromConfig_Custom_Histogram(t *testing.T) {
+	cfg := toml.ShaperConfig{
+		Custom: &toml.ShaperCustom{
+			PacketSize: &toml.DistConfig{
+				Type: toml.DistHistogram,
+				Histogram: &toml.HistogramDist{
+					Bins: []toml.HistogramBin{
+						{Value: 100, Weight: 1},
+						{Value: 1400, Weight: 1},
+					},
+				},
+			},
+			InterArrival: &toml.DistConfig{
+				Type:      toml.DistLogNormal,
+				LogNormal: &toml.LogNormalDist{Mu: -5, Sigma: 0.5},
+			},
+		},
+		Seed: int64Ptr(99),
+	}
+	s, err := FromConfig(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for range 100 {
+		n := s.NextPacketSize(shaper.DirectionUp)
+		if n != 100 && n != 1400 {
+			t.Fatalf("unexpected size %d, want 100 or 1400", n)
+		}
+		if d := s.NextDelay(shaper.DirectionUp); d < 0 {
+			t.Fatalf("negative delay: %v", d)
+		}
+	}
+}
+
+func TestFromConfig_Custom_BadDist(t *testing.T) {
+	cfg := toml.ShaperConfig{
+		Custom: &toml.ShaperCustom{
+			PacketSize: &toml.DistConfig{Type: "weird"},
+		},
+		Seed: int64Ptr(1),
+	}
+	if _, err := FromConfig(cfg); err == nil {
+		t.Fatal("expected error for unknown distribution type")
+	}
+}
+
+func TestFromConfig_NilSeed_Works(t *testing.T) {
+	cfg := toml.ShaperConfig{Preset: PresetChromeBrowsing}
+	s, err := FromConfig(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.NextPacketSize(shaper.DirectionUp) <= 0 {
+		t.Fatal("expected positive packet size")
+	}
+}
+
+func TestDistShaper_WrapUnwrap_Roundtrip(t *testing.T) {
+	rng := rand.New(rand.NewPCG(1, 2))
+	for _, size := range []int{0, 1, 100, 1500, 4096, 65536} {
+		s, err := ByName(PresetChromeBrowsing, 1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		payload := make([]byte, size)
+		for i := range payload {
+			payload[i] = byte(rng.UintN(256))
+		}
+		frames := s.Wrap(payload)
+		out := s.Unwrap(frames)
+		if !bytes.Equal(out, payload) {
+			t.Fatalf("size=%d: roundtrip mismatch (got %d bytes, want %d)", size, len(out), len(payload))
+		}
+	}
+}
+
+func TestDistShaper_NextPacketSize_RespectsMTU(t *testing.T) {
+	for _, name := range []string{
+		PresetChromeBrowsing, PresetYouTubeStreaming,
+		PresetBitTorrentIdle, PresetRandomPerSession,
+	} {
+		s, err := ByName(name, 5)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for range 5000 {
+			n := s.NextPacketSize(shaper.DirectionDown)
+			if n < 1 || n > defaultMTU {
+				t.Fatalf("%s: size %d out of [1, %d]", name, n, defaultMTU)
+			}
+		}
+	}
+}
+
+func TestDistShaper_NextDelay_NonNegative(t *testing.T) {
+	for _, name := range List() {
+		s, err := ByName(name, 11)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for range 1000 {
+			if d := s.NextDelay(shaper.DirectionUp); d < 0 {
+				t.Fatalf("%s: negative delay %v", name, d)
+			}
+		}
+	}
+}
+
+func TestNoopWrapEmpty(t *testing.T) {
+	s, err := ByName(PresetChromeBrowsing, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := s.Unwrap(nil)
+	if out != nil {
+		t.Fatalf("nil unwrap got %v", out)
+	}
+}
+
+func int64Ptr(v int64) *int64 { return &v }
+
+func TestConstDist(t *testing.T) {
+	c := constDist(42)
+	if c.Next() != 42 {
+		t.Fatalf("constDist.Next mismatch")
+	}
+	c.Reset() // no-op, must not panic
+}
+
+func TestFromConfig_Custom_Empty(t *testing.T) {
+	cfg := toml.ShaperConfig{
+		Custom: &toml.ShaperCustom{},
+		Seed:   int64Ptr(1),
+	}
+	s, err := FromConfig(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.NextPacketSize(shaper.DirectionUp) != defaultPacketSize {
+		t.Fatalf("expected default packet size %d", defaultPacketSize)
+	}
+	if s.NextDelay(shaper.DirectionUp) != 0 {
+		t.Fatalf("expected zero default delay")
+	}
+}
+
+func TestFromConfig_Custom_AllDistTypes(t *testing.T) {
+	tests := []struct {
+		name string
+		d    *toml.DistConfig
+	}{
+		{"pareto", &toml.DistConfig{Type: toml.DistPareto, Pareto: &toml.ParetoDist{Xm: 1, Alpha: 1.5}}},
+		{"markov", &toml.DistConfig{Type: toml.DistMarkov, Markov: &toml.MarkovDist{
+			States:      []toml.MarkovState{{Name: "a", Value: 100}, {Name: "b", Value: 1400}},
+			Transitions: [][]float64{{0.5, 0.5}, {0.3, 0.7}},
+		}}},
+		{"histogram", &toml.DistConfig{Type: toml.DistHistogram, Histogram: &toml.HistogramDist{
+			Bins: []toml.HistogramBin{{Value: 200, Weight: 1}},
+		}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := toml.ShaperConfig{
+				Custom: &toml.ShaperCustom{
+					PacketSize: tt.d,
+					Burst:      tt.d,
+				},
+				Seed:               int64Ptr(7),
+				RandomizationRange: 0.1,
+			}
+			s, err := FromConfig(cfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if n := s.NextPacketSize(shaper.DirectionDown); n < 1 {
+				t.Fatalf("bad size %d", n)
+			}
+		})
+	}
+}
+
+func TestFromConfig_Custom_BadHistogram(t *testing.T) {
+	cfg := toml.ShaperConfig{
+		Custom: &toml.ShaperCustom{
+			InterArrival: &toml.DistConfig{
+				Type:      toml.DistHistogram,
+				Histogram: &toml.HistogramDist{Bins: []toml.HistogramBin{{Value: 1, Weight: 0}}},
+			},
+		},
+		Seed: int64Ptr(1),
+	}
+	if _, err := FromConfig(cfg); err == nil {
+		t.Fatal("expected error for zero-weight histogram")
+	}
+}
+
+func TestFromConfig_Custom_BadBurst(t *testing.T) {
+	cfg := toml.ShaperConfig{
+		Custom: &toml.ShaperCustom{
+			Burst: &toml.DistConfig{Type: "weird"},
+		},
+		Seed: int64Ptr(1),
+	}
+	if _, err := FromConfig(cfg); err == nil {
+		t.Fatal("expected error for bad burst dist")
+	}
+}
+
+func TestFromConfig_Custom_BadInterArrival(t *testing.T) {
+	cfg := toml.ShaperConfig{
+		Custom: &toml.ShaperCustom{
+			InterArrival: &toml.DistConfig{Type: "weird"},
+		},
+		Seed: int64Ptr(1),
+	}
+	if _, err := FromConfig(cfg); err == nil {
+		t.Fatal("expected error for bad inter_arrival dist")
+	}
+}
+
+func TestUnwrap_TruncatedFrame(t *testing.T) {
+	// Build a valid frame, then truncate it to test the bounds-check branch.
+	s, err := ByName(PresetChromeBrowsing, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	frames := s.Wrap([]byte("hello world"))
+	// Short frame (< header).
+	frames = append(frames, []byte{0x01, 0x02})
+	// Frame with header claiming more bytes than present.
+	bad := make([]byte, frameHeaderLen+2)
+	bad[0] = 0xFF // claim huge length
+	bad[1] = 0xFF
+	bad[2] = 0xFF
+	bad[3] = 0xFF
+	bad[4] = 'X'
+	bad[5] = 'Y'
+	frames = append(frames, bad)
+	out := s.Unwrap(frames)
+	// Original payload should still be at the front; trailing garbage is XY.
+	if len(out) < len("hello world") || string(out[:len("hello world")]) != "hello world" {
+		t.Fatalf("expected hello world prefix, got %q", string(out))
+	}
+}
+
+func TestRegister_DuplicatePanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic on duplicate register")
+		}
+	}()
+	register(PresetChromeBrowsing, buildChromeBrowsing)
+}
+
+func BenchmarkChromeBrowsing_Next(b *testing.B) {
+	s, err := ByName(PresetChromeBrowsing, 1)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	for b.Loop() {
+		_ = s.NextPacketSize(shaper.DirectionUp)
+		_ = s.NextDelay(shaper.DirectionUp)
+	}
+}

--- a/internal/shaper/presets/random_per_session.go
+++ b/internal/shaper/presets/random_per_session.go
@@ -1,0 +1,55 @@
+package presets
+
+import (
+	"math/rand/v2"
+
+	"github.com/tiredvpn/tiredvpn/internal/shaper"
+	"github.com/tiredvpn/tiredvpn/internal/shaper/dist"
+)
+
+// PresetRandomPerSession is the registry name for a per-session randomized
+// preset: it picks one of {chrome_browsing, youtube_streaming, bittorrent_idle}
+// using `seed` and applies a ±randomizationFraction jitter to histogram bins
+// so that even repeated picks of the same base preset produce subtly different
+// signatures.
+const PresetRandomPerSession = "random_per_session"
+
+// randomizationFraction is the default ±jitter applied to histogram bins
+// (15%). Operators can override it via cfg.RandomizationRange when the
+// preset is selected from TOML.
+const randomizationFraction = 0.15
+
+func init() {
+	register(PresetRandomPerSession, buildRandomPerSession)
+}
+
+// buildRandomPerSession derives the basis preset name from `seed`, builds
+// it, then applies bin jitter on every histogram engine inside the resulting
+// distShaper. The function intentionally re-uses the same `seed` for the
+// underlying preset so that a known seed reproduces the exact same shape.
+func buildRandomPerSession(seed int64) (shaper.Shaper, error) {
+	candidates := []string{
+		PresetChromeBrowsing,
+		PresetYouTubeStreaming,
+		PresetBitTorrentIdle,
+	}
+	// Use a dedicated PCG stream to choose the basis preset so that the choice
+	// is independent of the underlying preset's RNG sequence.
+	chooserSeed1 := uint64(seed) //nolint:gosec
+	chooserSeed2 := uint64(seed) ^ 0xA5A5A5A5A5A5A5A5
+	chooser := rand.New(rand.NewPCG(chooserSeed1, chooserSeed2))
+	pick := candidates[chooser.IntN(len(candidates))]
+
+	s, err := ByName(pick, seed)
+	if err != nil {
+		return nil, err
+	}
+	if ds, ok := s.(*distShaper); ok {
+		for _, e := range []dist.Distribution{ds.sizeUp, ds.sizeDown, ds.delayUp, ds.delayDown} {
+			if h, ok := e.(*dist.Histogram); ok {
+				_ = h.SetRandomizationRange(randomizationFraction)
+			}
+		}
+	}
+	return s, nil
+}

--- a/internal/shaper/presets/youtube_streaming.go
+++ b/internal/shaper/presets/youtube_streaming.go
@@ -1,0 +1,66 @@
+package presets
+
+import (
+	"github.com/tiredvpn/tiredvpn/internal/shaper"
+	"github.com/tiredvpn/tiredvpn/internal/shaper/dist"
+)
+
+// PresetYouTubeStreaming is the registry name for an HD video stream.
+const PresetYouTubeStreaming = "youtube_streaming"
+
+// youtube_streaming models high-bitrate adaptive video: packets are nearly
+// always full-MTU on download, requests upstream are tiny (segment GETs and
+// ACKs), and inter-arrival on download is heavy-tailed (Pareto) because
+// playback alternates between burst-fill and rebuffering pauses.
+//
+// Numbers are derived from morph-audit Yandex/VK profiles (large packets
+// 1200–1400, ratio 15–18) plus published QUIC video traces.
+//
+// Download size histogram (bytes):
+//
+//	| value | weight | rationale                                  |
+//	|-------|--------|--------------------------------------------|
+//	|  1300 |   0.20 | TLS record, typical                        |
+//	|  1400 |   0.30 | MSS-aligned                                |
+//	|  1450 |   0.40 | near-MTU, dominant                         |
+//	|   600 |   0.05 | rare partial frame                         |
+//	|   100 |   0.05 | ACK / control                              |
+//
+// Upload size histogram is sparse and small (mostly ACKs and segment GETs).
+//
+// Inter-arrival: Pareto(xm=0.05 ms, alpha=1.5) on download (heavy tail for
+// rebuffering); LogNormal(mu=-3, sigma=1.5) on upload (sparse GETs).
+func init() {
+	register(PresetYouTubeStreaming, buildYouTubeStreaming)
+}
+
+func buildYouTubeStreaming(seed int64) (shaper.Shaper, error) {
+	downBins := []dist.HistogramBin{
+		{Value: 1300, Weight: 0.20},
+		{Value: 1400, Weight: 0.30},
+		{Value: 1450, Weight: 0.40},
+		{Value: 600, Weight: 0.05},
+		{Value: 100, Weight: 0.05},
+	}
+	upBins := []dist.HistogramBin{
+		{Value: 60, Weight: 0.55},  // ACKs
+		{Value: 200, Weight: 0.30}, // segment GETs
+		{Value: 500, Weight: 0.10},
+		{Value: 1300, Weight: 0.05}, // rare keep-alive PING with payload
+	}
+	sizeUp, err := dist.NewHistogram(upBins, seed^seedSaltSizeUp)
+	if err != nil {
+		return nil, err
+	}
+	sizeDown, err := dist.NewHistogram(downBins, seed^seedSaltSizeDown)
+	if err != nil {
+		return nil, err
+	}
+	return &distShaper{
+		sizeUp:    sizeUp,
+		sizeDown:  sizeDown,
+		delayUp:   dist.NewLogNormal(-3, 1.5, seed^seedSaltDelayUp),
+		delayDown: dist.NewPareto(0.05, 1.5, seed^seedSaltDelayDown),
+		mtu:       defaultMTU,
+	}, nil
+}


### PR DESCRIPTION
## Summary

- New package `internal/shaper/presets` implementing `ByName`, `List` and `FromConfig` over the existing `dist.Distribution` engines.
- Four built-in profiles: `chrome_browsing` (LogNormal delay, mid-size histogram), `youtube_streaming` (Pareto download, near-MTU bias), `bittorrent_idle` (sparse small packets, multi-second pauses), `random_per_session` (picks a basis preset from the seed + ±15% jitter — ready for `ServerHello.random`-derived seeding per the Hybrid handshake ADR).
- `distShaper` composes `dist.Distribution` engines for size+delay per direction, with `Wrap`/`Unwrap` using a 4-byte LE length prefix + zero padding up to `NextPacketSize`.

Refs: tiredvpn-oss-y37, #6.

## Numbers

- Median packet size (DirectionDown, seed=42, N=10000):
  - `chrome_browsing` ≈ 560 B mean
  - `youtube_streaming` ≈ 1289 B mean (Δ ≈ 729 B vs chrome → easily distinguishable)
- Coverage `internal/shaper/presets`: **91.8%**
- Benchmark `BenchmarkChromeBrowsing_Next`: **~67 ns/op**, 0 allocs

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/shaper/...` — all green
- [x] `golangci-lint run ./internal/shaper/...` — no issues
- [x] Determinism: same `(name, seed)` reproduces 1000 size/delay pairs
- [x] Wrap/Unwrap roundtrip up to 64 KiB
- [x] `NextPacketSize` clamped to `[1, mtu]` for all presets
- [x] `FromConfig` rejects mutually-exclusive preset+custom and builds from histogram/lognormal/pareto/markov

## Out of scope

Pipeline integration (`internal/strategy/morph.go`, server, client) — that is task `tiredvpn-oss-5wm` / I2.