### PR TITLE
feat(strategy/morph): wire Shaper interface into MorphedConn pipeline

### DIFF
--- a/internal/strategy/morph.go
+++ b/internal/strategy/morph.go
@@ -13,6 +13,7 @@ import (
 	"github.com/tiredvpn/tiredvpn/internal/evasion"
 	"github.com/tiredvpn/tiredvpn/internal/ktls"
 	"github.com/tiredvpn/tiredvpn/internal/log"
+	"github.com/tiredvpn/tiredvpn/internal/shaper"
 )
 
 // TrafficMorphStrategy morphs traffic to match target application patterns
@@ -314,6 +315,11 @@ type MorphedConn struct {
 	net.Conn
 	profile *TrafficProfile
 
+	// shaper drives sizing, delay and fragmentation. NoopShaper means
+	// "use the legacy per-Write padding pipeline" — we keep wire bytes
+	// byte-identical to pre-shaper builds in that mode (backward compat).
+	shaper shaper.Shaper
+
 	// Read buffer for partial reads
 	readBuf []byte
 
@@ -332,13 +338,24 @@ func (mc *MorphedConn) NetConn() net.Conn {
 	return mc.Conn
 }
 
-// NewMorphedConn creates a morphed connection.
-// It performs the application-layer Morph handshake over the underlying
-// (typically TLS) conn before returning.
+// NewMorphedConn creates a morphed connection with the legacy passthrough
+// shaper. It performs the application-layer Morph handshake over the
+// underlying (typically TLS) conn before returning.
 func NewMorphedConn(conn net.Conn, profile *TrafficProfile, secret []byte) *MorphedConn {
+	return NewMorphedConnWithShaper(conn, profile, secret, nil)
+}
+
+// NewMorphedConnWithShaper is like NewMorphedConn but lets callers inject a
+// behavioral shaper. A nil sh defaults to shaper.NoopShaper, which keeps the
+// wire format and Write/Read pipeline byte-identical to the pre-shaper code.
+func NewMorphedConnWithShaper(conn net.Conn, profile *TrafficProfile, secret []byte, sh shaper.Shaper) *MorphedConn {
+	if sh == nil {
+		sh = shaper.NoopShaper{}
+	}
 	mc := &MorphedConn{
 		Conn:    conn,
 		profile: profile,
+		shaper:  sh,
 		// Rate limiter disabled - was causing 80 KB/s bottleneck
 		rateLimiter: nil,
 	}
@@ -491,6 +508,12 @@ func (mc *MorphedConn) Write(p []byte) (int, error) {
 		return 0, nil
 	}
 
+	// Non-Noop shapers fragment + delay; Noop preserves the legacy wire layout
+	// exactly (one Write -> one frame, padding from profile).
+	if !isNoopShaper(mc.shaper) {
+		return mc.writeShaped(p)
+	}
+
 	// Build framed packet [header:6][data:N][padding:M]
 	padLen := mc.pickPaddingLen()
 	packet, fromPool := buildFrame(p, padLen)
@@ -531,7 +554,8 @@ func (mc *MorphedConn) Write(p []byte) (int, error) {
 // Reads header+data+padding in fewer syscalls; padding is silently dropped.
 // NOTE: Rate limiting on Read creates TCP backpressure to slow down server.
 func (mc *MorphedConn) Read(p []byte) (int, error) {
-	// If we have buffered data, return from buffer first
+	// Drain anything already buffered by either path before pulling new bytes;
+	// the shaper path may yield a payload larger than p in one go.
 	if len(mc.readBuf) > 0 {
 		n := copy(p, mc.readBuf)
 		mc.readBuf = mc.readBuf[n:]
@@ -541,6 +565,10 @@ func (mc *MorphedConn) Read(p []byte) (int, error) {
 			mc.rateLimiter.Wait(n)
 		}
 		return n, nil
+	}
+
+	if !isNoopShaper(mc.shaper) {
+		return mc.readShaped(p)
 	}
 
 	// Read packet header: [dataLen:4][paddingLen:2]

--- a/internal/strategy/morph_shaper.go
+++ b/internal/strategy/morph_shaper.go
@@ -1,0 +1,133 @@
+package strategy
+
+import (
+	"io"
+	"time"
+
+	"github.com/tiredvpn/tiredvpn/internal/config/toml"
+	"github.com/tiredvpn/tiredvpn/internal/shaper"
+)
+
+// isNoopShaper reports whether sh is the passthrough shaper. The legacy Write
+// path stays bit-identical to pre-shaper builds when this is true, so existing
+// servers keep wire compatibility regardless of how a connection is built.
+func isNoopShaper(sh shaper.Shaper) bool {
+	if sh == nil {
+		return true
+	}
+	switch sh.(type) {
+	case shaper.NoopShaper, *shaper.NoopShaper:
+		return true
+	}
+	return false
+}
+
+// writeShaped emits one or more frames per Write according to the shaper's
+// Wrap/NextPacketSize/NextDelay decisions. Inter-frame spacing is enforced
+// with time.Sleep — simpler than a ticker and good enough for the typical
+// sub-millisecond budgets the shaper produces.
+func (mc *MorphedConn) writeShaped(p []byte) (int, error) {
+	frames := mc.shaper.Wrap(p)
+	if len(frames) == 0 {
+		return len(p), nil
+	}
+	for i, frame := range frames {
+		target := mc.shaper.NextPacketSize(shaper.DirectionUp)
+		padLen := target - len(frame) - morphHeaderLen
+		if padLen < 0 {
+			padLen = 0
+		}
+		packet, fromPool := buildFrame(frame, padLen)
+
+		if mc.rateLimiter != nil {
+			mc.rateLimiter.Wait(len(packet))
+		}
+		_, err := mc.Conn.Write(packet)
+		if fromPool {
+			packetPool.Put(packet[:cap(packet)])
+		}
+		if err != nil {
+			if mc.rateLimiter != nil {
+				mc.rateLimiter.RecordFailure()
+			}
+			return 0, err
+		}
+		if mc.rateLimiter != nil {
+			mc.rateLimiter.RecordSuccess()
+		}
+		mc.packetsSent++
+		mc.bytesSent += int64(len(packet))
+
+		if d := mc.shaper.NextDelay(shaper.DirectionUp); d > 0 && i < len(frames)-1 {
+			time.Sleep(d)
+		}
+	}
+	return len(p), nil
+}
+
+// readShaped pulls a single Morph frame off the wire, strips padding and
+// hands the framed payload to shaper.Unwrap. Calling Unwrap with a single
+// frame matches the documented streaming contract: NoopShaper is identity,
+// distribution-driven shapers strip per-frame padding/markers as needed.
+func (mc *MorphedConn) readShaped(p []byte) (int, error) {
+	header := make([]byte, morphHeaderLen)
+	if _, err := io.ReadFull(mc.Conn, header); err != nil {
+		return 0, err
+	}
+	dataLen, paddingLen := readFrameHeader(header)
+
+	// Dummy frames carry no payload (keepalive). Match the legacy contract:
+	// signal the TUN layer with the 4-zero-byte sentinel.
+	if dataLen == 0 {
+		if paddingLen > 0 {
+			discard := make([]byte, paddingLen)
+			if _, err := io.ReadFull(mc.Conn, discard); err != nil {
+				return 0, err
+			}
+		}
+		if len(p) >= 4 {
+			p[0], p[1], p[2], p[3] = 0, 0, 0, 0
+			return 4, nil
+		}
+		return mc.readShaped(p)
+	}
+
+	totalPayload := dataLen + paddingLen
+	payload := make([]byte, totalPayload)
+	n, err := io.ReadFull(mc.Conn, payload)
+	if err != nil {
+		return 0, err
+	}
+	frame := payload[:dataLen]
+	data := mc.shaper.Unwrap([][]byte{frame})
+
+	mc.packetsRecv++
+	mc.bytesRecv += int64(n)
+
+	copied := copy(p, data)
+	if copied < len(data) {
+		mc.readBuf = append(mc.readBuf, data[copied:]...)
+	}
+	if mc.rateLimiter != nil {
+		mc.rateLimiter.Wait(copied)
+	}
+	return copied, nil
+}
+
+// ShaperFromConfig builds a Shaper for MorphedConn from the parsed TOML
+// [shaper] section. A nil cfg or one with neither preset nor custom returns
+// NoopShaper so callers can always safely pass through.
+//
+// Preset resolution and custom-distribution wiring live in a follow-up task
+// (see internal/shaper/presets, beads y37). For now we return NoopShaper for
+// any non-empty config so the call site is stable and tests are deterministic.
+func ShaperFromConfig(cfg *toml.ShaperConfig) (shaper.Shaper, error) {
+	if cfg == nil {
+		return shaper.NoopShaper{}, nil
+	}
+	if cfg.Preset == "" && cfg.Custom == nil {
+		return shaper.NoopShaper{}, nil
+	}
+	// TODO(y37): wire to internal/shaper/presets and dist registry.
+	return shaper.NoopShaper{}, nil
+}

--- a/internal/strategy/morph_shaper_test.go
+++ b/internal/strategy/morph_shaper_test.go
@@ -1,0 +1,234 @@
+package strategy
+
+import (
+	"bytes"
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/tiredvpn/tiredvpn/internal/config/toml"
+	"github.com/tiredvpn/tiredvpn/internal/shaper"
+)
+
+// fakeConn captures writes and serves canned reads so tests can inspect
+// the exact bytes Morph emits without going through a real socket.
+type fakeConn struct {
+	mu        sync.Mutex
+	writeBuf  bytes.Buffer
+	readBuf   bytes.Buffer
+	closed    bool
+}
+
+func (f *fakeConn) Read(b []byte) (int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.readBuf.Len() == 0 {
+		return 0, io.EOF
+	}
+	return f.readBuf.Read(b)
+}
+func (f *fakeConn) Write(b []byte) (int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.writeBuf.Write(b)
+}
+func (f *fakeConn) Close() error                       { f.closed = true; return nil }
+func (f *fakeConn) LocalAddr() net.Addr                { return &net.IPAddr{} }
+func (f *fakeConn) RemoteAddr() net.Addr               { return &net.IPAddr{} }
+func (f *fakeConn) SetDeadline(t time.Time) error      { return nil }
+func (f *fakeConn) SetReadDeadline(t time.Time) error  { return nil }
+func (f *fakeConn) SetWriteDeadline(t time.Time) error { return nil }
+
+func (f *fakeConn) writtenAfterHandshake(handshakeLen int) []byte {
+	b := f.writeBuf.Bytes()
+	if len(b) < handshakeLen {
+		return nil
+	}
+	return b[handshakeLen:]
+}
+
+// newTestMorphedConn skips the real handshake's randomness and just
+// computes the handshake length so tests can read post-handshake bytes.
+func handshakeLen(profile *TrafficProfile) int {
+	return 5 + len(profile.Name) + 32
+}
+
+// TestMorphedConn_NoopShaper_BackwardCompat: with default (nil) shaper the
+// Write pipeline emits exactly one [header:6][data:N][padding:M] frame per
+// Write whose layout matches readFrameHeader's view of the bytes.
+func TestMorphedConn_NoopShaper_BackwardCompat(t *testing.T) {
+	profile := &TrafficProfile{
+		Name:            "Test",
+		PacketSizes:     []int{100},
+		PacketSizeProbs: []float64{1.0},
+		MinPadding:      0,
+		MaxPadding:      0,
+	}
+	fc := &fakeConn{}
+	mc := NewMorphedConn(fc, profile, []byte("secretsecretsecretsecretsecretse"))
+
+	payload := []byte("hello world")
+	n, err := mc.Write(payload)
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if n != len(payload) {
+		t.Fatalf("Write returned %d, want %d", n, len(payload))
+	}
+
+	wire := fc.writtenAfterHandshake(handshakeLen(profile))
+	if len(wire) != morphHeaderLen+len(payload) {
+		t.Fatalf("noop frame size = %d, want %d", len(wire), morphHeaderLen+len(payload))
+	}
+	dataLen, padLen := readFrameHeader(wire)
+	if dataLen != len(payload) || padLen != 0 {
+		t.Fatalf("noop header dataLen=%d padLen=%d", dataLen, padLen)
+	}
+	if !bytes.Equal(wire[morphHeaderLen:morphHeaderLen+dataLen], payload) {
+		t.Fatalf("noop payload mismatch: %q", wire[morphHeaderLen:])
+	}
+}
+
+// mockShaper records calls and produces deterministic Wrap/Unwrap behaviour
+// so tests can assert the new Write path uses shaper output exclusively.
+type mockShaper struct {
+	wrapCalls    [][]byte
+	unwrapCalls  [][][]byte
+	nextSize     int
+	nextDelay    time.Duration
+	fragmentInto int // split payload into N equal-ish chunks; 0 => single frame
+}
+
+func (m *mockShaper) NextPacketSize(_ shaper.Direction) int    { return m.nextSize }
+func (m *mockShaper) NextDelay(_ shaper.Direction) time.Duration { return m.nextDelay }
+func (m *mockShaper) Wrap(p []byte) [][]byte {
+	m.wrapCalls = append(m.wrapCalls, append([]byte(nil), p...))
+	if m.fragmentInto <= 1 {
+		return [][]byte{p}
+	}
+	chunk := (len(p) + m.fragmentInto - 1) / m.fragmentInto
+	if chunk == 0 {
+		return [][]byte{p}
+	}
+	out := make([][]byte, 0, m.fragmentInto)
+	for i := 0; i < len(p); i += chunk {
+		end := min(i+chunk, len(p))
+		out = append(out, p[i:end])
+	}
+	return out
+}
+func (m *mockShaper) Unwrap(frames [][]byte) []byte {
+	m.unwrapCalls = append(m.unwrapCalls, frames)
+	total := 0
+	for _, f := range frames {
+		total += len(f)
+	}
+	out := make([]byte, 0, total)
+	for _, f := range frames {
+		out = append(out, f...)
+	}
+	return out
+}
+
+func TestMorphedConn_WithShaper_Wrap(t *testing.T) {
+	profile := &TrafficProfile{Name: "T", PacketSizes: []int{100}, PacketSizeProbs: []float64{1}}
+	fc := &fakeConn{}
+	ms := &mockShaper{nextSize: 64, fragmentInto: 3}
+	mc := NewMorphedConnWithShaper(fc, profile, []byte("secretsecretsecretsecretsecretse"), ms)
+
+	payload := bytes.Repeat([]byte("A"), 30)
+	if _, err := mc.Write(payload); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if len(ms.wrapCalls) != 1 {
+		t.Fatalf("Wrap called %d times, want 1", len(ms.wrapCalls))
+	}
+	if !bytes.Equal(ms.wrapCalls[0], payload) {
+		t.Fatalf("Wrap got %q, want %q", ms.wrapCalls[0], payload)
+	}
+
+	// Three fragments produced by mockShaper -> three frames on the wire,
+	// each [header:6][data:chunk][padding:64-chunk-6].
+	wire := fc.writtenAfterHandshake(handshakeLen(profile))
+	off := 0
+	frameCount := 0
+	for off < len(wire) {
+		dataLen, padLen := readFrameHeader(wire[off:])
+		total := morphHeaderLen + dataLen + padLen
+		if morphHeaderLen+dataLen+padLen != 64 {
+			t.Errorf("frame %d total=%d, want 64 (NextPacketSize)", frameCount, morphHeaderLen+dataLen+padLen)
+		}
+		off += total
+		frameCount++
+	}
+	if frameCount != 3 {
+		t.Fatalf("on wire frame count = %d, want 3", frameCount)
+	}
+}
+
+func TestMorphedConn_WithShaper_Roundtrip(t *testing.T) {
+	profile := &TrafficProfile{Name: "T", PacketSizes: []int{100}, PacketSizeProbs: []float64{1}}
+	cliConn, srvConn := net.Pipe()
+	defer cliConn.Close()
+	defer srvConn.Close()
+
+	clientShaper := &mockShaper{nextSize: 0, fragmentInto: 2}
+	serverShaper := &mockShaper{nextSize: 0, fragmentInto: 1}
+
+	// Build manually to skip the handshake byte exchange that net.Pipe would
+	// stall on (synchronous unbuffered Write blocks until Read on the peer).
+	client := &MorphedConn{Conn: cliConn, profile: profile, shaper: clientShaper}
+	server := &MorphedConn{Conn: srvConn, profile: profile, shaper: serverShaper}
+
+	want := bytes.Repeat([]byte("XY"), 50)
+	done := make(chan error, 1)
+	go func() {
+		_, err := client.Write(want)
+		done <- err
+	}()
+
+	got := make([]byte, 0, len(want))
+	for len(got) < len(want) {
+		buf := make([]byte, 256)
+		n, err := server.Read(buf)
+		if err != nil {
+			t.Fatalf("server.Read: %v", err)
+		}
+		got = append(got, buf[:n]...)
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("client.Write: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("roundtrip mismatch: got %d bytes, want %d", len(got), len(want))
+	}
+}
+
+func TestShaperFromConfig(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		sh, err := ShaperFromConfig(nil)
+		if err != nil || sh == nil {
+			t.Fatalf("nil cfg -> sh=%v err=%v", sh, err)
+		}
+		if !isNoopShaper(sh) {
+			t.Fatalf("nil cfg should give NoopShaper, got %T", sh)
+		}
+	})
+	t.Run("empty", func(t *testing.T) {
+		sh, err := ShaperFromConfig(&toml.ShaperConfig{})
+		if err != nil || !isNoopShaper(sh) {
+			t.Fatalf("empty cfg -> sh=%T err=%v", sh, err)
+		}
+	})
+	t.Run("preset", func(t *testing.T) {
+		sh, err := ShaperFromConfig(&toml.ShaperConfig{Preset: "chrome_browsing"})
+		if err != nil {
+			t.Fatalf("preset cfg err: %v", err)
+		}
+		if sh == nil {
+			t.Fatalf("preset cfg returned nil shaper")
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Inject `shaper.Shaper` into `MorphedConn`; `NoopShaper` keeps Write/Read byte-identical to pre-shaper builds (backward compat with deployed servers).
- Non-Noop shapers drive fragmentation via `Wrap`, target frame size via `NextPacketSize(DirectionUp)`, inter-frame spacing via `NextDelay`. `Read` strips per-frame padding then routes through `Unwrap` so `NoopShaper` is identity and future dist-shapers can transform.
- Adds `ShaperFromConfig(*toml.ShaperConfig)` stub returning `NoopShaper`; preset/custom resolution lands with `internal/shaper/presets` (y37).
- Wire format (`morphHeaderLen=6`, `MRPH` magic, `tired-morph` ALPN), kTLS, ClientHello fragmentation untouched.

Refs: tiredvpn-oss-5wm, #6

## Test plan
- [x] `go build ./...` green.
- [x] `go test ./...` — 530 tests pass across 25 packages, including all pre-existing `internal/strategy` tests unchanged.
- [x] `golangci-lint run ./internal/strategy/...` — issue count for `morph.go` unchanged vs `main` (5 pre-existing); new files (`morph_shaper.go`, `morph_shaper_test.go`) introduce zero lint issues.
- [x] `TestMorphedConn_NoopShaper_BackwardCompat` asserts wire layout `[header:6][data:N][padding:M]` is bit-stable in Noop mode.
- [x] `TestMorphedConn_WithShaper_Wrap` asserts `Wrap` is called with the original payload and each emitted frame matches `NextPacketSize`.
- [x] `TestMorphedConn_WithShaper_Roundtrip` (`net.Pipe`) confirms client Wrap → server Unwrap reconstruct identical payload.
- [x] `TestShaperFromConfig` covers nil / empty / preset paths.