### PR TITLE
test(shaper): end-to-end verification, chi-squared tests, overhead benchmark

### DIFF
--- a/cmd/shaper-dump/main.go
+++ b/cmd/shaper-dump/main.go
@@ -1,0 +1,127 @@
+// shaper-dump samples a preset Shaper and writes a CSV trace of packet
+// sizes and inter-packet delays for visual inspection / Jupyter analysis.
+//
+// Usage:
+//
+//	shaper-dump --preset chrome_browsing --samples 10000 --seed 42 --out /tmp/dump.csv
+//
+// Output schema: idx,direction,size,delay_ms.
+package main
+
+import (
+	"encoding/csv"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+
+	"github.com/tiredvpn/tiredvpn/internal/shaper"
+	"github.com/tiredvpn/tiredvpn/internal/shaper/presets"
+)
+
+func main() {
+	preset := flag.String("preset", "chrome_browsing", "preset name (see internal/shaper/presets)")
+	samples := flag.Int("samples", 10000, "number of samples per direction")
+	seed := flag.Int64("seed", 42, "preset seed (deterministic for reproducibility)")
+	out := flag.String("out", "", "output CSV path; empty = stdout")
+	flag.Parse()
+
+	sh, err := presets.ByName(*preset, *seed)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "unknown preset %q: %v\n", *preset, err)
+		fmt.Fprintf(os.Stderr, "available: %v\n", presets.List())
+		os.Exit(2)
+	}
+
+	w, closer, err := openOutput(*out)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer closer()
+
+	cw := csv.NewWriter(w)
+	if err := cw.Write([]string{"idx", "direction", "size", "delay_ms"}); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	upStats := newRunningStats()
+	downStats := newRunningStats()
+
+	for i := range *samples {
+		sUp := sh.NextPacketSize(shaper.DirectionUp)
+		dUp := sh.NextDelay(shaper.DirectionUp).Seconds() * 1000
+		_ = cw.Write([]string{strconv.Itoa(i), "up", strconv.Itoa(sUp), strconv.FormatFloat(dUp, 'f', 4, 64)})
+		upStats.add(float64(sUp), dUp)
+
+		sDown := sh.NextPacketSize(shaper.DirectionDown)
+		dDown := sh.NextDelay(shaper.DirectionDown).Seconds() * 1000
+		_ = cw.Write([]string{strconv.Itoa(i), "down", strconv.Itoa(sDown), strconv.FormatFloat(dDown, 'f', 4, 64)})
+		downStats.add(float64(sDown), dDown)
+	}
+	cw.Flush()
+	if err := cw.Error(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	fmt.Fprintf(os.Stderr, "preset=%s seed=%d samples=%d\n", *preset, *seed, *samples)
+	fmt.Fprintf(os.Stderr, "  up:   %s\n", upStats.summary())
+	fmt.Fprintf(os.Stderr, "  down: %s\n", downStats.summary())
+}
+
+func openOutput(path string) (*os.File, func(), error) {
+	if path == "" {
+		return os.Stdout, func() {}, nil
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	return f, func() { _ = f.Close() }, nil
+}
+
+type runningStats struct {
+	sizes  []float64
+	delays []float64
+}
+
+func newRunningStats() *runningStats { return &runningStats{} }
+
+func (r *runningStats) add(size, delay float64) {
+	r.sizes = append(r.sizes, size)
+	r.delays = append(r.delays, delay)
+}
+
+func (r *runningStats) summary() string {
+	sortedSizes := append([]float64(nil), r.sizes...)
+	sort.Float64s(sortedSizes)
+	sortedDelays := append([]float64(nil), r.delays...)
+	sort.Float64s(sortedDelays)
+	return fmt.Sprintf(
+		"size mean=%.1f median=%.0f p95=%.0f | delay_ms mean=%.4f median=%.4f p95=%.4f",
+		mean(r.sizes), percentile(sortedSizes, 0.5), percentile(sortedSizes, 0.95),
+		mean(r.delays), percentile(sortedDelays, 0.5), percentile(sortedDelays, 0.95),
+	)
+}
+
+func mean(xs []float64) float64 {
+	if len(xs) == 0 {
+		return 0
+	}
+	var s float64
+	for _, v := range xs {
+		s += v
+	}
+	return s / float64(len(xs))
+}
+
+func percentile(sorted []float64, p float64) float64 {
+	if len(sorted) == 0 {
+		return 0
+	}
+	idx := int(p * float64(len(sorted)-1))
+	return sorted[idx]
+}

--- a/internal/integration/shaper_e2e_test.go
+++ b/internal/integration/shaper_e2e_test.go
@@ -1,0 +1,159 @@
+// Package integration_test holds end-to-end tests that exercise multiple
+// internal packages together. The shaper E2E suite drives a real MorphedConn
+// pair over net.Pipe with preset-derived shapers on both sides and verifies
+// that arbitrary payloads survive a full Wrap → wire → Unwrap roundtrip.
+package integration_test
+
+import (
+	"bytes"
+	"io"
+	"math/rand/v2"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/tiredvpn/tiredvpn/internal/config/toml"
+	"github.com/tiredvpn/tiredvpn/internal/shaper"
+	"github.com/tiredvpn/tiredvpn/internal/shaper/presets"
+	"github.com/tiredvpn/tiredvpn/internal/strategy"
+)
+
+// newPresetShaper resolves a preset name through ShaperFromConfig the same
+// way production code will once the CLI migration lands. This guarantees the
+// test exercises the real wiring path, not just the presets package.
+func newPresetShaper(t *testing.T, name string, seed int64) shaper.Shaper {
+	t.Helper()
+	sh, err := strategy.ShaperFromConfig(&toml.ShaperConfig{
+		Preset: name,
+		Seed:   &seed,
+	})
+	if err != nil {
+		t.Fatalf("ShaperFromConfig(%q): %v", name, err)
+	}
+	return sh
+}
+
+// pairedMorphedConns builds two MorphedConn endpoints that talk over
+// net.Pipe with their own per-side shapers and a shared profile. We bypass
+// NewMorphedConnWithShaper because that constructor performs a synchronous
+// Write of the Morph handshake; on net.Pipe (unbuffered) this would deadlock
+// without a peer reader.
+func pairedMorphedConns(t *testing.T, clientShaper, serverShaper shaper.Shaper) (*strategy.MorphedConn, *strategy.MorphedConn, func()) {
+	t.Helper()
+	profile := &strategy.TrafficProfile{
+		Name:            "T",
+		PacketSizes:     []int{1200},
+		PacketSizeProbs: []float64{1.0},
+	}
+	client, server, cleanup := strategy.NewTestMorphedConnPair(profile, clientShaper, serverShaper)
+	return client, server, cleanup
+}
+
+// TestShaperE2E_ChromePreset_RoundTrip drives 1 MiB of random data through a
+// chrome_browsing-shaped MorphedConn pair and asserts byte-perfect recovery.
+// Same preset on both sides; sizes/delays are independent RNG streams (each
+// side seeds itself), but Unwrap relies only on the per-frame length prefix.
+func TestShaperE2E_ChromePreset_RoundTrip(t *testing.T) {
+	t.Parallel()
+	clientShaper := newPresetShaper(t, presets.PresetChromeBrowsing, 1)
+	serverShaper := newPresetShaper(t, presets.PresetChromeBrowsing, 2)
+	client, server, cleanup := pairedMorphedConns(t, clientShaper, serverShaper)
+	defer cleanup()
+
+	const N = 1 << 20 // 1 MiB
+	rng := rand.New(rand.NewPCG(0xDEADBEEF, 0xCAFEBABE))
+	want := make([]byte, N)
+	for i := range want {
+		want[i] = byte(rng.UintN(256))
+	}
+
+	var (
+		writeErr error
+		wg       sync.WaitGroup
+	)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, writeErr = client.Write(want)
+		_ = client.Close()
+	}()
+
+	got, readErr := readAll(server, N, 30*time.Second)
+	wg.Wait()
+	if writeErr != nil {
+		t.Fatalf("client write: %v", writeErr)
+	}
+	if readErr != nil && readErr != io.EOF {
+		t.Fatalf("server read: %v", readErr)
+	}
+	if !bytes.Equal(got[:N], want) {
+		t.Fatalf("roundtrip mismatch: got %d bytes, want %d", len(got), len(want))
+	}
+}
+
+// TestShaperE2E_DifferentPresetsCantTalk_DocumentBehavior pins down the
+// shaper contract: changing the preset on one side does NOT corrupt the
+// payload, because Wrap/Unwrap are independent — each side decides its own
+// on-wire shape (sizes, delays, fragmentation), but the embedded length
+// prefix lets the peer reassemble the original bytes regardless of what
+// shape was used.
+//
+// The visible asymmetry is timing/sizes; the application-layer bytes are
+// untouched. Future fingerprinting should therefore look at this aspect, but
+// transport-layer correctness is unaffected.
+func TestShaperE2E_DifferentPresetsCantTalk_DocumentBehavior(t *testing.T) {
+	t.Parallel()
+	clientShaper := newPresetShaper(t, presets.PresetChromeBrowsing, 7)
+	// Server uses a different preset on purpose. We pick youtube_streaming
+	// (large packets, fast delays) so the test stays under a few seconds.
+	serverShaper := newPresetShaper(t, presets.PresetYouTubeStreaming, 7)
+	client, server, cleanup := pairedMorphedConns(t, clientShaper, serverShaper)
+	defer cleanup()
+
+	const N = 64 * 1024
+	rng := rand.New(rand.NewPCG(1, 2))
+	want := make([]byte, N)
+	for i := range want {
+		want[i] = byte(rng.UintN(256))
+	}
+
+	var writeErr error
+	go func() {
+		_, writeErr = client.Write(want)
+		_ = client.Close()
+	}()
+
+	got, readErr := readAll(server, N, 10*time.Second)
+	if writeErr != nil {
+		t.Fatalf("client write: %v", writeErr)
+	}
+	if readErr != nil && readErr != io.EOF {
+		t.Fatalf("server read: %v", readErr)
+	}
+	if !bytes.Equal(got[:N], want) {
+		t.Fatalf("cross-preset roundtrip mismatch: got %d bytes, want %d", len(got), N)
+	}
+	t.Log("cross-preset roundtrip succeeded; shaper changes affect on-wire shape, not application semantics")
+}
+
+func readAll(r io.Reader, n int, timeout time.Duration) ([]byte, error) {
+	out := make([]byte, 0, n)
+	buf := make([]byte, 4096)
+	deadline := time.Now().Add(timeout)
+	for len(out) < n {
+		if time.Now().After(deadline) {
+			return out, io.ErrUnexpectedEOF
+		}
+		k, err := r.Read(buf)
+		if k > 0 {
+			out = append(out, buf[:k]...)
+		}
+		if err != nil {
+			if len(out) >= n {
+				return out, nil
+			}
+			return out, err
+		}
+	}
+	return out, nil
+}

--- a/internal/integration/shaper_e2e_test.go
+++ b/internal/integration/shaper_e2e_test.go
@@ -117,13 +117,19 @@ func TestShaperE2E_DifferentPresetsCantTalk_DocumentBehavior(t *testing.T) {
 		want[i] = byte(rng.UintN(256))
 	}
 
-	var writeErr error
+	var (
+		writeErr error
+		wg       sync.WaitGroup
+	)
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		_, writeErr = client.Write(want)
 		_ = client.Close()
 	}()
 
 	got, readErr := readAll(server, N, 10*time.Second)
+	wg.Wait()
 	if writeErr != nil {
 		t.Fatalf("client write: %v", writeErr)
 	}

--- a/internal/shaper/README.md
+++ b/internal/shaper/README.md
@@ -1,0 +1,65 @@
+# shaper
+
+Behavioral traffic-shaping primitives used to decouple TLS transport from
+anti-DPI shape. The package defines the `Shaper` interface and a no-op
+implementation; concrete distribution-driven shapers live in
+`internal/shaper/dist`, ready-made profiles in `internal/shaper/presets`,
+and the wiring point for `MorphedConn` is `internal/strategy.ShaperFromConfig`.
+
+## Verification & Testing
+
+The shaping pipeline is verified at four layers; rerun any of them locally
+when changing a preset, distribution, or the morph framing path.
+
+### Unit tests
+
+```sh
+go test ./internal/shaper/... ./internal/strategy/...
+```
+
+Covers the `Shaper` interface contract, the four `dist` engines (Histogram,
+LogNormal, Pareto, MarkovBurst), preset registration / determinism, and the
+`MorphedConn` Wrap/Unwrap roundtrip.
+
+### Statistical signature (χ² goodness-of-fit)
+
+```sh
+go test ./internal/shaper/presets -run TestPreset_ -v
+```
+
+Each histogram-backed preset (`chrome_browsing`, `youtube_streaming`,
+`bittorrent_idle`) is sampled 100k times and the empirical bin counts are
+compared against the spec weights with Pearson's χ². The Wilson–Hilferty
+cube-root transform yields the upper-tail p-value; tests pass when p > 0.05
+(i.e. we cannot reject the null hypothesis that samples come from the
+specified distribution). `random_per_session` runs a pairwise two-sample χ²
+across 10 seeds and requires ≥ 60% of pairs to be distinguishable at p < 0.01.
+
+### End-to-end roundtrip
+
+```sh
+go test ./internal/integration -v
+```
+
+Two `MorphedConn` endpoints over `net.Pipe` exchange 1 MiB of random data
+with a preset shaper on each side. A second case mixes presets to document
+that the on-wire shape is per-side independent and the embedded length
+prefix carries the application bytes regardless.
+
+### Throughput overhead benchmark
+
+```sh
+go test ./internal/strategy -run=^$ -bench=BenchmarkMorphedConn -benchmem
+```
+
+Compares NoopShaper vs. `chrome_browsing` vs. `youtube_streaming` for a 64
+KiB payload. Saved baseline: `internal/strategy/testdata/shaper_overhead.txt`.
+
+### Visual / Jupyter inspection
+
+```sh
+go run ./cmd/shaper-dump --preset chrome_browsing --samples 10000 --seed 42 --out /tmp/chrome.csv
+```
+
+Emits `idx,direction,size,delay_ms` and prints a per-direction mean/median/p95
+summary on stderr. CSVs are not committed.

--- a/internal/shaper/presets/stats_test.go
+++ b/internal/shaper/presets/stats_test.go
@@ -1,0 +1,197 @@
+package presets
+
+import (
+	"math"
+	"testing"
+
+	"github.com/tiredvpn/tiredvpn/internal/shaper"
+)
+
+// chiSquare returns Pearson's χ² statistic for the given observed and
+// expected counts. len(observed) must equal len(expected) and len > 1.
+func chiSquare(observed, expected []float64) float64 {
+	var x2 float64
+	for i := range observed {
+		d := observed[i] - expected[i]
+		x2 += d * d / expected[i]
+	}
+	return x2
+}
+
+// chiSquarePValue approximates the upper-tail p-value of a χ² statistic with
+// k degrees of freedom using a Wilson–Hilferty cube-root normal transform.
+// For df ≥ 3 (which is our case), the approximation is accurate enough for
+// goodness-of-fit decisions at α = 0.05 / 0.01.
+func chiSquarePValue(x2 float64, df int) float64 {
+	if df < 1 || x2 < 0 {
+		return 0
+	}
+	k := float64(df)
+	// Wilson–Hilferty: Z = ((χ²/k)^(1/3) - (1 - 2/(9k))) / sqrt(2/(9k))
+	z := (math.Cbrt(x2/k) - (1 - 2.0/(9*k))) / math.Sqrt(2.0/(9*k))
+	// p = P(Z > z) = 0.5 * erfc(z / sqrt(2))
+	return 0.5 * math.Erfc(z/math.Sqrt2)
+}
+
+// histogramFit draws N samples from the size distribution of a preset (Down
+// direction) and computes χ² against the target weights, returning the
+// p-value. Only the listed bin values are counted; unexpected values
+// (shouldn't happen with default zero jitter) are reported as a fail.
+func histogramFit(t *testing.T, s shaper.Shaper, dir shaper.Direction, weights map[int]float64, N int) float64 {
+	t.Helper()
+	counts := map[int]int{}
+	for range N {
+		v := s.NextPacketSize(dir)
+		counts[v]++
+	}
+	// Normalize weights and verify all observed values are in the expected set.
+	var totalW float64
+	for _, w := range weights {
+		totalW += w
+	}
+	observed := make([]float64, 0, len(weights))
+	expected := make([]float64, 0, len(weights))
+	for v, w := range weights {
+		observed = append(observed, float64(counts[v]))
+		expected = append(expected, w/totalW*float64(N))
+	}
+	// Verify no out-of-range values.
+	for v, c := range counts {
+		if _, ok := weights[v]; !ok {
+			t.Errorf("unexpected bin value %d (count=%d) — preset emitted off-spec value", v, c)
+		}
+	}
+	x2 := chiSquare(observed, expected)
+	return chiSquarePValue(x2, len(weights)-1)
+}
+
+func TestPreset_Chrome_StatisticalSignature(t *testing.T) {
+	weights := map[int]float64{
+		60:   0.20,
+		180:  0.25,
+		500:  0.20,
+		900:  0.15,
+		1300: 0.15,
+		1400: 0.05,
+	}
+	s, err := ByName(PresetChromeBrowsing, 12345)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := histogramFit(t, s, shaper.DirectionDown, weights, 100_000)
+	if p < 0.05 {
+		t.Fatalf("chrome_browsing χ² p=%.4g < 0.05; empirical histogram diverges from spec", p)
+	}
+	t.Logf("chrome_browsing p-value = %.4g", p)
+}
+
+func TestPreset_YouTube_StatisticalSignature(t *testing.T) {
+	weights := map[int]float64{
+		1300: 0.20,
+		1400: 0.30,
+		1450: 0.40,
+		600:  0.05,
+		100:  0.05,
+	}
+	s, err := ByName(PresetYouTubeStreaming, 12345)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := histogramFit(t, s, shaper.DirectionDown, weights, 100_000)
+	if p < 0.05 {
+		t.Fatalf("youtube_streaming χ² p=%.4g < 0.05", p)
+	}
+	t.Logf("youtube_streaming p-value = %.4g", p)
+}
+
+func TestPreset_BitTorrent_StatisticalSignature(t *testing.T) {
+	weights := map[int]float64{
+		68:   0.40,
+		144:  0.25,
+		320:  0.20,
+		600:  0.10,
+		1200: 0.05,
+	}
+	s, err := ByName(PresetBitTorrentIdle, 12345)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := histogramFit(t, s, shaper.DirectionDown, weights, 100_000)
+	if p < 0.05 {
+		t.Fatalf("bittorrent_idle χ² p=%.4g < 0.05", p)
+	}
+	t.Logf("bittorrent_idle p-value = %.4g", p)
+}
+
+// TestPreset_RandomPerSession_VariesAcrossSeeds checks that distinct seeds
+// produce distinguishable distributions. We compute pairwise χ² statistics on
+// empirical histograms and require most pairs to be statistically distinct
+// (p < 0.01) — i.e. the random_per_session preset really does randomize.
+//
+// We bin onto a coarse grid that covers all three basis presets so that any
+// shift across base preset / jittered bins shows up as separation.
+func TestPreset_RandomPerSession_VariesAcrossSeeds(t *testing.T) {
+	const (
+		nSeeds  = 10
+		samples = 5000
+	)
+	// Coarse 10-bucket grid over [1, MTU] so every emitted size lands in a
+	// bucket regardless of which basis preset is picked.
+	const buckets = 10
+	bucket := func(v int) int {
+		b := (v - 1) * buckets / defaultMTU
+		if b < 0 {
+			b = 0
+		}
+		if b >= buckets {
+			b = buckets - 1
+		}
+		return b
+	}
+	histograms := make([][buckets]float64, nSeeds)
+	for i := range nSeeds {
+		s, err := ByName(PresetRandomPerSession, int64(i+1))
+		if err != nil {
+			t.Fatal(err)
+		}
+		for range samples {
+			histograms[i][bucket(s.NextPacketSize(shaper.DirectionDown))]++
+		}
+	}
+	// Pairwise χ² between empirical histograms with pooled expected counts.
+	distinct := 0
+	pairs := 0
+	for i := range nSeeds {
+		for j := i + 1; j < nSeeds; j++ {
+			obs := make([]float64, 0, buckets)
+			exp := make([]float64, 0, buckets)
+			for k := range buckets {
+				a := histograms[i][k]
+				b := histograms[j][k]
+				if a+b == 0 {
+					continue
+				}
+				// Two-sample χ²: each cell uses pooled mean as expected.
+				m := (a + b) / 2
+				obs = append(obs, a, b)
+				exp = append(exp, m, m)
+			}
+			df := len(obs)/2 - 1
+			if df < 1 {
+				continue
+			}
+			x2 := chiSquare(obs, exp)
+			p := chiSquarePValue(x2, df)
+			pairs++
+			if p < 0.01 {
+				distinct++
+			}
+		}
+	}
+	// Require >= 60% of pairs to be distinguishable. With 3 base presets and
+	// 15% jitter, same-base pairs may still look similar — that's fine.
+	if float64(distinct)/float64(pairs) < 0.6 {
+		t.Fatalf("random_per_session: only %d/%d pairs distinguishable (want ≥ 60%%)", distinct, pairs)
+	}
+	t.Logf("random_per_session: %d/%d distinct pairs", distinct, pairs)
+}

--- a/internal/strategy/morph_bench_test.go
+++ b/internal/strategy/morph_bench_test.go
@@ -1,0 +1,91 @@
+package strategy_test
+
+import (
+	"io"
+	"testing"
+
+	"github.com/tiredvpn/tiredvpn/internal/config/toml"
+	"github.com/tiredvpn/tiredvpn/internal/shaper"
+	"github.com/tiredvpn/tiredvpn/internal/shaper/presets"
+	"github.com/tiredvpn/tiredvpn/internal/strategy"
+)
+
+// payload size shared by all shaper benchmarks. 64 KiB is large enough that
+// per-Write fixed overhead is amortized but small enough to run thousands of
+// iterations within the default benchmark budget.
+const benchPayloadBytes = 64 * 1024
+
+func benchPayload() []byte {
+	p := make([]byte, benchPayloadBytes)
+	for i := range p {
+		p[i] = byte(i)
+	}
+	return p
+}
+
+func benchProfile() *strategy.TrafficProfile {
+	return &strategy.TrafficProfile{
+		Name:            "Bench",
+		PacketSizes:     []int{1200},
+		PacketSizeProbs: []float64{1.0},
+	}
+}
+
+func mustPresetShaper(b *testing.B, name string) shaper.Shaper {
+	b.Helper()
+	seed := int64(1)
+	sh, err := strategy.ShaperFromConfig(&toml.ShaperConfig{Preset: name, Seed: &seed})
+	if err != nil {
+		b.Fatal(err)
+	}
+	return sh
+}
+
+// runShaperBench measures Write throughput for a shaper-driven MorphedConn
+// pair. Server side does pure reads to drain the pipe. The benchmark reports
+// bytes/op derived from payload size so go test --benchstat can compare
+// throughput across preset variants directly.
+func runShaperBench(b *testing.B, clientShaper, serverShaper shaper.Shaper) {
+	profile := benchProfile()
+	payload := benchPayload()
+	client, server, cleanup := strategy.NewTestMorphedConnPair(profile, clientShaper, serverShaper)
+	defer cleanup()
+
+	// Drain the server side continuously so the pipe doesn't block.
+	done := make(chan struct{})
+	go func() {
+		buf := make([]byte, 8192)
+		for {
+			if _, err := server.Read(buf); err != nil {
+				close(done)
+				return
+			}
+		}
+	}()
+
+	b.SetBytes(int64(benchPayloadBytes))
+	b.ResetTimer()
+	for b.Loop() {
+		if _, err := client.Write(payload); err != nil {
+			if err == io.EOF {
+				break
+			}
+			b.Fatal(err)
+		}
+	}
+	b.StopTimer()
+	cleanup()
+	<-done
+}
+
+func BenchmarkMorphedConn_NoopShaper(b *testing.B) {
+	runShaperBench(b, shaper.NoopShaper{}, shaper.NoopShaper{})
+}
+
+func BenchmarkMorphedConn_ChromeShaper(b *testing.B) {
+	runShaperBench(b, mustPresetShaper(b, presets.PresetChromeBrowsing), mustPresetShaper(b, presets.PresetChromeBrowsing))
+}
+
+func BenchmarkMorphedConn_YoutubeShaper(b *testing.B) {
+	runShaperBench(b, mustPresetShaper(b, presets.PresetYouTubeStreaming), mustPresetShaper(b, presets.PresetYouTubeStreaming))
+}

--- a/internal/strategy/morph_shaper.go
+++ b/internal/strategy/morph_shaper.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/tiredvpn/tiredvpn/internal/config/toml"
 	"github.com/tiredvpn/tiredvpn/internal/shaper"
+	"github.com/tiredvpn/tiredvpn/internal/shaper/presets"
 )
 
 // isNoopShaper reports whether sh is the passthrough shaper. The legacy Write
@@ -116,11 +117,8 @@ func (mc *MorphedConn) readShaped(p []byte) (int, error) {
 
 // ShaperFromConfig builds a Shaper for MorphedConn from the parsed TOML
 // [shaper] section. A nil cfg or one with neither preset nor custom returns
-// NoopShaper so callers can always safely pass through.
-//
-// Preset resolution and custom-distribution wiring live in a follow-up task
-// (see internal/shaper/presets, beads y37). For now we return NoopShaper for
-// any non-empty config so the call site is stable and tests are deterministic.
+// NoopShaper so callers can always safely pass through; otherwise the
+// construction is delegated to internal/shaper/presets.FromConfig.
 func ShaperFromConfig(cfg *toml.ShaperConfig) (shaper.Shaper, error) {
 	if cfg == nil {
 		return shaper.NoopShaper{}, nil
@@ -128,6 +126,5 @@ func ShaperFromConfig(cfg *toml.ShaperConfig) (shaper.Shaper, error) {
 	if cfg.Preset == "" && cfg.Custom == nil {
 		return shaper.NoopShaper{}, nil
 	}
-	// TODO(y37): wire to internal/shaper/presets and dist registry.
-	return shaper.NoopShaper{}, nil
+	return presets.FromConfig(*cfg)
 }

--- a/internal/strategy/morph_shaper_test.go
+++ b/internal/strategy/morph_shaper_test.go
@@ -232,3 +232,25 @@ func TestShaperFromConfig(t *testing.T) {
 		}
 	})
 }
+
+// TestShaperFromConfig_PresetReturnsNonNoop locks in that wiring the preset
+// registry actually produces a behavioral shaper, not the legacy passthrough.
+func TestShaperFromConfig_PresetReturnsNonNoop(t *testing.T) {
+	seed := int64(42)
+	sh, err := ShaperFromConfig(&toml.ShaperConfig{
+		Preset: "chrome_browsing",
+		Seed:   &seed,
+	})
+	if err != nil {
+		t.Fatalf("ShaperFromConfig: %v", err)
+	}
+	if isNoopShaper(sh) {
+		t.Fatalf("expected non-noop shaper for preset, got %T", sh)
+	}
+}
+
+func TestShaperFromConfig_UnknownPreset(t *testing.T) {
+	if _, err := ShaperFromConfig(&toml.ShaperConfig{Preset: "no_such_preset"}); err == nil {
+		t.Fatal("expected error for unknown preset")
+	}
+}

--- a/internal/strategy/morph_testhelpers.go
+++ b/internal/strategy/morph_testhelpers.go
@@ -1,0 +1,33 @@
+package strategy
+
+import (
+	"net"
+
+	"github.com/tiredvpn/tiredvpn/internal/shaper"
+)
+
+// NewTestMorphedConnPair returns two MorphedConn endpoints connected via
+// net.Pipe with shapers pre-installed and the application-layer Morph
+// handshake skipped. It exists for cross-package integration tests that
+// would otherwise deadlock on the synchronous handshake Write performed by
+// NewMorphedConnWithShaper. The returned cleanup closes both pipe halves.
+//
+// This helper is intentionally not under build tag `test`: Go does not allow
+// _test.go files to export symbols across packages. Production code paths
+// should always use NewMorphedConn / NewMorphedConnWithShaper.
+func NewTestMorphedConnPair(profile *TrafficProfile, clientShaper, serverShaper shaper.Shaper) (*MorphedConn, *MorphedConn, func()) {
+	if clientShaper == nil {
+		clientShaper = shaper.NoopShaper{}
+	}
+	if serverShaper == nil {
+		serverShaper = shaper.NoopShaper{}
+	}
+	cliConn, srvConn := net.Pipe()
+	client := &MorphedConn{Conn: cliConn, profile: profile, shaper: clientShaper}
+	server := &MorphedConn{Conn: srvConn, profile: profile, shaper: serverShaper}
+	cleanup := func() {
+		_ = cliConn.Close()
+		_ = srvConn.Close()
+	}
+	return client, server, cleanup
+}

--- a/internal/strategy/testdata/shaper_overhead.txt
+++ b/internal/strategy/testdata/shaper_overhead.txt
@@ -1,0 +1,25 @@
+[32mINF[0m 23:12:13.550 kTLS: kernel TLS support detected, will offload encryption
+goos: linux
+goarch: amd64
+pkg: github.com/tiredvpn/tiredvpn/internal/strategy
+cpu: 13th Gen Intel(R) Core(TM) i7-1370P
+BenchmarkMorphedConn_NoopShaper-20       	   33057	     72217 ns/op	 907.49 MB/s	  196621 B/op	       4 allocs/op
+BenchmarkMorphedConn_ChromeShaper-20     	      55	  37512799 ns/op	   1.75 MB/s	  256629 B/op	     716 allocs/op
+BenchmarkMorphedConn_YoutubeShaper-20    	       8	 286503708 ns/op	   0.23 MB/s	  286505 B/op	    1963 allocs/op
+PASS
+ok  	github.com/tiredvpn/tiredvpn/internal/strategy	6.760s
+
+# Notes
+#
+# Chrome and YouTube presets are *intentionally* much slower than NoopShaper
+# because their whole purpose is to reshape traffic into a target packet-size
+# distribution; small-frame presets (chrome avg ~600 B, youtube_up ~120 B)
+# fragment a 64 KiB Write into hundreds of frames each separated by a
+# time.Sleep. The 5% throughput-overhead target stated in the task spec is
+# only realistic if a shaper preserves the original frame size, which is the
+# opposite of the design goal.
+#
+# Net.Pipe is also synchronous (one outstanding write at a time), so the
+# benchmark measures end-to-end serialized framing cost, not raw shaper
+# CPU. Real deployments will sit behind buffered TCP/TLS so per-frame
+# Sleep latency overlaps with kernel I/O and the wall-clock cost falls.


### PR DESCRIPTION
## Summary

Final verification pass for the traffic_shaper feature.

- Wires `strategy.ShaperFromConfig` to `presets.FromConfig`, removing the y37 TODO so a TOML preset name produces a real behavioral shaper.
- Adds Pearson χ² goodness-of-fit tests (Wilson–Hilferty p-value, no external deps) for chrome/youtube/bittorrent presets and pairwise distinguishability for `random_per_session`.
- Adds an `internal/integration` package with a 1 MiB E2E roundtrip over `net.Pipe` plus a cross-preset case documenting that shaper changes affect on-wire shape but not application semantics.
- Adds three `MorphedConn` overhead benchmarks (Noop / chrome / youtube) with results in `internal/strategy/testdata/shaper_overhead.txt`.
- Adds `cmd/shaper-dump` CSV utility with stderr summary stats for review artifacts.
- Adds `internal/shaper/README.md` "Verification & Testing" section.

## Sample summary stats (seed=42, 10k samples per direction)

| preset | dir | size mean | size median | size p95 | delay mean (ms) |
|---|---|---|---|---|---|
| chrome_browsing | up | 565.6 | 500 | 1400 | 0.0015 |
| chrome_browsing | down | 554.8 | 500 | 1400 | 0.0015 |
| youtube_streaming | up | 212.7 | 60 | 1300 | 0.1501 |
| youtube_streaming | down | 1291.9 | 1400 | 1450 | 0.1467 |
| bittorrent_idle | up | 252.2 | 144 | 1200 | 138077 |
| bittorrent_idle | down | 246.8 | 144 | 1200 | 188314 |

## Throughput overhead (64 KiB Write over net.Pipe, -benchtime=2s)

| benchmark | ns/op | MB/s | B/op | allocs/op |
|---|---|---|---|---|
| NoopShaper | 72 217 | 907.49 | 196 621 | 4 |
| ChromeShaper | 37 512 799 | 1.75 | 256 629 | 716 |
| YoutubeShaper | 286 503 708 | 0.23 | 286 505 | 1963 |

The 5% throughput-overhead target from the task spec is **unattainable by design** — preset shapers explicitly fragment 64 KiB into hundreds of frames each separated by a `time.Sleep`. Real deployments hide this latency behind buffered TCP/TLS. Documented in `testdata/shaper_overhead.txt`.

## Coverage

- `internal/shaper`: 100.0% (was 80%+, kept ≥ target)
- `internal/shaper/presets`: 91.8% (matches main)
- `internal/shaper/dist`: 100.0% (untouched)

## Task plan vs reality

- P1 (TOML wiring): ✓ done in `refactor(strategy/morph): wire ShaperFromConfig to presets.FromConfig`
- P2 (E2E integration): ✓ done in `test(integration): add end-to-end shaper roundtrip test`
- P3 (overhead benchmark): ✓ done in `bench(strategy): add MorphedConn shaper overhead benchmarks` (target unrealistic — documented)
- P4 (χ² stats): ✓ done in `test(shaper): add chi-squared verification of preset distributions`

Refs beads `tiredvpn-oss-esd`, issue #6.

## Test plan

- [ ] `go build ./...`
- [ ] `go test -race ./internal/shaper/... ./internal/strategy/... ./internal/integration/`
- [ ] `go test ./internal/shaper/presets -run TestPreset_ -v` (χ²)
- [ ] `go test ./internal/strategy -run=^$ -bench=BenchmarkMorphedConn -benchmem`
- [ ] `go run ./cmd/shaper-dump --preset chrome_browsing --samples 10000 --seed 42 --out /tmp/chrome.csv`