### PR TITLE
feat(shaper/presets): add DataPlaneSafe gating (refs #18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to TiredVPN are documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versions follow [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Breaking
+
+- Shaper preset `bittorrent_idle` is no longer accepted in data-plane configs (`shaper.preset = "bittorrent_idle"` returns `ErrPresetNotDataPlaneSafe`). Its ~7 s median inter-arrival is suitable for cover-traffic generation only; cover-traffic emitters must call `presets.ByNameAllowAny`. `random_per_session` now picks only from data-plane-safe basis presets.
+
+### Added
+
+- `presets.IsDataPlaneSafe(name)` accessor and `DataPlaneSafe` flag on every registered preset.
+- `presets.ByNameAllowAny` entry point for cover-traffic callers that need access to non-data-plane presets.
+
 ## [1.0.3] - 2026-04-09
 
 ### Added

--- a/cmd/shaper-dump/main.go
+++ b/cmd/shaper-dump/main.go
@@ -27,7 +27,9 @@ func main() {
 	out := flag.String("out", "", "output CSV path; empty = stdout")
 	flag.Parse()
 
-	sh, err := presets.ByName(*preset, *seed)
+	// Inspection tool — allow any preset so cover-traffic profiles can be
+	// dumped for analysis, not just data-plane-safe ones.
+	sh, err := presets.ByNameAllowAny(*preset, *seed)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "unknown preset %q: %v\n", *preset, err)
 		fmt.Fprintf(os.Stderr, "available: %v\n", presets.List())

--- a/internal/shaper/README.md
+++ b/internal/shaper/README.md
@@ -6,6 +6,30 @@ implementation; concrete distribution-driven shapers live in
 `internal/shaper/dist`, ready-made profiles in `internal/shaper/presets`,
 and the wiring point for `MorphedConn` is `internal/strategy.ShaperFromConfig`.
 
+## Data-plane vs cover-traffic presets
+
+Each preset carries a `DataPlaneSafe` metadata flag that splits profiles
+into two categories:
+
+| Preset               | DataPlaneSafe | Median delay | Intended use                  |
+|----------------------|---------------|--------------|-------------------------------|
+| `chrome_browsing`    | yes           | ~0.9 ms      | data plane (HTTPS browsing)   |
+| `youtube_streaming`  | yes           | sub-second   | data plane (HD video)         |
+| `random_per_session` | yes           | sub-second   | data plane (rotates basis)    |
+| `bittorrent_idle`    | no            | ~7 s         | cover traffic only            |
+
+The data-plane entry points — `presets.FromConfig` (used by TOML config) and
+`presets.ByName` — refuse non-safe presets and return
+`ErrPresetNotDataPlaneSafe`. Putting `bittorrent_idle` into a tunnel would
+collapse throughput, since its inter-arrival distribution is built around
+multi-second gaps that are realistic for a stalled BT swarm participant but
+catastrophic for user payload.
+
+Cover-traffic emitters that intentionally need long idle gaps must call
+`presets.ByNameAllowAny` and assume responsibility for the schedule. Custom
+TOML shapers (`shaper.custom = ...`) are not gated — operators take
+responsibility for parameters they author.
+
 ## Verification & Testing
 
 The shaping pipeline is verified at four layers; rerun any of them locally

--- a/internal/shaper/presets/bittorrent_idle.go
+++ b/internal/shaper/presets/bittorrent_idle.go
@@ -26,7 +26,10 @@ const PresetBitTorrentIdle = "bittorrent_idle"
 // Inter-arrival: LogNormal(mu=2, sigma=2.5) → median ~7 s, with tail to
 // minutes — matching observed idle-swarm telemetry.
 func init() {
-	register(PresetBitTorrentIdle, buildBitTorrentIdle)
+	// DataPlaneSafe=false: median delay ~7 s — cover-traffic only. Building
+	// for the data plane would collapse throughput; callers that need this
+	// preset for cover-traffic must use ByNameAllowAny.
+	register(PresetBitTorrentIdle, false, buildBitTorrentIdle)
 }
 
 func buildBitTorrentIdle(seed int64) (shaper.Shaper, error) {

--- a/internal/shaper/presets/chrome_browsing.go
+++ b/internal/shaper/presets/chrome_browsing.go
@@ -29,7 +29,7 @@ const PresetChromeBrowsing = "chrome_browsing"
 //
 // No burst engine — browsing is request/response, not steady-state.
 func init() {
-	register(PresetChromeBrowsing, buildChromeBrowsing)
+	register(PresetChromeBrowsing, true, buildChromeBrowsing)
 }
 
 func buildChromeBrowsing(seed int64) (shaper.Shaper, error) {

--- a/internal/shaper/presets/presets.go
+++ b/internal/shaper/presets/presets.go
@@ -6,6 +6,12 @@
 // driven by a single seed, so that two Shapers built with the same name and
 // seed reproduce the same packet/delay sequence — a property exercised by
 // tests and required by the Hybrid handshake design (see ADR shaper-handshake).
+//
+// Presets carry a DataPlaneSafe flag distinguishing profiles fit for the VPN
+// data plane (sub-second delays, bounded fragmentation) from cover-traffic
+// generators that intentionally idle for seconds. Data-plane entry points
+// (FromConfig, ByName) reject unsafe presets; cover-traffic callers must use
+// ByNameAllowAny explicitly.
 package presets
 
 import (
@@ -20,32 +26,72 @@ import (
 	"github.com/tiredvpn/tiredvpn/internal/shaper/dist"
 )
 
-// ErrUnknownPreset is returned by ByName when the requested preset is not
-// registered.
+// ErrUnknownPreset is returned when the requested preset is not registered.
 var ErrUnknownPreset = errors.New("presets: unknown preset")
+
+// ErrPresetNotDataPlaneSafe is returned by FromConfig and ByName when the
+// requested preset is a cover-traffic profile (e.g. multi-second idle gaps)
+// and therefore unsuitable for tunneling user payload. Cover-traffic emitters
+// must call ByNameAllowAny explicitly.
+var ErrPresetNotDataPlaneSafe = errors.New("presets: preset is not safe for data plane")
 
 // presetBuilder is the constructor signature every preset file registers.
 type presetBuilder func(seed int64) (shaper.Shaper, error)
 
-// registry holds all built-in presets. It is populated by init() in each
-// preset file so that adding a new preset is a single-file change.
-var registry = map[string]presetBuilder{}
+// presetMeta carries both the constructor and metadata used by gating logic.
+// DataPlaneSafe == true means delays are bounded enough (sub-second median)
+// that the preset can carry user traffic without throughput collapse.
+type presetMeta struct {
+	Name          string
+	DataPlaneSafe bool
+	Build         presetBuilder
+}
 
-func register(name string, b presetBuilder) {
+// registry holds all built-in presets. Populated by init() in each preset
+// file so that adding a new preset is a single-file change.
+var registry = map[string]presetMeta{}
+
+func register(name string, dataPlaneSafe bool, b presetBuilder) {
 	if _, exists := registry[name]; exists {
 		panic(fmt.Sprintf("presets: duplicate registration for %q", name))
 	}
-	registry[name] = b
+	registry[name] = presetMeta{Name: name, DataPlaneSafe: dataPlaneSafe, Build: b}
 }
 
-// ByName returns a Shaper configured for the named preset.
-// Returns ErrUnknownPreset if name is not registered.
+// IsDataPlaneSafe reports whether the named preset is suitable for the VPN
+// data plane (sub-second delays, bounded fragmentation). Returns
+// ErrUnknownPreset for unknown names.
+func IsDataPlaneSafe(name string) (bool, error) {
+	m, ok := registry[name]
+	if !ok {
+		return false, fmt.Errorf("%w: %q", ErrUnknownPreset, name)
+	}
+	return m.DataPlaneSafe, nil
+}
+
+// ByName returns a Shaper configured for the named preset. It rejects presets
+// flagged as not data-plane-safe with ErrPresetNotDataPlaneSafe — use
+// ByNameAllowAny for cover-traffic generation.
 func ByName(name string, seed int64) (shaper.Shaper, error) {
-	b, ok := registry[name]
+	m, ok := registry[name]
 	if !ok {
 		return nil, fmt.Errorf("%w: %q", ErrUnknownPreset, name)
 	}
-	return b(seed)
+	if !m.DataPlaneSafe {
+		return nil, fmt.Errorf("%w: %q", ErrPresetNotDataPlaneSafe, name)
+	}
+	return m.Build(seed)
+}
+
+// ByNameAllowAny is like ByName but does not enforce DataPlaneSafe. Use only
+// for cover-traffic generation, never for data tunneling. Returns
+// ErrUnknownPreset for unknown names.
+func ByNameAllowAny(name string, seed int64) (shaper.Shaper, error) {
+	m, ok := registry[name]
+	if !ok {
+		return nil, fmt.Errorf("%w: %q", ErrUnknownPreset, name)
+	}
+	return m.Build(seed)
 }
 
 // List returns all available preset names in deterministic (sorted) order.
@@ -61,7 +107,8 @@ func List() []string {
 // FromConfig builds a Shaper from a parsed TOML [shaper] section. Either
 // cfg.Preset or cfg.Custom must be set, not both. cfg.RandomizationRange is
 // applied to histogram bins where supported. cfg.Seed, when nil, is replaced
-// by a freshly drawn cryptographic seed.
+// by a freshly drawn cryptographic seed. Non-data-plane-safe presets are
+// rejected here so that misconfiguration cannot collapse tunnel throughput.
 func FromConfig(cfg toml.ShaperConfig) (shaper.Shaper, error) {
 	if cfg.Preset != "" && cfg.Custom != nil {
 		return nil, errors.New("presets: preset and custom are mutually exclusive")
@@ -73,6 +120,8 @@ func FromConfig(cfg toml.ShaperConfig) (shaper.Shaper, error) {
 	seed := resolveSeed(cfg.Seed)
 
 	if cfg.Preset != "" {
+		// ByName already enforces DataPlaneSafe; relying on it keeps the gate
+		// in a single place.
 		s, err := ByName(cfg.Preset, seed)
 		if err != nil {
 			return nil, err

--- a/internal/shaper/presets/presets_test.go
+++ b/internal/shaper/presets/presets_test.go
@@ -44,11 +44,11 @@ func TestByName_Unknown(t *testing.T) {
 func TestByName_AllPresets_Determinism(t *testing.T) {
 	for _, name := range List() {
 		t.Run(name, func(t *testing.T) {
-			a, err := ByName(name, 42)
+			a, err := ByNameAllowAny(name, 42)
 			if err != nil {
 				t.Fatal(err)
 			}
-			b, err := ByName(name, 42)
+			b, err := ByNameAllowAny(name, 42)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -241,7 +241,7 @@ func TestDistShaper_NextPacketSize_RespectsMTU(t *testing.T) {
 		PresetChromeBrowsing, PresetYouTubeStreaming,
 		PresetBitTorrentIdle, PresetRandomPerSession,
 	} {
-		s, err := ByName(name, 5)
+		s, err := ByNameAllowAny(name, 5)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -256,7 +256,7 @@ func TestDistShaper_NextPacketSize_RespectsMTU(t *testing.T) {
 
 func TestDistShaper_NextDelay_NonNegative(t *testing.T) {
 	for _, name := range List() {
-		s, err := ByName(name, 11)
+		s, err := ByNameAllowAny(name, 11)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -411,7 +411,98 @@ func TestRegister_DuplicatePanics(t *testing.T) {
 			t.Fatal("expected panic on duplicate register")
 		}
 	}()
-	register(PresetChromeBrowsing, buildChromeBrowsing)
+	register(PresetChromeBrowsing, true, buildChromeBrowsing)
+}
+
+func TestIsDataPlaneSafe_Known(t *testing.T) {
+	cases := []struct {
+		name string
+		want bool
+	}{
+		{PresetChromeBrowsing, true},
+		{PresetYouTubeStreaming, true},
+		{PresetRandomPerSession, true},
+		{PresetBitTorrentIdle, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := IsDataPlaneSafe(tc.name)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("IsDataPlaneSafe(%q) = %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsDataPlaneSafe_Unknown(t *testing.T) {
+	_, err := IsDataPlaneSafe("does_not_exist")
+	if !errors.Is(err, ErrUnknownPreset) {
+		t.Fatalf("want ErrUnknownPreset, got %v", err)
+	}
+}
+
+func TestByName_RejectsUnsafePresetForDataPlane(t *testing.T) {
+	_, err := ByName(PresetBitTorrentIdle, 1)
+	if !errors.Is(err, ErrPresetNotDataPlaneSafe) {
+		t.Fatalf("want ErrPresetNotDataPlaneSafe, got %v", err)
+	}
+}
+
+func TestByNameAllowAny_AcceptsAll(t *testing.T) {
+	for _, name := range List() {
+		t.Run(name, func(t *testing.T) {
+			s, err := ByNameAllowAny(name, 3)
+			if err != nil {
+				t.Fatalf("ByNameAllowAny(%q): %v", name, err)
+			}
+			if s == nil {
+				t.Fatalf("ByNameAllowAny(%q): nil shaper", name)
+			}
+		})
+	}
+}
+
+func TestByNameAllowAny_Unknown(t *testing.T) {
+	_, err := ByNameAllowAny("does_not_exist", 1)
+	if !errors.Is(err, ErrUnknownPreset) {
+		t.Fatalf("want ErrUnknownPreset, got %v", err)
+	}
+}
+
+func TestFromConfig_RejectsUnsafePreset(t *testing.T) {
+	cfg := toml.ShaperConfig{
+		Preset: PresetBitTorrentIdle,
+		Seed:   int64Ptr(1),
+	}
+	_, err := FromConfig(cfg)
+	if !errors.Is(err, ErrPresetNotDataPlaneSafe) {
+		t.Fatalf("want ErrPresetNotDataPlaneSafe, got %v", err)
+	}
+}
+
+// TestFromConfig_AcceptsCustomEvenIfRiskyParams verifies that user-defined
+// custom configs bypass the DataPlaneSafe gate — operators take responsibility
+// for their own parameters.
+func TestFromConfig_AcceptsCustomEvenIfRiskyParams(t *testing.T) {
+	cfg := toml.ShaperConfig{
+		Custom: &toml.ShaperCustom{
+			InterArrival: &toml.DistConfig{
+				Type:      toml.DistLogNormal,
+				LogNormal: &toml.LogNormalDist{Mu: 8.9, Sigma: 2.5},
+			},
+		},
+		Seed: int64Ptr(1),
+	}
+	s, err := FromConfig(cfg)
+	if err != nil {
+		t.Fatalf("custom must be accepted regardless of params: %v", err)
+	}
+	if s == nil {
+		t.Fatal("nil shaper")
+	}
 }
 
 func BenchmarkChromeBrowsing_Next(b *testing.B) {

--- a/internal/shaper/presets/random_per_session.go
+++ b/internal/shaper/presets/random_per_session.go
@@ -8,10 +8,13 @@ import (
 )
 
 // PresetRandomPerSession is the registry name for a per-session randomized
-// preset: it picks one of {chrome_browsing, youtube_streaming, bittorrent_idle}
-// using `seed` and applies a ±randomizationFraction jitter to histogram bins
-// so that even repeated picks of the same base preset produce subtly different
-// signatures.
+// preset: it picks one of the data-plane-safe basis presets using `seed` and
+// applies a ±randomizationFraction jitter to histogram bins so that even
+// repeated picks of the same base preset produce subtly different signatures.
+//
+// Cover-traffic-only presets (e.g. bittorrent_idle) are intentionally excluded
+// from the candidate set so that random_per_session itself stays
+// data-plane-safe.
 const PresetRandomPerSession = "random_per_session"
 
 // randomizationFraction is the default ±jitter applied to histogram bins
@@ -20,7 +23,7 @@ const PresetRandomPerSession = "random_per_session"
 const randomizationFraction = 0.15
 
 func init() {
-	register(PresetRandomPerSession, buildRandomPerSession)
+	register(PresetRandomPerSession, true, buildRandomPerSession)
 }
 
 // buildRandomPerSession derives the basis preset name from `seed`, builds
@@ -31,7 +34,6 @@ func buildRandomPerSession(seed int64) (shaper.Shaper, error) {
 	candidates := []string{
 		PresetChromeBrowsing,
 		PresetYouTubeStreaming,
-		PresetBitTorrentIdle,
 	}
 	// Use a dedicated PCG stream to choose the basis preset so that the choice
 	// is independent of the underlying preset's RNG sequence.

--- a/internal/shaper/presets/stats_test.go
+++ b/internal/shaper/presets/stats_test.go
@@ -112,7 +112,7 @@ func TestPreset_BitTorrent_StatisticalSignature(t *testing.T) {
 		600:  0.10,
 		1200: 0.05,
 	}
-	s, err := ByName(PresetBitTorrentIdle, 12345)
+	s, err := ByNameAllowAny(PresetBitTorrentIdle, 12345)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -188,10 +188,11 @@ func TestPreset_RandomPerSession_VariesAcrossSeeds(t *testing.T) {
 			}
 		}
 	}
-	// Require >= 60% of pairs to be distinguishable. With 3 base presets and
-	// 15% jitter, same-base pairs may still look similar — that's fine.
-	if float64(distinct)/float64(pairs) < 0.6 {
-		t.Fatalf("random_per_session: only %d/%d pairs distinguishable (want ≥ 60%%)", distinct, pairs)
+	// Require >= 40% of pairs to be distinguishable. With 2 data-plane-safe
+	// base presets and 15% jitter, ~half the pairs share a base preset and
+	// are inherently similar — only cross-base pairs are reliably distinct.
+	if float64(distinct)/float64(pairs) < 0.4 {
+		t.Fatalf("random_per_session: only %d/%d pairs distinguishable (want ≥ 40%%)", distinct, pairs)
 	}
 	t.Logf("random_per_session: %d/%d distinct pairs", distinct, pairs)
 }

--- a/internal/shaper/presets/youtube_streaming.go
+++ b/internal/shaper/presets/youtube_streaming.go
@@ -31,7 +31,7 @@ const PresetYouTubeStreaming = "youtube_streaming"
 // Inter-arrival: Pareto(xm=0.05 ms, alpha=1.5) on download (heavy tail for
 // rebuffering); LogNormal(mu=-3, sigma=1.5) on upload (sparse GETs).
 func init() {
-	register(PresetYouTubeStreaming, buildYouTubeStreaming)
+	register(PresetYouTubeStreaming, true, buildYouTubeStreaming)
 }
 
 func buildYouTubeStreaming(seed int64) (shaper.Shaper, error) {


### PR DESCRIPTION
## Summary

- Adds `DataPlaneSafe` metadata flag to every preset and exposes `presets.IsDataPlaneSafe(name)` plus `ErrPresetNotDataPlaneSafe`.
- `presets.ByName` and `presets.FromConfig` now refuse non-data-plane-safe presets so a TOML misconfig cannot drop tunnel throughput to zero (`bittorrent_idle` median inter-arrival is ~7 s — cover-traffic only).
- New `presets.ByNameAllowAny` entry point for the future cover-traffic emitter; `random_per_session` candidate pool trimmed to data-plane-safe basis presets so it stays safe by construction.
- README gains a "Data-plane vs cover-traffic presets" section; CHANGELOG documents the breaking change and migration path.

Tracking: tiredvpn-oss-6hj. Refs https://github.com/tiredvpn/tiredvpn/issues/18 (shaper perf — preset gating aspect).

## Test plan

- [x] `go build ./...`
- [x] `go test -race ./...` (598 passed across 28 packages)
- [x] `golangci-lint run ./internal/shaper/... ./cmd/shaper-dump/...` clean
- [x] `internal/shaper/presets` coverage 92.8% (was 91.8%)
- [x] New tests: `IsDataPlaneSafe_{Known,Unknown}`, `ByName_RejectsUnsafePresetForDataPlane`, `ByNameAllowAny_{AcceptsAll,Unknown}`, `FromConfig_{RejectsUnsafePreset,AcceptsCustomEvenIfRiskyParams}`