### PR TITLE
test(shaper): verify perf fix on realistic benchmarks (follow-up needed for #18)

### DIFF
--- a/internal/integration/shaper_e2e_test.go
+++ b/internal/integration/shaper_e2e_test.go
@@ -6,6 +6,7 @@ package integration_test
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"math/rand/v2"
 	"sync"
@@ -140,6 +141,82 @@ func TestShaperE2E_DifferentPresetsCantTalk_DocumentBehavior(t *testing.T) {
 		t.Fatalf("cross-preset roundtrip mismatch: got %d bytes, want %d", len(got), N)
 	}
 	t.Log("cross-preset roundtrip succeeded; shaper changes affect on-wire shape, not application semantics")
+}
+
+// TestShaperE2E_LargePayload_Async exercises the async pacer end-to-end on a
+// 1 MiB payload through the chrome_browsing preset. The point is to verify
+// byte-for-byte recovery on a payload large enough to drive several queue
+// fills + adaptive-throttle cycles, not just a one-shot Wrap/Unwrap.
+func TestShaperE2E_LargePayload_Async(t *testing.T) {
+	t.Parallel()
+	clientShaper := newPresetShaper(t, presets.PresetChromeBrowsing, 11)
+	serverShaper := newPresetShaper(t, presets.PresetChromeBrowsing, 22)
+	client, server, cleanup := pairedMorphedConns(t, clientShaper, serverShaper)
+	defer cleanup()
+
+	const N = 1 << 20 // 1 MiB
+	rng := rand.New(rand.NewPCG(0xA1B2C3D4, 0x55555555))
+	want := make([]byte, N)
+	for i := range want {
+		want[i] = byte(rng.UintN(256))
+	}
+
+	var (
+		writeErr error
+		wg       sync.WaitGroup
+	)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, writeErr = client.Write(want)
+		_ = client.Close()
+	}()
+
+	got, readErr := readAll(server, N, 60*time.Second)
+	wg.Wait()
+	if writeErr != nil {
+		t.Fatalf("client write: %v", writeErr)
+	}
+	if readErr != nil && readErr != io.EOF {
+		t.Fatalf("server read: %v", readErr)
+	}
+	if !bytes.Equal(got[:N], want) {
+		t.Fatalf("large-payload roundtrip mismatch at %d bytes", len(got))
+	}
+}
+
+// TestShaperE2E_OverflowGraceful checks the overflow contract end-to-end:
+// when the server stops reading (simulated by never starting a reader and
+// letting net.Pipe block the pacer's Conn.Write), the client's Write must
+// eventually return ErrShaperOverflow rather than hanging. This is the
+// behavioural guarantee that lets the upper TUN layer fail fast instead of
+// piling up forever.
+func TestShaperE2E_OverflowGraceful(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("uses 1s+ wallclock for the overflow timer")
+	}
+	clientShaper := newPresetShaper(t, presets.PresetChromeBrowsing, 33)
+	serverShaper := newPresetShaper(t, presets.PresetChromeBrowsing, 44)
+	client, _, cleanup := pairedMorphedConns(t, clientShaper, serverShaper)
+	defer cleanup()
+
+	// Server side intentionally never reads. net.Pipe is unbuffered, so the
+	// pacer's first Conn.Write blocks forever; producer Writes fill the
+	// queue and eventually trip the 1s enqueue timeout.
+	payload := make([]byte, 4*1024*1024) // 4 MiB — far more than queue cap
+
+	start := time.Now()
+	_, err := client.Write(payload)
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, strategy.ErrShaperOverflow) {
+		t.Fatalf("got err=%v, want ErrShaperOverflow (after %v)", err, elapsed)
+	}
+	// Sanity: must surface within ~enqueueTimeout + a little, not minutes.
+	if elapsed > 5*time.Second {
+		t.Fatalf("Write took %v to return overflow; expected ~1s", elapsed)
+	}
 }
 
 func readAll(r io.Reader, n int, timeout time.Duration) ([]byte, error) {

--- a/internal/strategy/morph_pacer_saturation_test.go
+++ b/internal/strategy/morph_pacer_saturation_test.go
@@ -1,0 +1,120 @@
+package strategy
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+// TestPacer_SaturationDoesNotDeadlock pumps 100 MiB through a slow shaper
+// (5 ms per-frame target delay, capped to 50 ms by pacerMaxDelay) into a
+// fast consumer. Under adaptive throttle the queue fills, factor → 0, and
+// the producer must keep making progress. We assert completion within a
+// generous bound; the test fails by timeout if the pacer ever deadlocks.
+func TestPacer_SaturationDoesNotDeadlock(t *testing.T) {
+	if testing.Short() {
+		t.Skip("perf-sensitive saturation test")
+	}
+	c := &countingConn{}
+	p := newWritePacer(c, &constShaper{delay: 5 * time.Millisecond, size: 1500})
+
+	const totalFrames = 100 * 1024 * 1024 / 1500 // ~100 MiB / 1500 B
+	frame := make([]byte, 1500)
+
+	doneCh := make(chan error, 1)
+	go func() {
+		for range totalFrames {
+			if err := p.enqueue(pacedFrame{packet: frame}); err != nil {
+				doneCh <- err
+				return
+			}
+		}
+		doneCh <- nil
+	}()
+
+	select {
+	case err := <-doneCh:
+		if err != nil {
+			t.Fatalf("enqueue failed under saturation: %v", err)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatalf("pacer deadlocked: enqueued %d/%d frames in 30s", c.Writes(), totalFrames)
+	}
+	p.close()
+	if got := c.Writes(); int(got) != totalFrames {
+		t.Fatalf("post-close writes = %d, want %d", got, totalFrames)
+	}
+}
+
+// TestPacer_AdaptiveThrottle_Effective measures throughput in two phases:
+// (1) a baseline burst that fills past the 50% throttle threshold so factor
+// drops, then (2) a steady-state phase where the pacer should sustain
+// throughput well above the unscaled per-frame rate. The assertion is that
+// effective frames/sec under saturation greatly exceeds 1/delay (the rate a
+// non-throttling pacer would deliver), confirming the throttle keeps the
+// queue moving.
+func TestPacer_AdaptiveThrottle_Effective(t *testing.T) {
+	if testing.Short() {
+		t.Skip("perf-sensitive throttle test")
+	}
+	c := &countingConn{}
+	const perFrameDelay = 2 * time.Millisecond
+	p := newWritePacer(c, &constShaper{delay: perFrameDelay, size: 1500})
+
+	const N = 4096
+	frame := make([]byte, 1500)
+	start := time.Now()
+	for range N {
+		if err := p.enqueue(pacedFrame{packet: frame}); err != nil {
+			t.Fatalf("enqueue: %v", err)
+		}
+	}
+	p.close()
+	elapsed := time.Since(start)
+
+	// Without throttling the floor would be N * perFrameDelay = 4096 * 2ms ≈ 8.2s.
+	// Under adaptive throttling effective rate must exceed 5× that floor.
+	naive := time.Duration(N) * perFrameDelay
+	if elapsed > naive/5 {
+		t.Fatalf("throttle ineffective: elapsed=%v, naive=%v (want < naive/5)", elapsed, naive)
+	}
+	if got := c.Writes(); int(got) != N {
+		t.Fatalf("writes=%d, want %d", got, N)
+	}
+}
+
+// TestPacer_OverflowReturnsError pins the contract documented in ADR §7:
+// when the upstream cannot drain for longer than pacerEnqueueTimeout (1s),
+// enqueue returns ErrShaperOverflow rather than blocking the producer
+// forever. We hold the consumer wedged by gating Conn.Write so even with a
+// zero shaper delay the queue can't move; this is the same condition a real
+// downstream stall would create.
+func TestPacer_OverflowReturnsError(t *testing.T) {
+	if testing.Short() {
+		t.Skip("uses 1s+ wallclock for the overflow timer")
+	}
+	c := &countingConn{}
+	gate := make(chan struct{})
+	c.blockWrite = gate
+	p := newWritePacer(c, &constShaper{delay: 0, size: 1})
+
+	frame := []byte{0}
+	// Fill: one frame is in-flight (pacer goroutine blocked on Write) plus
+	// pacerQueueCap in the channel.
+	for range pacerQueueCap + 1 {
+		if err := p.enqueue(pacedFrame{packet: frame}); err != nil {
+			t.Fatalf("fill: %v", err)
+		}
+	}
+	start := time.Now()
+	err := p.enqueue(pacedFrame{packet: frame})
+	elapsed := time.Since(start)
+	if !errors.Is(err, ErrShaperOverflow) {
+		t.Fatalf("got %v, want ErrShaperOverflow", err)
+	}
+	if elapsed < pacerEnqueueTimeout || elapsed > pacerEnqueueTimeout+750*time.Millisecond {
+		t.Fatalf("elapsed %v outside [%v, +750ms]", elapsed, pacerEnqueueTimeout)
+	}
+	close(gate)
+	p.close()
+}

--- a/internal/strategy/morph_realistic_bench_test.go
+++ b/internal/strategy/morph_realistic_bench_test.go
@@ -1,0 +1,154 @@
+package strategy_test
+
+import (
+	"errors"
+	"io"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/tiredvpn/tiredvpn/internal/config/toml"
+	"github.com/tiredvpn/tiredvpn/internal/shaper"
+	"github.com/tiredvpn/tiredvpn/internal/shaper/presets"
+	"github.com/tiredvpn/tiredvpn/internal/strategy"
+)
+
+// realistic_bench_test exercises the shaped Write path over a real loopback
+// TCP socket instead of net.Pipe. Rationale (see adr-shaper-perf.md §8):
+// net.Pipe is synchronous; the kernel TCP buffer on 127.0.0.1 absorbs bursts
+// and lets the async pacer goroutine make progress while the producer keeps
+// enqueuing. The realistic numbers — and thus the issue #18 acceptance bar —
+// must be measured here, not on net.Pipe.
+
+const realisticPayloadBytes = 16 * 1024 * 1024 // 16 MiB
+
+func realisticProfile() *strategy.TrafficProfile {
+	return &strategy.TrafficProfile{
+		Name:            "Bench",
+		PacketSizes:     []int{1200},
+		PacketSizeProbs: []float64{1.0},
+	}
+}
+
+func mustRealisticPresetShaper(b *testing.B, name string) shaper.Shaper {
+	b.Helper()
+	seed := int64(1)
+	sh, err := strategy.ShaperFromConfig(&toml.ShaperConfig{Preset: name, Seed: &seed})
+	if err != nil {
+		b.Fatal(err)
+	}
+	return sh
+}
+
+// runRealisticBench writes a single 16 MiB payload through a shaped
+// MorphedConn pair connected via loopback TCP, while a server-side goroutine
+// drains continuously. Each b.Loop() iteration covers one full payload, which
+// means we measure steady-state throughput rather than per-Write fixed costs.
+func runRealisticBench(b *testing.B, clientShaper, serverShaper shaper.Shaper) {
+	b.Helper()
+	profile := realisticProfile()
+	payload := make([]byte, realisticPayloadBytes)
+	for i := range payload {
+		payload[i] = byte(i)
+	}
+
+	// One TCP pair per benchmark invocation; b.Loop iterates payloads over
+	// the same socket so each iteration includes a full Write + drain to the
+	// kernel buffer, but we don't pay listener/dial cost per iteration.
+	client, server, cleanup, err := strategy.NewTestMorphedConnPairTCP(profile, clientShaper, serverShaper)
+	if err != nil {
+		b.Fatalf("pair: %v", err)
+	}
+	defer cleanup()
+
+	// Counter the server-side reader hands back so the producer can wait
+	// for "this iteration's bytes have been drained" before declaring the
+	// iteration complete. Without that, all the work might still be sitting
+	// in the kernel send buffer when the timer stops.
+	var drained atomic.Int64
+	readDone := make(chan struct{})
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer close(readDone)
+		buf := make([]byte, 64*1024)
+		for {
+			n, err := server.Read(buf)
+			if n > 0 {
+				drained.Add(int64(n))
+			}
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	b.SetBytes(int64(realisticPayloadBytes))
+	b.ReportAllocs()
+	b.ResetTimer()
+	var written int64
+	for b.Loop() {
+		if _, err := client.Write(payload); err != nil {
+			if errors.Is(err, io.EOF) || errors.Is(err, net.ErrClosed) {
+				break
+			}
+			b.Fatalf("write: %v", err)
+		}
+		written += int64(realisticPayloadBytes)
+		// Wait until the server has drained at least everything we've
+		// written so far. This is what turns "producer enqueue MB/s" into
+		// "end-to-end MB/s".
+		deadline := time.Now().Add(60 * time.Second)
+		for drained.Load() < written {
+			if time.Now().After(deadline) {
+				b.Fatal("drain timeout")
+			}
+			time.Sleep(100 * time.Microsecond)
+		}
+	}
+	b.StopTimer()
+	_ = client.Close()
+	<-readDone
+	wg.Wait()
+}
+
+// BenchmarkRealistic_Noop is the loopback-TCP baseline. With NoopShaper this
+// is just framed Conn.Write into the kernel buffer; the resulting MB/s is the
+// upper bound any other preset must compare against.
+func BenchmarkRealistic_Noop(b *testing.B) {
+	runRealisticBench(b, shaper.NoopShaper{}, shaper.NoopShaper{})
+}
+
+// BenchmarkRealistic_Chrome_Async exercises chrome_browsing through the async
+// pacer over loopback TCP. This is the headline number for issue #18: target
+// is ≤ 30 % overhead vs Noop.
+func BenchmarkRealistic_Chrome_Async(b *testing.B) {
+	runRealisticBench(b,
+		mustRealisticPresetShaper(b, presets.PresetChromeBrowsing),
+		mustRealisticPresetShaper(b, presets.PresetChromeBrowsing),
+	)
+}
+
+// BenchmarkRealistic_Youtube_Async is the youtube_streaming counterpart.
+// Pareto-tail delays are clamped to 50 ms in the pacer (ADR §7) and the
+// up-direction packet sizes are tiny (~120 B), so this is the worst-case
+// preset for throughput; it's expected to underperform chrome.
+func BenchmarkRealistic_Youtube_Async(b *testing.B) {
+	runRealisticBench(b,
+		mustRealisticPresetShaper(b, presets.PresetYouTubeStreaming),
+		mustRealisticPresetShaper(b, presets.PresetYouTubeStreaming),
+	)
+}
+
+// BenchmarkRealistic_RandomPerSession sanity-checks the third data-plane-safe
+// preset; numbers should sit between chrome and youtube depending on which
+// candidate the seed selects.
+func BenchmarkRealistic_RandomPerSession(b *testing.B) {
+	runRealisticBench(b,
+		mustRealisticPresetShaper(b, presets.PresetRandomPerSession),
+		mustRealisticPresetShaper(b, presets.PresetRandomPerSession),
+	)
+}

--- a/internal/strategy/morph_testhelpers.go
+++ b/internal/strategy/morph_testhelpers.go
@@ -6,6 +6,55 @@ import (
 	"github.com/tiredvpn/tiredvpn/internal/shaper"
 )
 
+// NewTestMorphedConnPairTCP is the loopback-TCP analogue of
+// NewTestMorphedConnPair. Unlike net.Pipe (synchronous, end-to-end serialised
+// per Write), a real TCP socket on 127.0.0.1 has kernel send/receive buffers
+// of order ~BDP, which lets the pacer goroutine make forward progress while
+// the producer is still issuing Writes. This reflects the deployment regime
+// where shaper overhead must be measured. Cleanup closes both endpoints and
+// the listener.
+func NewTestMorphedConnPairTCP(profile *TrafficProfile, clientShaper, serverShaper shaper.Shaper) (*MorphedConn, *MorphedConn, func(), error) {
+	if clientShaper == nil {
+		clientShaper = shaper.NoopShaper{}
+	}
+	if serverShaper == nil {
+		serverShaper = shaper.NoopShaper{}
+	}
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	type accepted struct {
+		c   net.Conn
+		err error
+	}
+	ch := make(chan accepted, 1)
+	go func() {
+		c, err := ln.Accept()
+		ch <- accepted{c: c, err: err}
+	}()
+	cliConn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		_ = ln.Close()
+		return nil, nil, nil, err
+	}
+	a := <-ch
+	if a.err != nil {
+		_ = cliConn.Close()
+		_ = ln.Close()
+		return nil, nil, nil, a.err
+	}
+	srvConn := a.c
+	client := &MorphedConn{Conn: cliConn, profile: profile, shaper: clientShaper}
+	server := &MorphedConn{Conn: srvConn, profile: profile, shaper: serverShaper}
+	cleanup := func() {
+		_ = client.Close()
+		_ = server.Close()
+		_ = ln.Close()
+	}
+	return client, server, cleanup, nil
+}
+
 // NewTestMorphedConnPair returns two MorphedConn endpoints connected via
 // net.Pipe with shapers pre-installed and the application-layer Morph
 // handshake skipped. It exists for cross-package integration tests that

--- a/internal/strategy/testdata/shaper_overhead_realistic.txt
+++ b/internal/strategy/testdata/shaper_overhead_realistic.txt
@@ -1,0 +1,44 @@
+goos: linux
+goarch: amd64
+pkg: github.com/tiredvpn/tiredvpn/internal/strategy
+cpu: 13th Gen Intel(R) Core(TM) i7-1370P
+# Workload: 16 MiB single payload, server-side TCP loopback drainer, kernel
+# default send/recv buffers, async pacer enabled. Producer waits for the
+# server to drain its committed bytes each iteration so timed work covers
+# the full enqueue → wire → kernel-buffer → application path, not just the
+# enqueue handoff.
+BenchmarkRealistic_Noop-20                	       5	  31307741 ns/op	 535.88 MB/s	50274403 B/op	       6 allocs/op
+BenchmarkRealistic_Chrome_Async-20        	       5	 309922432 ns/op	  54.13 MB/s	72812126 B/op	  247071 allocs/op
+BenchmarkRealistic_Youtube_Async-20       	       5	1296364971 ns/op	  12.94 MB/s	94019756 B/op	  679751 allocs/op
+BenchmarkRealistic_RandomPerSession-20    	       5	1256263303 ns/op	  13.35 MB/s	93574827 B/op	  675503 allocs/op
+PASS
+ok  	github.com/tiredvpn/tiredvpn/internal/strategy	14.565s
+
+# Notes
+#
+# Acceptance bar from issue #18 / ADR-shaper-perf §2: ≤ 30 % overhead vs
+# Noop on bulk transfers. Computed against the Noop loopback baseline of
+# 535.88 MB/s above:
+#
+#   chrome_browsing : 54.13 MB/s → overhead = 1 - 54.13/535.88 = 89.9 %
+#   youtube_streaming: 12.94 MB/s → overhead = 97.6 %
+#   random_per_session: 13.35 MB/s → overhead = 97.5 %
+#
+# The async pacer fix (PR #20) lifted chrome from 1.75 MB/s (sync, net.Pipe)
+# to 74 MB/s (async, net.Pipe) and now 54 MB/s (async, real TCP) — a 31×
+# improvement in the deployment regime. But the 30 % overhead target is
+# not met on any preset.
+#
+# Why the headline target is missed: per-frame allocations dominate. At
+# chrome_browsing's mean ~600 B frame size a 16 MiB payload generates
+# ~28 000 frames, each going through buildFrame + Wrap + len-prefix +
+# rate-limit checks (~250 k allocs / 70 MB allocated, see allocs above).
+# That is independent of how clever the pacer is — it's structural cost in
+# the framing layer. youtube_streaming makes it worse: ~120 B avg frame, so
+# ~140 k frames per 16 MiB.
+#
+# Conclusion: this verification establishes that PR #19 + PR #20 fixed the
+# producer-side time.Sleep stall (the root cause of issue #18 as filed), but
+# bulk throughput remains framing-bound. A separate follow-up — reducing
+# per-frame allocs and/or coalescing multiple frames into a single Conn.Write
+# — would be needed to reach 30 %. See shaper_perf_summary.md.

--- a/internal/strategy/testdata/shaper_perf_summary.md
+++ b/internal/strategy/testdata/shaper_perf_summary.md
@@ -1,0 +1,67 @@
+# Shaper performance fix verification
+
+Verification run for issue #18 after PR #19 (DataPlaneSafe gating) and
+PR #20 (async pacer goroutine + adaptive throttle + 50 ms delay cap +
+1 s overflow timeout) merged into main.
+
+Hardware: 13th Gen Intel Core i7-1370P, Linux amd64, kernel default
+TCP buffers, kTLS available but not on this hop (loopback, no TLS).
+
+## Results
+
+| Preset            | Before fix (MB/s) | After fix - net.Pipe (MB/s) | After fix - real TCP (MB/s) | Overhead vs Noop (real TCP) | χ² test | Acceptance (≤30%) |
+|-------------------|------------------:|----------------------------:|----------------------------:|----------------------------:|---------|-------------------|
+| Noop              |             907.5 |                       907.5 |                       535.9 |                          0% | —       | reference         |
+| chrome_browsing   |              1.75 |                        74.0 |                        54.1 |                       89.9% | pass    | NOT MET           |
+| youtube_streaming |              0.23 |                         9.9 |                        12.9 |                       97.6% | pass    | NOT MET           |
+| random_per_session|                 — |                           — |                        13.4 |                       97.5% | pass    | NOT MET           |
+
+Sources: `shaper_overhead.txt` (pre-fix), `shaper_overhead_async.txt`
+(post-PR-20 net.Pipe), `shaper_overhead_realistic.txt` (this run, real TCP).
+
+## χ² regression
+
+All four `TestPreset_*_StatisticalSignature` and the
+`TestPreset_RandomPerSession_VariesAcrossSeeds` tests pass without any
+relaxation. The 50 ms delay cap introduced in PR #20 affects inter-frame
+delays only; the χ² tests in `internal/shaper/presets/stats_test.go` measure
+`NextPacketSize` distributions, which are untouched.
+
+## Did we hit the goal?
+
+**No.** The async pacer fix delivered a 31× improvement on chrome
+(1.75 → 54 MB/s on the deployment-realistic loopback-TCP benchmark) and
+similar magnitude wins on youtube/random_per_session, but throughput
+overhead vs Noop remains at ~90 % across the board — far above the 30 %
+acceptance bar from the issue.
+
+The remaining cost is **structural framing overhead**, not the producer
+sleep stall PR #20 fixed. With chrome_browsing's mean ~600 B frame size, a
+16 MiB payload generates ~28 000 frames × (allocation in `buildFrame`,
+length-prefix write, `Wrap` slice creation, individual `Conn.Write` syscall,
+shaper `NextPacketSize` + `NextDelay` RNG calls). The bench shows ~250 k
+allocs and 70 MB allocated for chrome on a 16 MiB transfer — that's the
+ceiling. youtube_streaming's ~120 B avg frame multiplies it by 5×.
+
+Concretely, the issue as filed ("shaper time.Sleep dominates write path")
+is fixed: the producer no longer blocks on sub-tick sleeps, and the cure
+demonstrably moves the needle by 30×+. But the original 30 % overhead bar
+turns out to be unreachable from this layer alone; getting there requires
+follow-up work on the framing layer (per-frame alloc reduction, batching
+multiple shaped frames into one Conn.Write, or a pool-aware Wrap path) and
+perhaps a re-baselined target that accounts for "shaper produces small
+packets — that is the design".
+
+## Recommendation
+
+- **Do not close #18 in this PR.** The acceptance criterion was not met.
+- Open a follow-up issue scoped to "reduce per-frame allocation in
+  morph framing layer" (target candidates: `buildFrame` second alloc,
+  pre-sized Wrap output, scatter/gather writev in pacer). A reasonable
+  target is half the current overhead (45 %) at chrome_browsing, with
+  the understanding that small-packet presets like youtube_streaming
+  inherently cap above 50 % overhead due to per-syscall and per-allocation
+  fixed cost regardless of what we do above the framing layer.
+- This PR delivers the verification harness, regression smoke tests for the
+  pacer's saturation/overflow contracts, and end-to-end large-payload +
+  graceful-overflow assertions, all running green under `-race`.


### PR DESCRIPTION
## Summary

- Adds a loopback-TCP realistic benchmark suite (16 MiB payload, kernel send buffers, server-side drainer) for the four data-plane-safe shaper presets, plus the supporting `NewTestMorphedConnPairTCP` helper.
- Adds saturation/overflow regression tests for the async pacer (`TestPacer_SaturationDoesNotDeadlock`, `TestPacer_AdaptiveThrottle_Effective`, `TestPacer_OverflowReturnsError`) and two end-to-end assertions (`TestShaperE2E_LargePayload_Async`, `TestShaperE2E_OverflowGraceful`).
- Documents numbers and verdict in `internal/strategy/testdata/shaper_overhead_realistic.txt` and `internal/strategy/testdata/shaper_perf_summary.md`.

## Real-TCP throughput results

| Preset             | After fix - real TCP | Overhead vs Noop | Acceptance ≤30% |
|--------------------|---------------------:|-----------------:|-----------------|
| Noop               |             535.9 MB/s |                 0% | reference |
| chrome_browsing    |              54.1 MB/s |              89.9% | NOT MET |
| youtube_streaming  |              12.9 MB/s |              97.6% | NOT MET |
| random_per_session |              13.4 MB/s |              97.5% | NOT MET |

The async pacer (PR #20) delivered a 31× improvement on chrome over the previous synchronous baseline (1.75 MB/s → 54.1 MB/s), but the 30 % overhead target from issue #18 is not reachable from the pacer layer alone — remaining cost is per-frame allocation + per-frame `Conn.Write` syscall in the framing layer.

All χ² statistical-signature tests pass without relaxation (the 50 ms delay cap touches inter-frame timing, not packet-size distributions).

## Recommendation

- **Do NOT close #18.** Acceptance criterion not met on real TCP.
- Open a follow-up issue scoped to "reduce per-frame allocation in morph framing layer" with a realistic target (e.g. ≤ 50 % overhead on chrome, with explicit acknowledgement that small-packet presets cap higher due to syscall fixed cost).

Tracking task: tiredvpn-oss-gw9. Issue: #18.

## Test plan

- [x] `go build ./...`
- [x] `go test -race ./...` (612 tests, all packages, 28 packages)
- [x] `golangci-lint run ./...` (no new findings on changed files)
- [x] All four data-plane-safe presets route through async pacer without panics on realistic bench
- [x] χ² regression tests stay green (`internal/shaper/presets`, 4 stats tests)
- [x] Overflow returns `ErrShaperOverflow` end-to-end within ~1s, not minutes