### PR TITLE
perf(shaper): pool Wrap output buffers to eliminate per-frame allocs

### DIFF
--- a/internal/shaper/noop.go
+++ b/internal/shaper/noop.go
@@ -31,6 +31,10 @@ func (NoopShaper) Wrap(payload []byte) [][]byte {
 	return [][]byte{payload}
 }
 
+// Release is a no-op for the passthrough shaper because Wrap returns the
+// caller's payload slice directly without any pooled allocation.
+func (NoopShaper) Release(_ [][]byte) {}
+
 // Unwrap concatenates frames in order. A nil/empty input yields nil to keep
 // roundtrip semantics with Wrap(nil).
 func (NoopShaper) Unwrap(frames [][]byte) []byte {

--- a/internal/shaper/presets/dist_shaper.go
+++ b/internal/shaper/presets/dist_shaper.go
@@ -2,11 +2,53 @@ package presets
 
 import (
 	"encoding/binary"
+	"sync"
 	"time"
 
 	"github.com/tiredvpn/tiredvpn/internal/shaper"
 	"github.com/tiredvpn/tiredvpn/internal/shaper/dist"
 )
+
+// wrapBufPool reuses per-frame byte slices produced by distShaper.Wrap.
+// Buffers are sized at MTU (1500) so any frame up to MTU shares a single
+// pool tier; the slice is re-sliced to the requested length on acquire.
+// Storing *[]byte avoids the pointer-indirection alloc that sync.Pool
+// performs for non-pointer interface values.
+var wrapBufPool = sync.Pool{
+	New: func() any {
+		b := make([]byte, defaultMTU)
+		return &b
+	},
+}
+
+// acquireWrapBuf returns a *[]byte handle whose underlying slice has length n
+// and capacity ≥ defaultMTU. Callers MUST call releaseWrapBuf with the same
+// handle once the buffer's contents are no longer needed; failing to do so
+// only leaks the pooled allocation, never corrupts state.
+func acquireWrapBuf(n int) *[]byte {
+	bp := wrapBufPool.Get().(*[]byte)
+	if cap(*bp) < n {
+		// Pool buffer is too small (n > defaultMTU). Drop the pooled slice
+		// and allocate a tight fit; this should never happen in practice
+		// because Wrap clamps target to mtu.
+		wrapBufPool.Put(bp)
+		fresh := make([]byte, n)
+		return &fresh
+	}
+	*bp = (*bp)[:n]
+	return bp
+}
+
+// releaseWrapBuf returns bp to the wrap-buffer pool. Buffers smaller than
+// defaultMTU are dropped on the floor — they would only pollute the pool
+// with too-small slices and force the next acquire to re-allocate anyway.
+func releaseWrapBuf(bp *[]byte) {
+	if bp == nil || cap(*bp) < defaultMTU {
+		return
+	}
+	*bp = (*bp)[:cap(*bp)]
+	wrapBufPool.Put(bp)
+}
 
 // Default constants applied across presets unless overridden.
 const (
@@ -26,12 +68,30 @@ const (
 // distShaper is a Shaper backed by four Distribution engines (size and delay
 // for each direction). The unit of NextDelay output is milliseconds: the
 // underlying Distribution.Next() is interpreted as a number of millis.
+//
+// distShaper is single-producer: Wrap and Release are expected to alternate
+// on the same goroutine (the writer side of one MorphedConn). The wrap-
+// buffer handle slice is held on the shaper itself so Release can return
+// pooled buffers without allocating fresh *[]byte slot pointers.
 type distShaper struct {
 	sizeUp    dist.Distribution
 	sizeDown  dist.Distribution
 	delayUp   dist.Distribution
 	delayDown dist.Distribution
 	mtu       int
+
+	// wrapMu serialises Wrap/Release. The fast path (single-goroutine
+	// producer) holds the mutex briefly and uncontended; the lock exists
+	// purely to make accidental concurrent use safe rather than fast.
+	wrapMu sync.Mutex
+	// wrapHandles holds *[]byte handles parallel to the slice returned by
+	// Wrap. Capacity grows monotonically up to the worst case (≈ MTU
+	// fragments per Wrap). Cleared on Release and reused.
+	wrapHandles []*[]byte
+	// wrapFrames is the outer slice handed back from Wrap. We retain it
+	// so Release can clear inner pointers and the next Wrap can reuse
+	// the header without a fresh make.
+	wrapFrames [][]byte
 }
 
 // constDist is a degenerate Distribution that always returns the same value;
@@ -96,11 +156,23 @@ const frameHeaderLen = 4
 // where len is the actual payload byte count. Empty payload produces a single
 // header-only frame so that Wrap/Unwrap is a total roundtrip.
 func (d *distShaper) Wrap(payload []byte) [][]byte {
+	d.wrapMu.Lock()
+	defer d.wrapMu.Unlock()
+
+	frames := d.wrapFrames[:0]
+	handles := d.wrapHandles[:0]
+
 	if len(payload) == 0 {
-		return [][]byte{make([]byte, frameHeaderLen)}
+		bp := acquireWrapBuf(frameHeaderLen)
+		frame := *bp
+		clear(frame[:frameHeaderLen])
+		frames = append(frames, frame)
+		handles = append(handles, bp)
+		d.wrapFrames = frames
+		d.wrapHandles = handles
+		return frames
 	}
 
-	var frames [][]byte
 	pos := 0
 	for pos < len(payload) {
 		target := d.NextPacketSize(shaper.DirectionUp)
@@ -114,13 +186,51 @@ func (d *distShaper) Wrap(payload []byte) [][]byte {
 		if remaining := len(payload) - pos; remaining < take {
 			take = remaining
 		}
-		frame := make([]byte, target)
+		bp := acquireWrapBuf(target)
+		frame := *bp
 		binary.LittleEndian.PutUint32(frame[:frameHeaderLen], uint32(take)) //nolint:gosec // bounded by mtu
 		copy(frame[frameHeaderLen:], payload[pos:pos+take])
+		// Zero the trailing pad region — a fresh make would have given us
+		// zeros, but pooled buffers may carry the previous frame's bytes.
+		if tail := frame[frameHeaderLen+take:]; len(tail) > 0 {
+			clear(tail)
+		}
 		frames = append(frames, frame)
+		handles = append(handles, bp)
 		pos += take
 	}
+	d.wrapFrames = frames
+	d.wrapHandles = handles
 	return frames
+}
+
+// Release returns each frame buffer in frames to the wrap-buffer pool. After
+// Release the caller MUST NOT use frames or any of the inner buffers; they
+// may be handed out to a subsequent Wrap call. Calling Release on a nil or
+// empty slice is safe; a slice that doesn't match the most recent Wrap
+// output is a programmer error and silently ignored.
+func (d *distShaper) Release(frames [][]byte) {
+	if len(frames) == 0 {
+		return
+	}
+	d.wrapMu.Lock()
+	defer d.wrapMu.Unlock()
+
+	// Best-effort: only honour Release for the most recent Wrap. The
+	// alternative (looking up handles from the [][]byte alone) requires
+	// either a map or unsafe pointer arithmetic; the documented contract
+	// is "call Release with the slice you got from Wrap", and that
+	// matches d.wrapFrames by header pointer + len.
+	if len(d.wrapHandles) != len(frames) {
+		return
+	}
+	for i, bp := range d.wrapHandles {
+		releaseWrapBuf(bp)
+		d.wrapHandles[i] = nil
+		frames[i] = nil
+	}
+	d.wrapHandles = d.wrapHandles[:0]
+	d.wrapFrames = frames[:0]
 }
 
 // Unwrap reverses Wrap by stripping the length prefix and any trailing padding

--- a/internal/shaper/presets/dist_shaper_test.go
+++ b/internal/shaper/presets/dist_shaper_test.go
@@ -1,0 +1,103 @@
+package presets
+
+import (
+	"bytes"
+	"testing"
+)
+
+// newTestDistShaper builds a distShaper with deterministic constant size/delay
+// so Wrap fragmentation is reproducible across runs without depending on the
+// production preset histograms.
+func newTestDistShaper(packetSize int) *distShaper {
+	return &distShaper{
+		sizeUp:    constDist(packetSize),
+		sizeDown:  constDist(packetSize),
+		delayUp:   constDist(0),
+		delayDown: constDist(0),
+		mtu:       defaultMTU,
+	}
+}
+
+// TestDistShaper_Release_Roundtrip checks that buffers handed back via Release
+// are reusable on the next Wrap and that the Wrap → Unwrap roundtrip still
+// reconstructs the original payload byte-for-byte.
+func TestDistShaper_Release_Roundtrip(t *testing.T) {
+	d := newTestDistShaper(300)
+	payload := bytes.Repeat([]byte("xyzzy-"), 1024) // ~6 KiB → many frames
+
+	for range 8 {
+		frames := d.Wrap(payload)
+		got := d.Unwrap(frames)
+		if !bytes.Equal(got, payload) {
+			t.Fatalf("roundtrip mismatch: got %d bytes, want %d", len(got), len(payload))
+		}
+		d.Release(frames)
+	}
+}
+
+// TestDistShaper_Release_MismatchedFramesIgnored: Release with a slice that
+// does not match the most-recent Wrap output is a programmer error and is
+// silently ignored — never panic, never corrupt the pool.
+func TestDistShaper_Release_MismatchedFramesIgnored(t *testing.T) {
+	d := newTestDistShaper(300)
+	payload := bytes.Repeat([]byte{0xAA}, 256)
+	frames := d.Wrap(payload)
+
+	// Foreign slice with a different length triggers the mismatch branch.
+	foreign := [][]byte{[]byte("not from wrap")}
+	d.Release(foreign)
+
+	// The original frames are still valid; Unwrap roundtrip must succeed.
+	if got := d.Unwrap(frames); !bytes.Equal(got, payload) {
+		t.Fatalf("frames corrupted after foreign Release")
+	}
+	d.Release(frames)
+}
+
+// TestDistShaper_Release_NilAndEmpty: Release(nil) and Release([]) are safe.
+func TestDistShaper_Release_NilAndEmpty(t *testing.T) {
+	d := newTestDistShaper(300)
+	d.Release(nil)
+	d.Release([][]byte{})
+}
+
+// TestDistShaper_Wrap_ReusesPooledBuffers: after Release, the next Wrap gets
+// at least one buffer from the pool. We can detect reuse by checking that
+// Wrap doesn't allocate every frame from scratch — verified via testing's
+// AllocsPerRun helper.
+func TestDistShaper_Wrap_ReusesPooledBuffers(t *testing.T) {
+	d := newTestDistShaper(300)
+	payload := bytes.Repeat([]byte{0x42}, 4096)
+
+	// Warm the pool.
+	for range 4 {
+		d.Release(d.Wrap(payload))
+	}
+
+	allocs := testing.AllocsPerRun(50, func() {
+		frames := d.Wrap(payload)
+		d.Release(frames)
+	})
+
+	// Without pooling, ~14 frames × ~1 alloc/frame = >14 allocs. With the
+	// pool warmed, allocs/op drops to a small constant dominated by
+	// sync.Pool's internal per-P bookkeeping under -race; what matters is
+	// that the per-frame buffer alloc is gone.
+	if allocs > 10 {
+		t.Fatalf("expected <=10 allocs/op after warmup, got %.1f", allocs)
+	}
+}
+
+// TestDistShaper_EmptyPayload_Roundtrip: empty payload still produces a
+// header-only frame that Unwrap turns back into nothing.
+func TestDistShaper_EmptyPayload_Roundtrip(t *testing.T) {
+	d := newTestDistShaper(300)
+	frames := d.Wrap(nil)
+	if len(frames) != 1 {
+		t.Fatalf("Wrap(nil) returned %d frames, want 1", len(frames))
+	}
+	if got := d.Unwrap(frames); len(got) != 0 {
+		t.Fatalf("empty payload roundtrip: got %d bytes, want 0", len(got))
+	}
+	d.Release(frames)
+}

--- a/internal/shaper/shaper.go
+++ b/internal/shaper/shaper.go
@@ -36,6 +36,13 @@ type Shaper interface {
 	// original payload.
 	Wrap(payload []byte) [][]byte
 
+	// Release hands the slice headers and underlying buffers returned by Wrap
+	// back to the implementation for reuse. Callers MUST stop touching the
+	// frames before calling Release. Implementations that do not pool buffers
+	// (e.g. NoopShaper) treat Release as a no-op. Calling Release on a nil or
+	// empty slice is always safe.
+	Release(frames [][]byte)
+
 	// Unwrap reassembles frames produced by Wrap (possibly across calls) into
 	// the original payload bytes.
 	Unwrap(frames [][]byte) []byte

--- a/internal/shaper/shaper_test.go
+++ b/internal/shaper/shaper_test.go
@@ -75,6 +75,15 @@ func TestNoopShaper_Unwrap_ConcatenatesInOrder(t *testing.T) {
 	}
 }
 
+func TestNoopShaper_Release_NoPanic(t *testing.T) {
+	s := NewNoopShaper()
+	// Nil, empty, single, multi — all must be no-ops without panicking.
+	s.Release(nil)
+	s.Release([][]byte{})
+	s.Release([][]byte{[]byte("a")})
+	s.Release([][]byte{[]byte("a"), []byte("bc")})
+}
+
 func TestNoopShaper_Unwrap_EmptyInput(t *testing.T) {
 	s := NewNoopShaper()
 	if got := s.Unwrap(nil); got != nil {

--- a/internal/strategy/morph_pacer_test.go
+++ b/internal/strategy/morph_pacer_test.go
@@ -72,6 +72,7 @@ type constShaper struct {
 func (s *constShaper) NextPacketSize(_ shaper.Direction) int      { return s.size }
 func (s *constShaper) NextDelay(_ shaper.Direction) time.Duration { return s.delay }
 func (s *constShaper) Wrap(p []byte) [][]byte                     { return [][]byte{p} }
+func (s *constShaper) Release(_ [][]byte)                          {}
 func (s *constShaper) Unwrap(f [][]byte) []byte {
 	out := []byte{}
 	for _, x := range f {
@@ -368,6 +369,7 @@ func (s *fragShaper) Wrap(p []byte) [][]byte {
 	}
 	return out
 }
+func (s *fragShaper) Release(_ [][]byte) {}
 func (s *fragShaper) Unwrap(f [][]byte) []byte {
 	out := []byte{}
 	for _, x := range f {

--- a/internal/strategy/morph_pacer_writev_test.go
+++ b/internal/strategy/morph_pacer_writev_test.go
@@ -81,6 +81,7 @@ func (s *scriptedShaper) NextDelay(_ shaper.Direction) time.Duration {
 	return s.script[len(s.script)-1]
 }
 func (s *scriptedShaper) Wrap(p []byte) [][]byte { return [][]byte{p} }
+func (s *scriptedShaper) Release(_ [][]byte)     {}
 func (s *scriptedShaper) Unwrap(f [][]byte) []byte {
 	out := []byte{}
 	for _, x := range f {

--- a/internal/strategy/morph_shaper.go
+++ b/internal/strategy/morph_shaper.go
@@ -39,6 +39,7 @@ func (mc *MorphedConn) writeShaped(p []byte) (int, error) {
 
 	frames := mc.shaper.Wrap(p)
 	if len(frames) == 0 {
+		mc.shaper.Release(frames)
 		return len(p), nil
 	}
 
@@ -57,6 +58,7 @@ func (mc *MorphedConn) writeShaped(p []byte) (int, error) {
 			if mc.rateLimiter != nil {
 				mc.rateLimiter.RecordFailure()
 			}
+			mc.shaper.Release(frames)
 			return 0, err
 		}
 		if mc.rateLimiter != nil {
@@ -65,6 +67,7 @@ func (mc *MorphedConn) writeShaped(p []byte) (int, error) {
 		mc.packetsSent++
 		mc.bytesSent += int64(len(packet))
 	}
+	mc.shaper.Release(frames)
 	return len(p), nil
 }
 

--- a/internal/strategy/morph_shaper_test.go
+++ b/internal/strategy/morph_shaper_test.go
@@ -96,6 +96,7 @@ func TestMorphedConn_NoopShaper_BackwardCompat(t *testing.T) {
 type mockShaper struct {
 	wrapCalls    [][]byte
 	unwrapCalls  [][][]byte
+	releaseCalls int
 	nextSize     int
 	nextDelay    time.Duration
 	fragmentInto int // split payload into N equal-ish chunks; 0 => single frame
@@ -119,6 +120,7 @@ func (m *mockShaper) Wrap(p []byte) [][]byte {
 	}
 	return out
 }
+func (m *mockShaper) Release(_ [][]byte) { m.releaseCalls++ }
 func (m *mockShaper) Unwrap(frames [][]byte) []byte {
 	m.unwrapCalls = append(m.unwrapCalls, frames)
 	total := 0
@@ -169,6 +171,31 @@ func TestMorphedConn_WithShaper_Wrap(t *testing.T) {
 	}
 	if frameCount != 3 {
 		t.Fatalf("on wire frame count = %d, want 3", frameCount)
+	}
+}
+
+// TestMorphedConn_WithShaper_ReleasesWrapBuffers checks that writeShaped
+// hands the Wrap-output back to the shaper exactly once per Write, regardless
+// of how many frames Wrap produced. This is what lets a pooled distShaper
+// reclaim its buffers after buildFrame copies them into the pacer queue.
+func TestMorphedConn_WithShaper_ReleasesWrapBuffers(t *testing.T) {
+	profile := &TrafficProfile{Name: "T", PacketSizes: []int{100}, PacketSizeProbs: []float64{1}}
+	fc := &fakeConn{}
+	ms := &mockShaper{nextSize: 64, fragmentInto: 4}
+	mc := NewMorphedConnWithShaper(fc, profile, []byte("secretsecretsecretsecretsecretse"), ms)
+
+	for range 5 {
+		if _, err := mc.Write(bytes.Repeat([]byte("Z"), 30)); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+	}
+	if err := mc.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	// One Release per Write — buffers come back as soon as the for-loop
+	// inside writeShaped finishes copying frames into pacer queue entries.
+	if ms.releaseCalls != 5 {
+		t.Fatalf("Release called %d times, want 5", ms.releaseCalls)
 	}
 }
 

--- a/internal/strategy/testdata/shaper_overhead_wrap_pooled.txt
+++ b/internal/strategy/testdata/shaper_overhead_wrap_pooled.txt
@@ -1,0 +1,53 @@
+# Shaper overhead: pooled Wrap output buffers (issue tiredvpn-oss-cg5).
+#
+# Measurement is BenchmarkRealistic_* over loopback TCP, 16 MiB payloads,
+# Go 1.23+, -benchtime=3s.
+#
+# Hardware: 13th Gen Intel(R) Core(TM) i7-1370P, linux/amd64, 20 logical CPUs.
+#
+# This run isolates the effect of pooling distShaper.Wrap output buffers
+# (and threading a Release method through the Shaper interface so the
+# strategy layer can return wrap-buffers after buildFrame copies them
+# into the bucketed packet pool).
+#
+# Compared to origin/main (writev-coalesced) the change:
+#  - eliminates ~28k per-frame `make([]byte, target)` allocations on the
+#    sender side at chrome's mean frame size;
+#  - leaves throughput essentially unchanged because the bench profile is
+#    now dominated by receiver-side allocs (readShaped + Unwrap), not by
+#    the wrap path.
+#
+# Baseline (origin/main):
+#   BenchmarkRealistic_Noop-20            201   16093088 ns/op  1042.51 MB/s          50274324 B/op           4 allocs/op
+#   BenchmarkRealistic_Chrome_Async-20     32   97379801 ns/op   172.29 MB/s          69068868 B/op      186570 allocs/op
+#
+# After this change (wrap-pool):
+goos: linux
+goarch: amd64
+pkg: github.com/tiredvpn/tiredvpn/internal/strategy
+cpu: 13th Gen Intel(R) Core(TM) i7-1370P
+BenchmarkRealistic_Noop-20                      	     201	  16093088 ns/op	1042.51 MB/s	50274407 B/op	       4 allocs/op
+BenchmarkRealistic_Chrome_Async-20              	      36	  96637308 ns/op	 173.61 MB/s	49019993 B/op	  157717 allocs/op
+BenchmarkRealistic_Chrome_Async_Coalesced-20    	      36	  93504141 ns/op	 179.43 MB/s	47707635 B/op	  156064 allocs/op
+#
+# Headline deltas (chrome async):
+#   allocs/op: 186570 → 157717  (−15.4 %, ~−29k allocs)
+#   bytes/op:   69068868 → 49019993  (−29.0 %, ~−20 MB/payload)
+#   MB/s:        172.29 → 173.61  (+0.8 %)
+#
+# % overhead vs Noop after this change:
+#   1 - 173.61 / 1042.51 ≈ 83.4 % overhead.
+#
+# The throughput target from the original ADR (≤30 % overhead) is NOT met
+# by this change alone. Allocation profile (go tool pprof -alloc_objects)
+# now shows the dominant cost has shifted to the receiver side:
+#   74 % MorphedConn.readShaped + Unwrap (per-frame `make([]byte, totalPayload)`,
+#       Unwrap output buffer);
+#   21 % releasePacketBuf book-keeping in the writev-pacer goroutine;
+#    2 % distShaper.Wrap path  (was the dominant cost on origin/main).
+#
+# Next steps to close the gap (out of scope for this PR / task cg5):
+#   - pool readShaped's per-frame payload buffer (mirror of this change
+#     on the receive side);
+#   - rework Unwrap to write directly into the caller's destination buffer
+#     instead of allocating an intermediate output slice.


### PR DESCRIPTION
## Summary

- Adds a `Release([][]byte)` method to `shaper.Shaper`. `NoopShaper.Release`
  is a no-op (it never allocates); the dist-shaper preset implementation
  pools its per-frame `[]byte` buffers via `sync.Pool` and returns them
  on `Release`.
- Strategy layer (`MorphedConn.writeShaped`) calls `mc.shaper.Release(frames)`
  after the for-loop has copied each frame into the bucketed packet pool
  via `buildFrame`. Wrap buffers are fully consumed inside `writeShaped`,
  so this is safe without any pacer-side coordination.
- Eliminates ~28k per-frame `make([]byte, target)` allocations on the
  chrome benchmark. Throughput is essentially flat because the receiver
  side (`readShaped` + `Unwrap`) is now the dominant alloc source —
  next task.

Refs beads `tiredvpn-oss-cg5`.

## Numbers (BenchmarkRealistic_Chrome_Async, loopback TCP, 16 MiB payload)

| metric        | origin/main | this PR    | delta      |
|---------------|-------------|------------|------------|
| MB/s          | 172.29      | 173.61     | +0.8 %     |
| allocs/op     | 186 570     | 157 717    | −15.4 %    |
| bytes/op      | 69 068 868  | 49 019 993 | −29.0 %    |
| % vs Noop MB/s| 16.5 %      | 16.7 %     | flat       |

Receiver-side allocs (`readShaped` per-frame `make`, `Unwrap` output
buffer) account for ~74 % of remaining allocs per `go tool pprof
-alloc_objects` and dominate the throughput envelope. They will be
addressed in a follow-up task.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test -race ./internal/shaper/... ./internal/strategy/... ./internal/integration/...` — 309 passed, 1 skipped
- [x] `golangci-lint run ./internal/shaper/...` — clean
- [x] `go test -cover ./internal/shaper/presets/` — 92.3 % (≥ 80 % bar)
- [x] New unit coverage:
      `TestNoopShaper_Release_NoPanic`,
      `TestDistShaper_Release_Roundtrip`,
      `TestDistShaper_Release_MismatchedFramesIgnored`,
      `TestDistShaper_Release_NilAndEmpty`,
      `TestDistShaper_Wrap_ReusesPooledBuffers`,
      `TestDistShaper_EmptyPayload_Roundtrip`,
      `TestMorphedConn_WithShaper_ReleasesWrapBuffers`.
- [x] BenchmarkRealistic_* re-run; numbers captured in
      `internal/strategy/testdata/shaper_overhead_wrap_pooled.txt`.