### PR TITLE
perf(shaper): eliminate receiver-side allocations in readShaped + Unwrap

### DIFF
--- a/internal/shaper/presets/dist_shaper.go
+++ b/internal/shaper/presets/dist_shaper.go
@@ -2,12 +2,17 @@ package presets
 
 import (
 	"encoding/binary"
+	"errors"
 	"sync"
 	"time"
 
 	"github.com/tiredvpn/tiredvpn/internal/shaper"
 	"github.com/tiredvpn/tiredvpn/internal/shaper/dist"
 )
+
+// errUnwrapBufferTooSmall is returned by UnwrapInto when the destination
+// buffer cannot fit the unwrapped payload.
+var errUnwrapBufferTooSmall = errors.New("dist_shaper: UnwrapInto destination too small")
 
 // wrapBufPool reuses per-frame byte slices produced by distShaper.Wrap.
 // Buffers are sized at MTU (1500) so any frame up to MTU shares a single
@@ -258,4 +263,31 @@ func (d *distShaper) Unwrap(frames [][]byte) []byte {
 		out = append(out, f[frameHeaderLen:frameHeaderLen+n]...)
 	}
 	return out
+}
+
+// UnwrapInto writes the unwrapped payload from frames into out and returns the
+// number of bytes written. Callers may pass an out slice with capacity ≥ the
+// expected payload length (an MTU-sized scratch buffer is sufficient for the
+// single-frame case used by the receiver hot path). Returns an error only if
+// the destination buffer is too small.
+func (d *distShaper) UnwrapInto(out []byte, frames [][]byte) (int, error) {
+	if len(frames) == 0 {
+		return 0, nil
+	}
+	pos := 0
+	for _, f := range frames {
+		if len(f) < frameHeaderLen {
+			continue
+		}
+		n := int(binary.LittleEndian.Uint32(f[:frameHeaderLen]))
+		if n > len(f)-frameHeaderLen {
+			n = len(f) - frameHeaderLen
+		}
+		if pos+n > len(out) {
+			return pos, errUnwrapBufferTooSmall
+		}
+		copy(out[pos:pos+n], f[frameHeaderLen:frameHeaderLen+n])
+		pos += n
+	}
+	return pos, nil
 }

--- a/internal/shaper/presets/dist_shaper_test.go
+++ b/internal/shaper/presets/dist_shaper_test.go
@@ -88,6 +88,60 @@ func TestDistShaper_Wrap_ReusesPooledBuffers(t *testing.T) {
 	}
 }
 
+// TestDistShaper_UnwrapInto_Roundtrip verifies the in-place fast path produces
+// the same bytes as the allocating Unwrap and reports the correct length.
+func TestDistShaper_UnwrapInto_Roundtrip(t *testing.T) {
+	d := newTestDistShaper(300)
+	payload := bytes.Repeat([]byte("UVW-"), 256)
+
+	frames := d.Wrap(payload)
+	defer d.Release(frames)
+
+	out := make([]byte, len(payload))
+	n, err := d.UnwrapInto(out, frames)
+	if err != nil {
+		t.Fatalf("UnwrapInto: %v", err)
+	}
+	if n != len(payload) {
+		t.Fatalf("UnwrapInto n=%d, want %d", n, len(payload))
+	}
+	if !bytes.Equal(out[:n], payload) {
+		t.Fatalf("UnwrapInto bytes mismatch")
+	}
+}
+
+// TestDistShaper_UnwrapInto_BufferTooSmall: returns an error rather than
+// silently truncating; the bytes that did fit are still written.
+func TestDistShaper_UnwrapInto_BufferTooSmall(t *testing.T) {
+	d := newTestDistShaper(300)
+	payload := bytes.Repeat([]byte{0x55}, 1024)
+	frames := d.Wrap(payload)
+	defer d.Release(frames)
+
+	tiny := make([]byte, 100)
+	n, err := d.UnwrapInto(tiny, frames)
+	if err == nil {
+		t.Fatalf("UnwrapInto with tiny buffer: expected error, got n=%d", n)
+	}
+}
+
+// TestDistShaper_UnwrapInto_NoAllocs verifies the fast path is allocation-free
+// once the destination buffer is owned by the caller.
+func TestDistShaper_UnwrapInto_NoAllocs(t *testing.T) {
+	d := newTestDistShaper(300)
+	payload := bytes.Repeat([]byte("Z"), 600)
+	frames := d.Wrap(payload)
+	defer d.Release(frames)
+
+	out := make([]byte, 1500)
+	allocs := testing.AllocsPerRun(50, func() {
+		_, _ = d.UnwrapInto(out, frames)
+	})
+	if allocs > 0 {
+		t.Fatalf("UnwrapInto allocs/op = %.1f, want 0", allocs)
+	}
+}
+
 // TestDistShaper_EmptyPayload_Roundtrip: empty payload still produces a
 // header-only frame that Unwrap turns back into nothing.
 func TestDistShaper_EmptyPayload_Roundtrip(t *testing.T) {

--- a/internal/strategy/morph.go
+++ b/internal/strategy/morph.go
@@ -365,6 +365,17 @@ type MorphedConn struct {
 	// Read buffer for partial reads
 	readBuf []byte
 
+	// readScratchBuf is a single-goroutine scratch buffer used by readShaped
+	// to absorb padding bytes from dummy frames without per-frame allocation.
+	// Lazy-initialised; sized at MTU. readShaped is invoked from a single
+	// reader goroutine per connection, so this is race-free by construction.
+	readScratchBuf []byte
+
+	// readUnwrapBuf backs the in-place UnwrapInto fast path; reused per
+	// frame so Unwrap on the receiver side does not allocate. Same single-
+	// goroutine invariant as readScratchBuf.
+	readUnwrapBuf []byte
+
 	// Statistics tracking
 	bytesSent   int64
 	bytesRecv   int64

--- a/internal/strategy/morph_shaper.go
+++ b/internal/strategy/morph_shaper.go
@@ -76,7 +76,8 @@ func (mc *MorphedConn) writeShaped(p []byte) (int, error) {
 // frame matches the documented streaming contract: NoopShaper is identity,
 // distribution-driven shapers strip per-frame padding/markers as needed.
 func (mc *MorphedConn) readShaped(p []byte) (int, error) {
-	header := make([]byte, morphHeaderLen)
+	var headerArr [morphHeaderLen]byte
+	header := headerArr[:]
 	if _, err := io.ReadFull(mc.Conn, header); err != nil {
 		return 0, err
 	}
@@ -86,7 +87,7 @@ func (mc *MorphedConn) readShaped(p []byte) (int, error) {
 	// signal the TUN layer with the 4-zero-byte sentinel.
 	if dataLen == 0 {
 		if paddingLen > 0 {
-			discard := make([]byte, paddingLen)
+			discard := mc.acquireScratch(paddingLen)
 			if _, err := io.ReadFull(mc.Conn, discard); err != nil {
 				return 0, err
 			}
@@ -99,25 +100,74 @@ func (mc *MorphedConn) readShaped(p []byte) (int, error) {
 	}
 
 	totalPayload := dataLen + paddingLen
-	payload := make([]byte, totalPayload)
+	payload, bucket := acquirePacketBuf(totalPayload)
 	n, err := io.ReadFull(mc.Conn, payload)
 	if err != nil {
+		releasePacketBuf(payload, bucket)
 		return 0, err
 	}
 	frame := payload[:dataLen]
-	data := mc.shaper.Unwrap([][]byte{frame})
 
 	mc.packetsRecv++
 	mc.bytesRecv += int64(n)
 
-	copied := copy(p, data)
-	if copied < len(data) {
-		mc.readBuf = append(mc.readBuf, data[copied:]...)
+	// Fast path for shapers that support in-place unwrap into a caller-
+	// provided buffer; falls back to allocating Unwrap otherwise.
+	var copied int
+	if u, ok := mc.shaper.(unwrapInto); ok {
+		// distShaper.UnwrapInto: writes payload into mc's readUnwrapBuf
+		// (lazy MTU-sized scratch) so we don't pay per-frame Unwrap allocs.
+		if mc.readUnwrapBuf == nil {
+			mc.readUnwrapBuf = make([]byte, defaultReadScratchSize)
+		}
+		nn, uerr := u.UnwrapInto(mc.readUnwrapBuf[:cap(mc.readUnwrapBuf)], [][]byte{frame})
+		if uerr != nil {
+			releasePacketBuf(payload, bucket)
+			return 0, uerr
+		}
+		data := mc.readUnwrapBuf[:nn]
+		copied = copy(p, data)
+		if copied < len(data) {
+			mc.readBuf = append(mc.readBuf, data[copied:]...)
+		}
+	} else {
+		data := mc.shaper.Unwrap([][]byte{frame})
+		copied = copy(p, data)
+		if copied < len(data) {
+			mc.readBuf = append(mc.readBuf, data[copied:]...)
+		}
 	}
+	releasePacketBuf(payload, bucket)
 	if mc.rateLimiter != nil {
 		mc.rateLimiter.Wait(copied)
 	}
 	return copied, nil
+}
+
+// defaultReadScratchSize is the lazy-allocated per-conn scratch buffer for
+// padding discard and Unwrap output. Sized at MTU; readShaped is single-
+// goroutine on the read side, so no synchronisation is needed.
+const defaultReadScratchSize = 1500
+
+// acquireScratch returns a slice of length n backed by mc.readScratchBuf.
+// If n exceeds the existing capacity, the buffer is grown (rare: only when
+// paddingLen > MTU, which the wire format does not normally produce).
+func (mc *MorphedConn) acquireScratch(n int) []byte {
+	want := n
+	if want < defaultReadScratchSize {
+		want = defaultReadScratchSize
+	}
+	if cap(mc.readScratchBuf) < want {
+		mc.readScratchBuf = make([]byte, want)
+	}
+	return mc.readScratchBuf[:n]
+}
+
+// unwrapInto is an optional fast-path interface implemented by shapers that
+// can decode frames directly into a caller-provided buffer, avoiding the
+// per-frame allocation of the standard Unwrap method.
+type unwrapInto interface {
+	UnwrapInto(out []byte, frames [][]byte) (int, error)
 }
 
 // ShaperFromConfig builds a Shaper for MorphedConn from the parsed TOML

--- a/internal/strategy/morph_shaper_alloc_test.go
+++ b/internal/strategy/morph_shaper_alloc_test.go
@@ -1,0 +1,148 @@
+package strategy
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/tiredvpn/tiredvpn/internal/shaper/presets"
+)
+
+// scriptedConn replays a fixed byte stream for Read; Write is a sink. Unlike
+// fakeConn it implements net.Conn and never returns io.EOF until the entire
+// scripted buffer has been drained, which is what readShaped needs across
+// repeated Read calls.
+type scriptedConn struct {
+	mu      sync.Mutex
+	rd      *bytes.Reader
+	written bytes.Buffer
+}
+
+func newScriptedConn(in []byte) *scriptedConn {
+	return &scriptedConn{rd: bytes.NewReader(in)}
+}
+
+func (s *scriptedConn) Read(b []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.rd.Read(b)
+}
+func (s *scriptedConn) Write(b []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.written.Write(b)
+}
+func (s *scriptedConn) Close() error                       { return nil }
+func (s *scriptedConn) LocalAddr() net.Addr                { return &net.IPAddr{} }
+func (s *scriptedConn) RemoteAddr() net.Addr               { return &net.IPAddr{} }
+func (s *scriptedConn) SetDeadline(t time.Time) error      { return nil }
+func (s *scriptedConn) SetReadDeadline(t time.Time) error  { return nil }
+func (s *scriptedConn) SetWriteDeadline(t time.Time) error { return nil }
+
+// buildShapedFrames produces N back-to-back wire frames suitable for feeding
+// into MorphedConn.Read with a chrome-style preset. Each frame carries a 4-byte
+// distShaper header + payload; the morph framing wrapper is added on top.
+func buildShapedFrames(t *testing.T, payloads [][]byte, padding int) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	for _, p := range payloads {
+		// distShaper-style inner frame: [len:4][payload:N]
+		inner := make([]byte, 4+len(p))
+		binary.LittleEndian.PutUint32(inner[:4], uint32(len(p)))
+		copy(inner[4:], p)
+
+		// Morph framing: [dataLen:4 BE][paddingLen:2 BE]
+		var hdr [morphHeaderLen]byte
+		binary.BigEndian.PutUint32(hdr[0:4], uint32(len(inner)))
+		binary.BigEndian.PutUint16(hdr[4:6], uint16(padding))
+		buf.Write(hdr[:])
+		buf.Write(inner)
+		if padding > 0 {
+			buf.Write(make([]byte, padding))
+		}
+	}
+	return buf.Bytes()
+}
+
+// TestReadShaped_HeaderStackAlloc verifies the per-frame header buffer no
+// longer escapes to the heap. With pooled payload + UnwrapInto we expect a
+// constant-bounded allocs/op across many reads.
+func TestReadShaped_HeaderStackAlloc(t *testing.T) {
+	payload := bytes.Repeat([]byte("A"), 64)
+	frame := buildShapedFrames(t, [][]byte{payload}, 0)
+
+	// Concatenate many frames so AllocsPerRun has plenty of iterations.
+	const reps = 64
+	stream := bytes.Repeat(frame, reps)
+
+	sc := newScriptedConn(stream)
+	d, err := presets.ByName(presets.PresetChromeBrowsing, 1)
+	if err != nil {
+		t.Fatalf("preset: %v", err)
+	}
+	mc := &MorphedConn{Conn: sc, shaper: d}
+
+	dst := make([]byte, 1500)
+	// Warm up the pools.
+	for range 4 {
+		if _, err := mc.readShaped(dst); err != nil {
+			t.Fatalf("warmup readShaped: %v", err)
+		}
+	}
+
+	// Now measure across the remaining frames.
+	allocs := testing.AllocsPerRun(20, func() {
+		_, _ = mc.readShaped(dst)
+	})
+	// Pooled payload + UnwrapInto + scratch buf reuse should keep allocs/op
+	// bounded by sync.Pool's internal bookkeeping under -race. 4 is generous.
+	if allocs > 4 {
+		t.Fatalf("readShaped allocs/op = %.1f, want ≤ 4", allocs)
+	}
+}
+
+// TestReadShaped_DiscardBufferReused: reading two consecutive dummy frames
+// (dataLen=0) should reuse the per-conn discard scratch buffer rather than
+// allocate a fresh `make([]byte, paddingLen)` each time.
+func TestReadShaped_DiscardBufferReused(t *testing.T) {
+	// Dummy frame: dataLen=0, paddingLen=200. Followed by a real keepalive
+	// payload would yield 4 zero-bytes; for this test we just measure the
+	// padding read path's allocation profile.
+	var frame bytes.Buffer
+	var hdr [morphHeaderLen]byte
+	binary.BigEndian.PutUint32(hdr[0:4], 0)   // dataLen=0
+	binary.BigEndian.PutUint16(hdr[4:6], 200) // paddingLen=200
+	frame.Write(hdr[:])
+	frame.Write(make([]byte, 200))
+
+	const reps = 32
+	stream := bytes.Repeat(frame.Bytes(), reps)
+
+	sc := newScriptedConn(stream)
+	d, err := presets.ByName(presets.PresetChromeBrowsing, 1)
+	if err != nil {
+		t.Fatalf("preset: %v", err)
+	}
+	mc := &MorphedConn{Conn: sc, shaper: d}
+
+	dst := make([]byte, 64)
+	// Warm scratch buf.
+	if _, err := mc.readShaped(dst); err != nil {
+		t.Fatalf("warmup: %v", err)
+	}
+
+	prevPtr := &mc.readScratchBuf[0]
+	for range reps - 1 {
+		if _, err := mc.readShaped(dst); err != nil && err != io.EOF {
+			t.Fatalf("readShaped: %v", err)
+		}
+		if &mc.readScratchBuf[0] != prevPtr {
+			t.Fatalf("readScratchBuf reallocated between reads (data race or growth?)")
+		}
+	}
+}
+

--- a/internal/strategy/testdata/shaper_overhead_receiver.txt
+++ b/internal/strategy/testdata/shaper_overhead_receiver.txt
@@ -1,0 +1,78 @@
+# Shaper overhead: receiver-side allocations eliminated (issue tiredvpn-oss-8nl).
+#
+# Measurement is BenchmarkRealistic_* over loopback TCP, 16 MiB payloads,
+# Go 1.23+, -benchtime=3s.
+#
+# Hardware: 13th Gen Intel(R) Core(TM) i7-1370P, linux/amd64, 20 logical CPUs.
+#
+# This run isolates the effect of removing per-frame allocations on the
+# receiver side:
+#  - readShaped header buffer is now a 6-byte stack array (was make([]byte, 6)).
+#  - readShaped padding-discard buffer is a per-MorphedConn scratch slice,
+#    lazily MTU-sized, reused across frames (was make([]byte, paddingLen)).
+#  - readShaped payload buffer is acquired from the bucketed packet pool used
+#    by the legacy noop path (was make([]byte, totalPayload)).
+#  - distShaper exposes a new UnwrapInto(out, frames) fast path that decodes
+#    directly into a caller-provided buffer; readShaped uses it via type
+#    assertion, falling back to allocating Unwrap for shapers that don't
+#    implement it (NoopShaper still works since the noop branch never enters
+#    readShaped — isNoopShaper short-circuits in MorphedConn.Read).
+#
+# Baseline (post-PR #25, wrap-pooled):
+#   BenchmarkRealistic_Noop-20            201   16093088 ns/op  1042.51 MB/s    50274407 B/op       4 allocs/op
+#   BenchmarkRealistic_Chrome_Async-20     36   96637308 ns/op   173.61 MB/s    49019993 B/op  157717 allocs/op
+#   BenchmarkRealistic_Chrome_Async_Coal.- 36   93504141 ns/op   179.43 MB/s    47707635 B/op  156064 allocs/op
+#
+# After this change (receiver-no-alloc):
+goos: linux
+goarch: amd64
+pkg: github.com/tiredvpn/tiredvpn/internal/strategy
+cpu: 13th Gen Intel(R) Core(TM) i7-1370P
+BenchmarkRealistic_Noop-20                      	     210	  16397710 ns/op	1023.14 MB/s	50274405 B/op	       4 allocs/op
+BenchmarkRealistic_Chrome_Async-20              	      39	  87547584 ns/op	 191.64 MB/s	 5819041 B/op	  127059 allocs/op
+BenchmarkRealistic_Chrome_Async_Coalesced-20    	      45	  87676801 ns/op	 191.35 MB/s	 4542666 B/op	  125576 allocs/op
+#
+# Headline deltas (chrome async):
+#   bytes/op:  49019993 → 5819041   (−88.1 %, ~8.4× reduction)
+#   allocs/op:    157717 → 127059   (−19.4 %, ~−30k allocs)
+#   MB/s:         173.61 → 191.64   (+10.4 %)
+#   ns/op:      96637308 → 87547584 (−9.4 %)
+#
+# % overhead vs Noop after this change:
+#   1 - 191.64 / 1023.14 ≈ 81.3 % overhead (was 83.4 %).
+#
+# Targets vs achieved (issue 8nl acceptance bar):
+#   chrome throughput ≥ 350 MB/s          → NOT met (191 MB/s).
+#   allocs/op ≤ 80k                       → NOT met (127k).
+#   bytes/op reduction                    → vastly exceeded (8.4× reduction).
+#
+# Where remaining allocations live (go tool pprof -alloc_objects after change):
+#   - 4× allocs/frame (≈ 28k frames × 4.5 = 127k) live in:
+#     1. writePacer enqueue path: pacedFrame{packet, bucket} struct heap-
+#        escapes via channel send (~28k allocs/run).
+#     2. distShaper.Wrap on the sender: even with the wrap-pool, each frame
+#        produces one *[]byte handle slot in the wrapHandles slice when it
+#        grows past the previous high-water mark (~28k allocs first run,
+#        amortised after).
+#     3. mc.readBuf = append(mc.readBuf, ...) when the destination Read
+#        buffer is smaller than the frame payload — this is rare with the
+#        64KiB drain buffer in the bench but still measurable.
+#     4. sync.Pool internal per-P bookkeeping under -race adds a small
+#        constant per acquire/release pair.
+#
+# Why throughput didn't reach the 350 MB/s target despite the alloc cleanup:
+#   The receiver allocation profile is no longer the dominant cost. CPU is
+#   now spent on:
+#     - pacer goroutine scheduling + channel ops (~30 % of receiver-side time);
+#     - writev syscall + io.ReadFull on the loopback socket;
+#     - per-frame distribution sampling (NextPacketSize) on the sender.
+#   The next throughput lever is reducing the goroutine handoff cost (e.g.
+#   merging the pacer into the writer goroutine when burst budget is empty).
+#   That is out of scope for this task and tracked separately.
+#
+# Test plan executed:
+#   - go build ./... — clean.
+#   - go test -race ./... — 634 tests pass.
+#   - golangci-lint run ./internal/shaper/... — no issues found.
+#   - golangci-lint run ./internal/strategy/... — no NEW issues from this
+#     change (pre-existing errcheck/unused warnings on unrelated files).


### PR DESCRIPTION
## Summary

Removes the per-frame `make([]byte, ...)` calls left on the receive path after PR #25 (sender wrap-pool):

- `readShaped` header is a 6-byte stack array.
- `readShaped` padding-discard uses a per-`MorphedConn` MTU-sized scratch slice, reused across frames.
- `readShaped` payload buffer comes from the bucketed `acquirePacketBuf` pool already in use by the legacy noop path.
- `distShaper.UnwrapInto(out, frames)` writes the unwrapped payload into a caller-provided buffer; `readShaped` uses it via type assertion with a fallback to the allocating `Unwrap`.

Wire format and the `shaper.Shaper` interface are unchanged. `NoopShaper` is untouched (its noop branch never enters `readShaped`).

Tracks beads `tiredvpn-oss-8nl`.

## Bench (chrome async, 16 MiB payload, 13th gen i7-1370P, -benchtime=3s)

| metric | before (wrap-pooled) | after | delta |
|---|---|---|---|
| MB/s | 173.61 | 191.64 | +10.4% |
| ns/op | 96637308 | 87547584 | -9.4% |
| bytes/op | 49019993 | 5819041 | -88.1% (8.4x) |
| allocs/op | 157717 | 127059 | -19.4% |
| overhead vs Noop | 83.4% | 81.3% | |

The 350 MB/s throughput target from `8nl` is **not** reached by this change alone. Pprof shows the remaining cost is in pacer-goroutine scheduling/channel ops and per-frame distribution sampling, not allocations; tracked separately. Bytes/op collapse is the primary win for long-lived connections under GC pressure.

Full numbers + context in `internal/strategy/testdata/shaper_overhead_receiver.txt`.

## Test plan

- [x] `go build ./...`
- [x] `go test -race ./...` (634 tests pass)
- [x] `golangci-lint run ./internal/shaper/...` clean
- [x] No new lint issues from `./internal/strategy/...`
- [x] `TestReadShaped_HeaderStackAlloc` — allocs/op ≤ 4 in the readShaped hot path
- [x] `TestReadShaped_DiscardBufferReused` — scratch buf pointer stable across frames
- [x] `TestDistShaper_UnwrapInto_Roundtrip` / `_BufferTooSmall` / `_NoAllocs`
- [x] Coverage `internal/shaper/presets`: 91.5%