### PR TITLE
feat(configs): example client/server TOML configs

### DIFF
--- a/configs/client.example.toml
+++ b/configs/client.example.toml
@@ -1,0 +1,73 @@
+# tiredvpn client configuration
+# Run: tiredvpn --config /etc/tiredvpn/client.toml
+#
+# CLI flags override these values. Unknown fields are rejected (strict TOML).
+
+[server]
+# Upstream tiredvpn endpoint to connect to.
+address = "vpn.example.org"
+port = 443
+
+[strategy]
+# TLS-mimicry transport. Options: reality, grpc, morph, ...
+mode = "reality"
+
+# Optional strategy-specific options (free-form key/value).
+# [strategy.options]
+# service = "google.firestore.v1.Firestore"
+
+[shaper]
+# Behavioural traffic shaper. Use a named preset OR a [shaper.custom] block,
+# but not both. Presets are resolved by the shaper registry.
+preset = "chrome_browsing"
+
+# Optional ±N% jitter applied to distribution samples; range [0.0, 1.0).
+randomization_range = 0.1
+
+# Optional fixed seed for reproducible shaping. Omit for per-session entropy.
+# seed = 1234567890
+
+# --- Advanced: custom distributions (mutually exclusive with `preset`) ---
+# Comment out `preset` above before enabling [shaper.custom].
+#
+# [shaper.custom.packet_size]
+# type = "histogram"
+# [[shaper.custom.packet_size.histogram.bins]]
+# value = 64
+# weight = 0.2
+# [[shaper.custom.packet_size.histogram.bins]]
+# value = 1280
+# weight = 0.5
+# [[shaper.custom.packet_size.histogram.bins]]
+# value = 1500
+# weight = 0.3
+#
+# [shaper.custom.inter_arrival]
+# type = "lognormal"
+# [shaper.custom.inter_arrival.lognormal]
+# mu = -4.0
+# sigma = 1.2
+
+[tls]
+# SNI presented to the upstream — should match the cover hostname.
+server_name = "www.cloudflare.com"
+
+# uTLS fingerprint label. See strategy docs for supported values.
+fingerprint = "chrome_120"
+
+# ALPN protocols, in preference order.
+alpn = ["h2", "http/1.1"]
+
+# Pin a custom CA bundle (PEM). Omit to use system roots.
+# ca_cert = "/etc/tiredvpn/ca.pem"
+
+# Disable cert verification — for local testing only. NEVER set in production.
+# insecure_skip_verify = false
+
+[logging]
+# trace, debug, info, warn, error
+level = "info"
+# Output format: text or json.
+format = "json"
+# Destination: stderr, stdout, or a file path.
+output = "stderr"

--- a/configs/server.example.toml
+++ b/configs/server.example.toml
@@ -1,0 +1,48 @@
+# tiredvpn server configuration
+# Run: tiredvpn-server --config /etc/tiredvpn/server.toml
+#
+# Unknown fields are rejected (strict TOML) — typos surface immediately.
+
+[listen]
+# Public-facing listen socket. 0.0.0.0 = all IPv4 interfaces.
+address = "0.0.0.0"
+port = 443
+
+[strategy]
+# TLS-mimicry transport. Must match what clients are configured to use.
+mode = "reality"
+
+# [strategy.options]
+# free-form strategy-specific options
+
+# Server-side shaping is opt-in; by default the server is shaper-agnostic
+# and follows whatever the client negotiates.
+#
+# [shaper]
+# preset = "chrome_browsing"
+# randomization_range = 0.1
+
+[tls]
+# PEM-encoded server certificate and private key.
+cert_file = "/etc/tiredvpn/server.crt"
+key_file  = "/etc/tiredvpn/server.key"
+
+# ALPN advertised by the listener.
+alpn = ["h2", "http/1.1"]
+
+# Optional mTLS — require clients to present a cert signed by this CA.
+# client_ca_file = "/etc/tiredvpn/clients.pem"
+
+[auth]
+# Authentication mode. Typical: "token".
+mode = "token"
+
+# Either inline `tokens` or `tokens_file` (one per line). Use the file form
+# in production so secrets aren't baked into the config.
+tokens_file = "/etc/tiredvpn/tokens.txt"
+# tokens = ["replace-me-with-a-real-token"]
+
+[logging]
+level = "info"
+format = "json"
+output = "/var/log/tiredvpn.log"

--- a/internal/config/toml/example_test.go
+++ b/internal/config/toml/example_test.go
@@ -1,0 +1,19 @@
+package toml
+
+import "testing"
+
+// TestExampleConfigs_LoadCleanly is a regression check for the user-facing
+// configs/*.example.toml files. If somebody adds a required field or renames
+// a key without updating the examples, this test fails first.
+func TestExampleConfigs_LoadCleanly(t *testing.T) {
+	t.Run("client", func(t *testing.T) {
+		if _, err := LoadClient("../../../configs/client.example.toml"); err != nil {
+			t.Fatalf("client example: %v", err)
+		}
+	})
+	t.Run("server", func(t *testing.T) {
+		if _, err := LoadServer("../../../configs/server.example.toml"); err != nil {
+			t.Fatalf("server example: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Adds `configs/client.example.toml` and `configs/server.example.toml` — fully commented templates users can copy into `/etc/tiredvpn/`.
- Field names match the strict TOML schema in `internal/config/toml`; commented-out advanced blocks (`[shaper.custom]`, etc.) parse cleanly when uncommented.
- Adds `TestExampleConfigs_LoadCleanly` regression check so future schema changes that break the examples fail fast in CI.

Refs: beads `tiredvpn-oss-nu5` (Phase 3 of the documentation/onboarding plan).

## Test plan
- [x] `go build ./...`
- [x] `go test -race ./internal/config/...`
- [x] Manually verified the commented `[shaper.custom]` variant loads via `LoadClient` after uncommenting.