### PR TITLE
feat(cmd): wire TOML config + version via ldflags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
           GOOS: linux
           GOARCH: amd64
         run: |
-          go build -ldflags="-s -w" -o tiredvpn-linux-amd64 ./cmd/tiredvpn/
+          go build -ldflags="-s -w -X main.version=${GITHUB_REF_NAME#v}" -o tiredvpn-linux-amd64 ./cmd/tiredvpn/
           tar -czf tiredvpn-linux-amd64.tar.gz tiredvpn-linux-amd64
 
       - name: Build linux/arm64
@@ -94,7 +94,7 @@ jobs:
           GOOS: linux
           GOARCH: arm64
         run: |
-          go build -ldflags="-s -w" -o tiredvpn-linux-arm64 ./cmd/tiredvpn/
+          go build -ldflags="-s -w -X main.version=${GITHUB_REF_NAME#v}" -o tiredvpn-linux-arm64 ./cmd/tiredvpn/
           tar -czf tiredvpn-linux-arm64.tar.gz tiredvpn-linux-arm64
 
       - name: Generate checksums

--- a/cmd/tiredvpn/config.go
+++ b/cmd/tiredvpn/config.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"net"
+	"strconv"
+
+	"github.com/tiredvpn/tiredvpn/internal/client"
+	tomlcfg "github.com/tiredvpn/tiredvpn/internal/config/toml"
+	"github.com/tiredvpn/tiredvpn/internal/log"
+	"github.com/tiredvpn/tiredvpn/internal/server"
+	"github.com/tiredvpn/tiredvpn/internal/shaper/presets"
+)
+
+// applyClientTOMLConfig optionally loads a TOML config from path and overlays
+// it onto cfg. If path is empty, this is a no-op (legacy CLI-only path is
+// preserved). When path is non-empty, fields present in the TOML are applied
+// to cfg unless they were also explicitly set on the CLI (CLI > TOML > defaults
+// — this precedence is enforced inside ResolveClient via flag.Visit).
+//
+// Mapped fields:
+//   - server.address + server.port → cfg.ServerAddr (joined host:port)
+//   - strategy.mode                → cfg.StrategyName
+//   - shaper.{preset|custom}       → cfg.Shaper (built via presets.FromConfig)
+//   - logging.level                → log.SetDebug when "debug"
+//
+// Unmapped TOML fields (TLS server_name/fingerprint/ALPN, strategy.options,
+// logging.format/output) are accepted by the schema but not yet wired into the
+// runtime client.Config — these are gaps tracked separately and ignored here.
+func applyClientTOMLConfig(cfg *client.Config, path string, fs *flag.FlagSet) error {
+	if path == "" {
+		return nil
+	}
+	tcfg, err := tomlcfg.ResolveClient(path, fs)
+	if err != nil {
+		return fmt.Errorf("config %s: %w", path, err)
+	}
+
+	cfg.ServerAddr = joinHostPort(tcfg.Server.Address, tcfg.Server.Port)
+	if tcfg.Strategy.Mode != "" {
+		cfg.StrategyName = tcfg.Strategy.Mode
+	}
+	if tcfg.Logging.Level == "debug" {
+		log.SetDebug(true)
+		cfg.Debug = true
+	}
+
+	if tcfg.Shaper != nil && (tcfg.Shaper.Preset != "" || tcfg.Shaper.Custom != nil) {
+		sh, err := presets.FromConfig(*tcfg.Shaper)
+		if err != nil {
+			return fmt.Errorf("shaper: %w", err)
+		}
+		cfg.Shaper = sh
+	}
+	return nil
+}
+
+// applyServerTOMLConfig is the server-side counterpart of applyClientTOMLConfig.
+//
+// Mapped fields:
+//   - listen.address + listen.port → cfg.ListenAddr
+//   - tls.cert_file                → cfg.CertFile
+//   - tls.key_file                 → cfg.KeyFile
+//   - logging.level                → log.SetDebug when "debug"
+//   - shaper.*                     → cfg.Shaper (reserved; server pipeline does
+//     not yet consume it — see server.Config.Shaper)
+//
+// Gaps: strategy.mode, auth.{mode,tokens,tokens_file}, tls.alpn,
+// tls.client_ca_file are not yet wired into server.Config.
+func applyServerTOMLConfig(cfg *server.Config, path string, fs *flag.FlagSet) error {
+	if path == "" {
+		return nil
+	}
+	tcfg, err := tomlcfg.ResolveServer(path, fs)
+	if err != nil {
+		return fmt.Errorf("config %s: %w", path, err)
+	}
+
+	cfg.ListenAddr = joinHostPort(tcfg.Listen.Address, tcfg.Listen.Port)
+	if tcfg.TLS.CertFile != "" {
+		cfg.CertFile = tcfg.TLS.CertFile
+	}
+	if tcfg.TLS.KeyFile != "" {
+		cfg.KeyFile = tcfg.TLS.KeyFile
+	}
+	if tcfg.Logging.Level == "debug" {
+		log.SetDebug(true)
+		cfg.Debug = true
+	}
+
+	if tcfg.Shaper != nil && (tcfg.Shaper.Preset != "" || tcfg.Shaper.Custom != nil) {
+		sh, err := presets.FromConfig(*tcfg.Shaper)
+		if err != nil {
+			return fmt.Errorf("shaper: %w", err)
+		}
+		cfg.Shaper = sh
+	}
+	return nil
+}
+
+// joinHostPort builds a "host:port" string. Empty host yields ":port" so that
+// listen addresses like ":443" round-trip through the TOML schema cleanly.
+func joinHostPort(host string, port int) string {
+	return net.JoinHostPort(host, strconv.Itoa(port))
+}

--- a/cmd/tiredvpn/main.go
+++ b/cmd/tiredvpn/main.go
@@ -21,8 +21,10 @@ import (
 	"github.com/tiredvpn/tiredvpn/internal/server"
 )
 
+// version is overridden at link time via -ldflags="-X main.version=$VERSION".
+// "dev" indicates an untagged local build.
 var (
-	version   = "1.0.1"
+	version   = "dev"
 	buildTime = "unknown"
 )
 
@@ -304,6 +306,8 @@ func runServer(args []string) {
 
 	cfg := &server.Config{}
 
+	configPath := fs.String("config", "", "Path to TOML config (overrides defaults; CLI flags override TOML)")
+
 	fs.StringVar(&cfg.ListenAddr, "listen", ":443", "Listen address")
 	fs.StringVar(&cfg.CertFile, "cert", "server.crt", "TLS certificate file")
 	fs.StringVar(&cfg.KeyFile, "key", "server.key", "TLS key file")
@@ -361,6 +365,11 @@ func runServer(args []string) {
 	cfg.IPPoolLeaseTime = *ipPoolLease
 	cfg.PortHopInterval = *portHopInterval
 
+	if err := applyServerTOMLConfig(cfg, *configPath, fs); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
 	// Start pprof server if enabled
 	if *pprofAddr != "" {
 		go func() {
@@ -382,6 +391,8 @@ func runClient(args []string) {
 	fs.Usage = printClientHelp
 
 	cfg := &client.Config{}
+
+	configPath := fs.String("config", "", "Path to TOML config (overrides defaults; CLI flags override TOML)")
 
 	fs.StringVar(&cfg.ListenAddr, "listen", "127.0.0.1:1080", "Local proxy address (SOCKS5/HTTP auto-detect)")
 	fs.StringVar(&cfg.HTTPListenAddr, "http-listen", "", "Separate HTTP proxy address (optional)")
@@ -464,6 +475,11 @@ func runClient(args []string) {
 	cfg.CircuitResetTime = *circuitResetTime
 	cfg.APIAddr = *apiAddr
 	cfg.PortHopInterval = *portHopInterval
+
+	if err := applyClientTOMLConfig(cfg, *configPath, fs); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
 
 	if *showVersion {
 		fmt.Printf("tiredvpn client %s (built %s)\n", version, buildTime)

--- a/cmd/tiredvpn/main_test.go
+++ b/cmd/tiredvpn/main_test.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"flag"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/tiredvpn/tiredvpn/internal/client"
+	"github.com/tiredvpn/tiredvpn/internal/server"
+)
+
+// TestVersion_DefaultIsDev guards against accidental hardcoding of a release
+// version in source. Release artifacts override this via -ldflags.
+func TestVersion_DefaultIsDev(t *testing.T) {
+	if version != "dev" {
+		t.Fatalf("default version = %q, want %q (release builds inject the tag via -ldflags)", version, "dev")
+	}
+}
+
+// TestApplyClientTOMLConfig_EmptyPath_NoOp verifies that omitting --config
+// leaves the existing CLI-derived client.Config untouched (legacy code path).
+func TestApplyClientTOMLConfig_EmptyPath_NoOp(t *testing.T) {
+	cfg := &client.Config{ServerAddr: "from-cli:1234", StrategyName: "morph"}
+	fs := flag.NewFlagSet("client", flag.ContinueOnError)
+
+	if err := applyClientTOMLConfig(cfg, "", fs); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.ServerAddr != "from-cli:1234" || cfg.StrategyName != "morph" {
+		t.Fatalf("config mutated by no-op call: %+v", cfg)
+	}
+	if cfg.Shaper != nil {
+		t.Fatalf("shaper unexpectedly set: %v", cfg.Shaper)
+	}
+}
+
+// TestApplyServerTOMLConfig_EmptyPath_NoOp mirrors the client test for server.
+func TestApplyServerTOMLConfig_EmptyPath_NoOp(t *testing.T) {
+	cfg := &server.Config{ListenAddr: ":443", CertFile: "x.crt", KeyFile: "x.key"}
+	fs := flag.NewFlagSet("server", flag.ContinueOnError)
+
+	if err := applyServerTOMLConfig(cfg, "", fs); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.ListenAddr != ":443" || cfg.CertFile != "x.crt" || cfg.KeyFile != "x.key" {
+		t.Fatalf("config mutated by no-op call: %+v", cfg)
+	}
+}
+
+// TestApplyClientTOMLConfig_AppliesFields verifies a minimal valid client
+// config is mapped onto runtime fields (server address, strategy mode,
+// shaper).
+func TestApplyClientTOMLConfig_AppliesFields(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "client.toml")
+	body := `
+[server]
+address = "vpn.example.org"
+port = 8443
+
+[strategy]
+mode = "morph"
+
+[shaper]
+preset = "youtube_streaming"
+
+[tls]
+
+[logging]
+level = "info"
+`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &client.Config{}
+	fs := flag.NewFlagSet("client", flag.ContinueOnError)
+	if err := applyClientTOMLConfig(cfg, path, fs); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if got, want := cfg.ServerAddr, "vpn.example.org:8443"; got != want {
+		t.Errorf("ServerAddr = %q, want %q", got, want)
+	}
+	if got, want := cfg.StrategyName, "morph"; got != want {
+		t.Errorf("StrategyName = %q, want %q", got, want)
+	}
+	if cfg.Shaper == nil {
+		t.Errorf("Shaper = nil, want non-nil for preset=youtube_streaming")
+	}
+}
+
+// TestApplyClientTOMLConfig_InvalidTOML surfaces a clear error path so the
+// CLI can fail-fast with a useful message.
+func TestApplyClientTOMLConfig_InvalidTOML(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "broken.toml")
+	if err := os.WriteFile(path, []byte("not = valid = toml = content\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &client.Config{}
+	fs := flag.NewFlagSet("client", flag.ContinueOnError)
+	if err := applyClientTOMLConfig(cfg, path, fs); err == nil {
+		t.Fatal("expected error for malformed TOML, got nil")
+	}
+}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -20,6 +20,7 @@ import (
 	"github.com/tiredvpn/tiredvpn/internal/log"
 	"github.com/tiredvpn/tiredvpn/internal/pool"
 	"github.com/tiredvpn/tiredvpn/internal/porthopping"
+	"github.com/tiredvpn/tiredvpn/internal/shaper"
 	"github.com/tiredvpn/tiredvpn/internal/strategy"
 	"github.com/tiredvpn/tiredvpn/internal/tun"
 )
@@ -103,6 +104,10 @@ type Config struct {
 	PortHopInterval    time.Duration // Hop interval (default: 60s)
 	PortHopStrategy    string        // Strategy: random, sequential, fibonacci
 	PortHopSeed        string        // Seed for deterministic hopping (optional)
+
+	// Shaper, when non-nil, is forwarded to the strategy manager and drives
+	// MorphedConn behaviour. Built from TOML [shaper] in cmd/tiredvpn.
+	Shaper shaper.Shaper
 }
 
 // Run starts the client with the given configuration
@@ -236,6 +241,7 @@ func buildManager(cfg *Config, secret string) (*strategy.Manager, error) {
 		PQServerKemPubB64:  cfg.PQServerKemPubB64,
 		AndroidMode:        cfg.AndroidMode,
 		PortHopping:        portHoppingCfg,
+		Shaper:             cfg.Shaper,
 	}
 	mgr := strategy.NewDefaultManager(mgrCfg)
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -216,6 +216,12 @@ type Config struct {
 	ListenAddrV6 string // "[::]:995"
 	EnableIPv6   bool   // default: true
 	DualStack    bool   // default: true
+
+	// Shaper, when non-nil, is built from TOML [shaper]. The server-side
+	// pipeline does not yet consume it — server morph processing lives
+	// outside internal/strategy.MorphedConn — so this field is reserved for
+	// future wiring. Stored to keep the TOML round-trip honest.
+	Shaper any
 }
 
 // serverContext holds runtime context for multi-client mode

--- a/internal/strategy/morph.go
+++ b/internal/strategy/morph.go
@@ -23,6 +23,10 @@ type TrafficMorphStrategy struct {
 	profile   *TrafficProfile
 	baseStrat Strategy // Underlying strategy (e.g., gRPC tunnel)
 	secret    []byte   // Secret for authentication
+
+	// customShaper, when non-nil, is injected into MorphedConn instead of the
+	// legacy NoopShaper. Wired from TOML [shaper] via the manager config.
+	customShaper shaper.Shaper
 }
 
 // TrafficProfile defines statistical properties of traffic to mimic.
@@ -342,7 +346,13 @@ func (s *TrafficMorphStrategy) Connect(ctx context.Context, target string) (net.
 	}
 
 	// Wrap with morphing layer
-	return NewMorphedConn(baseConn, s.profile, s.secret), nil
+	return NewMorphedConnWithShaper(baseConn, s.profile, s.secret, s.customShaper), nil
+}
+
+// SetShaper injects a custom Shaper into all subsequent MorphedConn instances
+// produced by this strategy. nil reverts to the legacy passthrough shaper.
+func (s *TrafficMorphStrategy) SetShaper(sh shaper.Shaper) {
+	s.customShaper = sh
 }
 
 // MorphedConn wraps a connection with traffic morphing.

--- a/internal/strategy/strategy.go
+++ b/internal/strategy/strategy.go
@@ -15,6 +15,7 @@ import (
 	"github.com/tiredvpn/tiredvpn/internal/log"
 	"github.com/tiredvpn/tiredvpn/internal/mux"
 	"github.com/tiredvpn/tiredvpn/internal/porthopping"
+	"github.com/tiredvpn/tiredvpn/internal/shaper"
 )
 
 // Strategy defines interface for DPI evasion techniques
@@ -926,6 +927,11 @@ type DefaultManagerConfig struct {
 	// Port hopping for DPI evasion
 	// High ports (47000+) are less analyzed by DPI, periodic port changes complicate blocking
 	PortHopping *porthopping.Config
+
+	// Shaper, when non-nil, is injected into Traffic-Morph strategies and
+	// drives sizing/inter-arrival in MorphedConn. nil keeps the legacy
+	// NoopShaper behaviour (wire-format unchanged).
+	Shaper shaper.Shaper
 }
 
 // NewDefaultManager creates a manager with all strategies pre-registered
@@ -1093,10 +1099,18 @@ func registerMorphStrategies(m *Manager, cfg DefaultManagerConfig, hasSecret boo
 	if !hasSecret {
 		return
 	}
-	m.Register(NewTrafficMorphStrategy(m, YandexVideoProfile, nil, cfg.Secret))
-	m.Register(NewTrafficMorphStrategy(m, VKVideoProfile, nil, cfg.Secret))
-	m.Register(NewTrafficMorphStrategy(m, BaiduVideoProfile, nil, cfg.Secret))
-	m.Register(NewTrafficMorphStrategy(m, AparatVideoProfile, nil, cfg.Secret))
+	for _, profile := range []*TrafficProfile{
+		YandexVideoProfile,
+		VKVideoProfile,
+		BaiduVideoProfile,
+		AparatVideoProfile,
+	} {
+		strat := NewTrafficMorphStrategy(m, profile, nil, cfg.Secret)
+		if cfg.Shaper != nil {
+			strat.SetShaper(cfg.Shaper)
+		}
+		m.Register(strat)
+	}
 }
 
 // registerMeshAndAntiProbe registers Mesh Relay and Anti-Probe strategies.


### PR DESCRIPTION
## Summary
- Adds `--config <path>` to both `tiredvpn client` and `tiredvpn server`. Without the flag the existing CLI-only flow is unchanged; with it, `internal/config/toml` resolves CLI > TOML > defaults via `flag.Visit`.
- Maps TOML fields into runtime configs: server/listen address+port, `strategy.mode`, `tls.cert_file`/`key_file`, `logging.level`, and `[shaper]` (preset/custom) built through `presets.FromConfig` so `DataPlaneSafe` gating is centralized.
- Threads the resulting `shaper.Shaper` through `client.Config` → `strategy.DefaultManagerConfig` → `TrafficMorphStrategy` so `MorphedConn` picks it up via `NewMorphedConnWithShaper` (nil-default keeps wire format byte-identical).
- Replaces hardcoded `version = "1.0.1"` with `"dev"` and overrides it from the git tag via `-ldflags="-X main.version=…"` in `release.yml`.

Closes [tiredvpn-oss-55g](beads://tiredvpn-oss-55g).

## What maps from TOML to runtime
| TOML | Client field | Server field |
|---|---|---|
| `server.address` + `server.port` | `cfg.ServerAddr` | n/a |
| `listen.address` + `listen.port` | n/a | `cfg.ListenAddr` |
| `strategy.mode` | `cfg.StrategyName` | (gap — not yet wired) |
| `shaper.{preset\|custom}` | `cfg.Shaper` (live in MorphedConn) | `cfg.Shaper` (reserved) |
| `tls.cert_file` / `tls.key_file` | n/a | `cfg.CertFile` / `cfg.KeyFile` |
| `logging.level=debug` | `cfg.Debug = true` + `log.SetDebug(true)` | same |

## Documented gaps
- Server side stores `Shaper` but the server's morph pipeline does not consume it yet (no `MorphedConn` callers in `internal/server`).
- `strategy.options`, `tls.{server_name,fingerprint,alpn,ca_cert,client_ca_file,insecure_skip_verify}`, `auth.{mode,tokens,tokens_file}`, `logging.{format,output}` are accepted by the schema but not yet mapped onto `client.Config`/`server.Config`.

## Test plan
- [x] `go build ./...`
- [x] `go test -race -timeout 5m -short ./internal/... ./cmd/...` (620 passed)
- [x] `go vet ./...` clean
- [x] Manual: `tiredvpn version` prints `dev` for `go run`, prints injected tag with `-ldflags`
- [x] Manual: `tiredvpn client --config /tmp/empty.toml` reports `server.address is required` instead of crashing
- [ ] CI green