### PR TITLE
docs: traffic shaper + TOML config sections, finalize CHANGELOG[1.1.0]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,31 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-05-04
+
+### Added
+
+- **Traffic Shaper** — new behavioural masking layer (`internal/shaper`) that decouples DPI shape from TLS transport. Distribution engines (Histogram, LogNormal, Pareto, MarkovBurst), four ready-made presets (`chrome_browsing`, `youtube_streaming`, `random_per_session`, `bittorrent_idle`) and a `cmd/shaper-dump` utility for χ² / Jupyter visualization.
+- **TOML configuration** — `tiredvpn client|server --config <path>` (`internal/config/toml`). Strict validation via `pelletier/go-toml/v2 DisallowUnknownFields`, precedence CLI > TOML > defaults, full field reference in [`internal/config/toml/MIGRATION.md`](internal/config/toml/MIGRATION.md).
+- Example configs: [`configs/client.example.toml`](configs/client.example.toml), [`configs/server.example.toml`](configs/server.example.toml). Regression-tested by `TestExampleConfigs_LoadCleanly`.
+- `presets.IsDataPlaneSafe(name)` accessor and `DataPlaneSafe` flag on every registered preset.
+- `presets.ByNameAllowAny` entry point for cover-traffic callers that need access to non-data-plane presets.
+- Real-tunnel TCP e2e test (`internal/integration/tunnel_e2e_test.go`, build tag `integration_e2e`) that loads both sides from TOML and verifies byte-perfect 1 MiB roundtrip.
+- Documentation: [`docs/client.md`](docs/client.md) and [`docs/server.md`](docs/server.md) gained "Configuration via TOML" and "Traffic Shaper" sections; [`internal/shaper/README.md`](internal/shaper/README.md) carries the final performance table.
+
+### Performance
+
+- Shaped-write throughput on `chrome_browsing` improved **109×** (1.75 → ~191 MB/s on loopback TCP, 16 MiB workload). Heap traffic dropped **12×** (~70 MB → ~5.8 MB per transfer), allocations −24%.
+- The pipeline now runs an async pacer goroutine with sleep coalescing, adaptive throttling on queue overflow, a 50 ms inter-frame delay cap, and `writev` (`net.Buffers`) coalescing. Frame buffers are pulled from a 4-bucket `sync.Pool`; `Wrap` and `Unwrap` reuse output slices via a new `Shaper.Release` method.
+- Honest trade-off: ~80% throughput overhead vs. unshaped Noop remains in the pacer goroutine handoff. Operators who do not need DPI shape masking should omit `[shaper]` from their TOML — the rest of the anti-DPI stack (REALITY, port-hop, RTT masking) is fully effective on its own.
+
 ### Breaking
 
 - Shaper preset `bittorrent_idle` is no longer accepted in data-plane configs (`shaper.preset = "bittorrent_idle"` returns `ErrPresetNotDataPlaneSafe`). Its ~7 s median inter-arrival is suitable for cover-traffic generation only; cover-traffic emitters must call `presets.ByNameAllowAny`. `random_per_session` now picks only from data-plane-safe basis presets.
 
-### Added
+### Changed
 
-- `presets.IsDataPlaneSafe(name)` accessor and `DataPlaneSafe` flag on every registered preset.
-- `presets.ByNameAllowAny` entry point for cover-traffic callers that need access to non-data-plane presets.
+- `version` is now passed through `-ldflags` from `git describe` at release build time. Local development builds report `dev`.
 
 ## [1.0.3] - 2026-04-09
 

--- a/docs/client.md
+++ b/docs/client.md
@@ -219,6 +219,68 @@ Benchmark results show per-strategy latency, success rate, and throughput. Use t
 
 See [monitoring.md](monitoring.md) for Prometheus metrics details.
 
+## Configuration via TOML (preferred)
+
+Since v1.1.0 the client accepts `--config <path>` to load all options from a
+TOML file. Any CLI flag passed alongside overrides the file value
+(precedence: CLI > TOML > defaults), so existing scripts keep working.
+
+```bash
+tiredvpn client --config /etc/tiredvpn/client.toml
+```
+
+A copy-paste-ready template lives in [`configs/client.example.toml`](../configs/client.example.toml).
+
+Minimal example:
+
+```toml
+[server]
+address = "vpn.example.com"
+port    = 443
+
+[strategy]
+mode = "morph"
+
+[shaper]
+preset = "chrome_browsing"
+
+[logging]
+level = "info"
+```
+
+CLI-only flags (TUN, port-hopping, ECH, post-quantum, benchmarking) are not
+yet mapped to TOML and stay command-line only — see the
+[migration guide](../internal/config/toml/MIGRATION.md) for the field-by-field
+table and roadmap.
+
+## Traffic Shaper
+
+The shaper is a behavioural masking layer that sits between strategy and
+transport. Strategies (REALITY, morph, etc.) hide *what* you send; the shaper
+hides *the timing and sizes of how you send it*, so DPI cannot kluster
+multiple users by their packet-distribution histogram.
+
+Enable via `[shaper]` in TOML. Available presets:
+
+| Preset                 | Use case                            | Throughput    | Trade-off                                |
+|------------------------|-------------------------------------|---------------|------------------------------------------|
+| `chrome_browsing`      | HTTPS browsing mimicry              | ~191 MB/s     | ~80% overhead vs. unshaped, recommended  |
+| `youtube_streaming`    | HD video streaming mimicry          | sleep-bound   | bulk transfer caps in single-digit MB/s  |
+| `random_per_session`   | rotates basis preset per connection | sleep-bound   | hardest to fingerprint, same caveat      |
+| `bittorrent_idle`      | cover traffic only                  | n/a           | rejected in data plane (median ~7 s)     |
+
+Recommendation: start with `chrome_browsing`. Switch to
+`random_per_session` when you specifically need the rotation property
+(adversary collects long traces). Use `youtube_streaming` only on
+interactive / non-bulk workloads.
+
+Custom distributions are supported via `[shaper.custom]` — see the example
+config and the [shaper README](../internal/shaper/README.md) for histogram /
+log-normal / Pareto / Markov-burst parameter shapes.
+
+If you do not need DPI shape masking, omit `[shaper]` entirely; throughput
+defaults to native (>1 GB/s on loopback).
+
 ## Configuration Examples
 
 ### Russia (TSPU bypass)

--- a/docs/server.md
+++ b/docs/server.md
@@ -115,6 +115,63 @@ Client → Server A (relay) → Server B (upstream/exit) → Internet
 
 The fake website (`-fake-root`) is what any DPI probe or direct browser sees when connecting without a valid auth token. Put static HTML files there to mimic a real web service.
 
+## Configuration via TOML (preferred)
+
+Since v1.1.0 the server accepts `--config <path>` to load all options from a
+TOML file. Any CLI flag passed alongside overrides the file value
+(precedence: CLI > TOML > defaults), so existing systemd units keep working.
+
+```bash
+tiredvpn server --config /etc/tiredvpn/server.toml
+```
+
+A copy-paste-ready template lives in [`configs/server.example.toml`](../configs/server.example.toml).
+
+Minimal example:
+
+```toml
+[listen]
+address = "0.0.0.0"
+port    = 443
+
+[strategy]
+mode = "reality"
+
+[tls]
+cert_file = "/etc/tiredvpn/server.crt"
+key_file  = "/etc/tiredvpn/server.key"
+
+[auth]
+mode         = "token"
+tokens_file  = "/etc/tiredvpn/secrets.txt"
+
+[logging]
+level = "info"
+```
+
+Most CLI-only flags (Redis multi-tenancy, port-hopping range, monitoring
+endpoints, post-quantum) are not yet mapped to TOML and stay command-line
+only — see the
+[migration guide](../internal/config/toml/MIGRATION.md) for the field-by-field
+table and roadmap.
+
+## Traffic Shaper (server side)
+
+Server-side shaping is **opt-in**. By default the server is shaper-agnostic:
+each `MorphedConn` runs `NoopShaper` so server-to-client throughput is native.
+Enable `[shaper]` only when your threat model requires the server to also
+emit a specific statistical signature on its egress traffic.
+
+```toml
+[shaper]
+preset = "chrome_browsing"
+```
+
+Available presets and trade-offs are identical to the client side —
+see [client.md → Traffic Shaper](client.md#traffic-shaper). The
+`bittorrent_idle` preset is rejected in the data plane (≈7 s median
+inter-arrival is incompatible with tunnelling user payload).
+
 ## Configuration Examples
 
 ### Minimal single-client

--- a/internal/shaper/README.md
+++ b/internal/shaper/README.md
@@ -87,3 +87,30 @@ go run ./cmd/shaper-dump --preset chrome_browsing --samples 10000 --seed 42 --ou
 
 Emits `idx,direction,size,delay_ms` and prints a per-direction mean/median/p95
 summary on stderr. CSVs are not committed.
+
+## Performance characteristics
+
+Final numbers from `internal/strategy/testdata/shaper_overhead_receiver.txt`,
+loopback TCP, 16 MiB payload, async pacer + writev coalescing + bucketed pool +
+pooled Wrap/Unwrap buffers:
+
+| Preset               | Throughput   | bytes/op | allocs/op | Notes                                    |
+|----------------------|--------------|---------:|----------:|------------------------------------------|
+| Noop (baseline)      | ~1040 MB/s   |   ~50 MB |       ~4  | Direct passthrough, no shaping           |
+| `chrome_browsing`    | **~191 MB/s**|   5.8 MB |    127 k  | Recommended for HTTPS-mimicry data plane |
+| `youtube_streaming`  | sleep-bound  |       —  |        —  | Pareto tail dominates wallclock          |
+| `random_per_session` | sleep-bound  |       —  |        —  | Same family as basis preset              |
+
+Honest trade-off: `chrome_browsing` is **109×** faster than the original
+synchronous shaper (1.75 → 191 MB/s) with **12×** less heap traffic, but still
+sits at ~80% throughput overhead vs. unshaped Noop. Headroom remains in the
+pacer goroutine handoff / channel ops — pursued only when a real workload
+needs it. Operators who need raw bandwidth can run with no shaper (`omit
+[shaper]` in TOML); the rest of the anti-DPI stack (REALITY, port-hop, RTT
+masking) stays effective on its own.
+
+Sleep-bound presets (`youtube_streaming`, `random_per_session`) spend most of
+their wallclock honoring inter-arrival distributions clamped to a 50 ms cap;
+on bulk transfer this caps throughput in single-digit MB/s. They are designed
+for workloads where the shape matters more than throughput (interactive,
+chat-like, browsing-like). For bulk transfer prefer `chrome_browsing`.


### PR DESCRIPTION
## Summary

- `docs/client.md`, `docs/server.md` — sections "Configuration via TOML" (`--config`) and "Traffic Shaper" with preset trade-off table.
- `internal/shaper/README.md` — "Performance characteristics" with final bench numbers (chrome 191 MB/s, 109× speedup, 12× heap reduction; honest ~80% overhead vs. Noop).
- `CHANGELOG.md` — finalize `[Unreleased]` → `[1.1.0] - 2026-05-04`. Sections: Added, Performance, Breaking, Changed.

Refs beads `tiredvpn-oss-so4`. Last docs piece before tagging v1.1.0.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...` (642 passed across 28 packages)
- [x] markdown links resolve to in-repo paths