### PR TITLE
docs(helm): translate chart comments and README to english

### DIFF
--- a/.github/workflows/chart-release.yml
+++ b/.github/workflows/chart-release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Chart version (без префикса chart-v). Если пусто — берётся из Chart.yaml."
+        description: "Chart version (without the chart-v prefix). If empty, taken from Chart.yaml."
         required: false
         type: string
 

--- a/deploy/helm/tiredvpn/README.md
+++ b/deploy/helm/tiredvpn/README.md
@@ -1,21 +1,28 @@
 # tiredvpn Helm chart
 
-Production-grade Helm chart для развёртывания [tiredvpn](https://github.com/tiredvpn/tiredvpn-oss) — DPI-resistant VPN — в Kubernetes. Чарт поддерживает развёртывание сервера (exit node) и/или клиента (SOCKS5-прокси либо TUN-туннель) в одном release.
+Helm chart for deploying [tiredvpn](https://github.com/tiredvpn/tiredvpn-oss) — DPI-resistant VPN — on Kubernetes. The chart can deploy the server (exit node) and/or the client (SOCKS5 proxy or TUN tunnel) from a single release.
 
-## Установка
+## Install
 
 ```bash
-helm repo add bitnami https://charts.bitnami.com/bitnami    # для опционального Redis
+helm install my-tiredvpn oci://ghcr.io/tiredvpn/charts/tiredvpn \
+  --version 0.1.0 -f my-values.yaml
+```
+
+Or from a local checkout:
+
+```bash
+helm repo add bitnami https://charts.bitnami.com/bitnami    # for the optional Redis subchart
 cd deploy/helm/tiredvpn
 helm dependency update
 helm install my-tiredvpn . -f my-values.yaml
 ```
 
-Минимальные требования: Kubernetes ≥ 1.25, Helm ≥ 3.8.
+Requirements: Kubernetes ≥ 1.25, Helm ≥ 3.8.
 
-## Примеры использования
+## Examples
 
-### 1. Минимальный сервер (single-client)
+### 1. Minimal server (single-client)
 
 ```bash
 helm install vpn deploy/helm/tiredvpn \
@@ -25,7 +32,7 @@ helm install vpn deploy/helm/tiredvpn \
   --set server.auth.secret="$(openssl rand -hex 32)"
 ```
 
-### 2. Multi-client сервер с Redis
+### 2. Multi-client server with Redis
 
 ```bash
 helm install vpn deploy/helm/tiredvpn \
@@ -36,14 +43,14 @@ helm install vpn deploy/helm/tiredvpn \
   --set server.metrics.serviceMonitor.enabled=true
 ```
 
-После старта добавь клиентов через admin API:
+After startup, add clients via the admin API:
 
 ```bash
 kubectl exec deploy/vpn-tiredvpn-server -- /tiredvpn admin add \
   -api http://127.0.0.1:8080 -server vpn.example.com:443
 ```
 
-### 3. Сервер с port-hopping и IPv6 dual-stack
+### 3. Server with port-hopping and IPv6 dual-stack
 
 ```bash
 helm install vpn deploy/helm/tiredvpn -f - <<EOF
@@ -61,7 +68,7 @@ server:
 EOF
 ```
 
-### 4. Клиент в SOCKS5-режиме (доступен из других подов кластера)
+### 4. Client in SOCKS5 mode (reachable by other pods in the cluster)
 
 ```bash
 helm install proxy deploy/helm/tiredvpn -f - <<EOF
@@ -78,11 +85,11 @@ client:
 EOF
 ```
 
-Из любого пода: `curl -x socks5h://proxy-tiredvpn-client-socks:1080 https://ifconfig.me`.
+From any pod: `curl -x socks5h://proxy-tiredvpn-client-socks:1080 https://ifconfig.me`.
 
-### 5. Клиент в TUN-режиме (DaemonSet, тоннелирует трафик узла)
+### 5. Client in TUN mode (DaemonSet, tunnels node traffic)
 
-> ⚠️  Дефолтный образ `tiredvpn/tiredvpn` собран `FROM scratch` и не содержит `ip`/`iptables`, которые клиент использует для конфигурации TUN. Соберите собственный образ на базе alpine/debian с `iproute2` + `iptables` и укажите его через `client.tun.image.repository`.
+> ⚠️  The default `tiredvpn/tiredvpn` image is built `FROM scratch` and does not contain `ip` / `iptables`, which the client uses to configure the TUN device. Build your own image based on alpine/debian with `iproute2` + `iptables` and point `client.tun.image.repository` at it.
 
 ```bash
 helm install vpn-tunnel deploy/helm/tiredvpn -f - <<EOF
@@ -93,66 +100,66 @@ client:
   server: { existingSecret: vpn-credentials }
   tun:
     routes: "0.0.0.0/0"
-    usePrivileged: false   # NET_ADMIN+NET_RAW caps вместо privileged
+    usePrivileged: false   # NET_ADMIN+NET_RAW caps instead of privileged
     image:
       repository: myorg/tiredvpn-tun
       tag: 1.1.3
 EOF
 ```
 
-## Структура values
+## values structure
 
-| Раздел | Описание |
+| Section | Description |
 |---|---|
-| `global.image.*` | Реджистри, тег (default — `appVersion` чарта), pullPolicy |
-| `serviceAccount.*` | SA создаётся один на release |
-| `server.enabled` | toggle сервера |
-| `server.config.*` | CLI-флаги бинаря (listen, ipv6, quic, portHopping, tun, upstream, fakeRoot, api, pprof, debug) |
-| `server.tls.{existingSecret, create, cert, key}` | TLS-сертификаты: готовый Secret или inline PEM |
-| `server.auth.{mode, secret, tokens, existingSecret}` | Аутентификация: `secret`/`tokens`/`external` |
-| `server.redis.addr` | Внешний Redis (если не используется bitnami subchart) |
-| `server.tomlConfig` | Альтернатива `config.*` — сырой TOML, монтируется как ConfigMap |
-| `server.service.{main, api}` | Два отдельных Service: main (TCP+UDP/LoadBalancer) и api (ClusterIP) |
-| `server.{resources, podSecurityContext, securityContext, nodeSelector, ...}` | стандартные K8s-настройки пода |
+| `global.image.*` | Registry, tag (defaults to chart `appVersion`), pullPolicy |
+| `serviceAccount.*` | One SA per release |
+| `server.enabled` | Server toggle |
+| `server.config.*` | Binary CLI flags (listen, ipv6, quic, portHopping, tun, upstream, fakeRoot, api, pprof, debug) |
+| `server.tls.{existingSecret, create, cert, key}` | TLS certificates: existing Secret or inline PEM |
+| `server.auth.{mode, secret, tokens, existingSecret}` | Authentication: `secret` / `tokens` / `external` |
+| `server.redis.addr` | External Redis address (used when the bitnami subchart is not enabled) |
+| `server.tomlConfig` | Alternative to `config.*` — raw TOML mounted via ConfigMap |
+| `server.service.{main, api}` | Two separate Services: main (TCP+UDP/LoadBalancer) and api (ClusterIP) |
+| `server.{resources, podSecurityContext, securityContext, nodeSelector, ...}` | standard K8s pod settings |
 | `server.pdb.enabled` | PodDisruptionBudget |
 | `server.networkPolicy.enabled` | NetworkPolicy (ingress main+api, egress DNS+world) |
-| `server.metrics.serviceMonitor.enabled` | Prometheus ServiceMonitor на `/metrics` через api-порт |
-| `server.autoscaling.enabled` | HPA — **требует** общий Redis backend |
-| `client.enabled` | toggle клиента |
+| `server.metrics.serviceMonitor.enabled` | Prometheus ServiceMonitor scraping `/metrics` on the api port |
+| `server.autoscaling.enabled` | HPA — **requires** a shared Redis backend |
+| `client.enabled` | Client toggle |
 | `client.mode` | `socks` (Deployment) \| `tun` (DaemonSet) \| `both` |
-| `client.server.{address, secret, existingSecret}` | Адрес+secret VPN-сервера |
-| `client.config.*` | CLI-флаги: strategy, cover, quic, ech, pq, rttMasking, ipv6, portHop, adaptive, api, pprof |
-| `client.tomlConfig` | Альтернатива `config.*` |
-| `client.socks.*` | SOCKS-режим: listen/replicaCount/service/resources/PDB |
-| `client.tun.*` | TUN-режим: name/ip/peerIp/mtu/routes/usePrivileged/image |
-| `client.metrics.serviceMonitor.enabled` | Только для SOCKS-режима (тоже через `api`-порт) |
-| `client.networkPolicy.enabled` | NetworkPolicy для SOCKS |
-| `redis.enabled` | Поднимает bitnami/redis как зависимость; если включён и `server.redis.addr` пусто — сервер автоматически подключится к `<release>-redis-master:6379` |
+| `client.server.{address, secret, existingSecret}` | VPN server address + secret |
+| `client.config.*` | CLI flags: strategy, cover, quic, ech, pq, rttMasking, ipv6, portHop, adaptive, api, pprof |
+| `client.tomlConfig` | Alternative to `config.*` |
+| `client.socks.*` | SOCKS mode: listen / replicaCount / service / resources / PDB |
+| `client.tun.*` | TUN mode: name / ip / peerIp / mtu / routes / usePrivileged / image |
+| `client.metrics.serviceMonitor.enabled` | SOCKS mode only (also via the `api` port) |
+| `client.networkPolicy.enabled` | NetworkPolicy for SOCKS |
+| `redis.enabled` | Pull in bitnami/redis as a dependency; if enabled and `server.redis.addr` is empty, the server is wired to `<release>-redis-master:6379` automatically |
 
-Полный список значений и их default'ы смотри в [values.yaml](./values.yaml) (комментарии рядом с каждым полем).
+Full value list with defaults: see [values.yaml](./values.yaml) (each field has an inline comment).
 
-## CLI-флаги ↔ values
+## CLI flags ↔ values
 
-Чарт рендерит args бинаря из `server.config.*` / `client.config.*` (см. `_helpers.tpl`). Если нужен флаг, не покрытый values напрямую, используй:
+The chart renders binary args from `server.config.*` / `client.config.*` (see `_helpers.tpl`). For a flag not covered by values:
 
-- `server.extraArgs` / `client.extraArgs` — добавляются в конец args (`extraArgs: ["-foo", "bar"]`);
-- `server.tomlConfig` / `client.tomlConfig` — целиком заменяет CLI-флаги на TOML-конфиг (см. `configs/server.example.toml` в основном репо).
+- `server.extraArgs` / `client.extraArgs` — appended to args (`extraArgs: ["-foo", "bar"]`);
+- `server.tomlConfig` / `client.tomlConfig` — replaces all CLI flags with a TOML config (see `configs/server.example.toml` in the main repo).
 
-## Проверка перед установкой
+## Verify before installing
 
 ```bash
 helm lint deploy/helm/tiredvpn -f ci/server-minimal-values.yaml
 helm template my-release deploy/helm/tiredvpn -f ci/server-minimal-values.yaml | kubectl apply --dry-run=client -f -
 ```
 
-В `ci/` лежат фикстуры для типичных сценариев (server-minimal, server-redis, server-porthop, client-socks, client-tun, both) — используются для lint-чеков в CI/локально.
+`ci/` contains fixtures for typical scenarios (server-minimal, server-redis, server-porthop, client-socks, client-tun, both); they're used for lint checks in CI and locally.
 
-## Совместимость
+## Compatibility
 
-- Версии Helm: 3.8+
-- Версии Kubernetes: 1.25+ (использует `policy/v1` PDB, `autoscaling/v2` HPA, `networking.k8s.io/v1` NetworkPolicy)
-- Версии tiredvpn: соответствует `appVersion` Chart.yaml (по умолчанию `1.1.3`)
+- Helm: 3.8+
+- Kubernetes: 1.25+ (uses `policy/v1` PDB, `autoscaling/v2` HPA, `networking.k8s.io/v1` NetworkPolicy)
+- tiredvpn: matches `appVersion` in Chart.yaml (default `1.1.3`)
 
-## Лицензия
+## License
 
-AGPL-3.0 (наследуется от основного проекта).
+AGPL-3.0 (inherited from the main project).

--- a/deploy/helm/tiredvpn/ci/both-values.yaml
+++ b/deploy/helm/tiredvpn/ci/both-values.yaml
@@ -1,4 +1,4 @@
-# Server + Client (SOCKS) в одном release — для split-test.
+# Server + Client (SOCKS) in the same release — for split-test setups.
 server:
   enabled: true
   service:

--- a/deploy/helm/tiredvpn/ci/client-socks-values.yaml
+++ b/deploy/helm/tiredvpn/ci/client-socks-values.yaml
@@ -1,4 +1,4 @@
-# Только клиент в SOCKS5-режиме (Deployment + ClusterIP).
+# Client in SOCKS5 mode only (Deployment + ClusterIP).
 server:
   enabled: false
 

--- a/deploy/helm/tiredvpn/ci/client-tun-values.yaml
+++ b/deploy/helm/tiredvpn/ci/client-tun-values.yaml
@@ -1,5 +1,5 @@
-# Только клиент в TUN-режиме (DaemonSet, privileged).
-# Внимание: использует override образа на alpine-base с iproute2/iptables.
+# Client in TUN mode only (DaemonSet, privileged).
+# NOTE: uses an image override based on alpine with iproute2/iptables.
 server:
   enabled: false
 
@@ -20,5 +20,5 @@ client:
     routes: "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"
     usePrivileged: false   # NET_ADMIN+NET_RAW caps
     image:
-      repository: "myorg/tiredvpn-tun"  # override: образ с iproute2+iptables
+      repository: "myorg/tiredvpn-tun"  # override: image with iproute2+iptables
       tag: "1.1.3"

--- a/deploy/helm/tiredvpn/ci/server-minimal-values.yaml
+++ b/deploy/helm/tiredvpn/ci/server-minimal-values.yaml
@@ -1,9 +1,9 @@
-# Минимальный single-client сервер с inline TLS и secret.
+# Minimal single-client server with inline TLS and shared secret.
 server:
   enabled: true
   service:
     main:
-      type: ClusterIP   # для lint без LB
+      type: ClusterIP   # avoid LB for lint
   tls:
     create: true
     cert: |

--- a/deploy/helm/tiredvpn/ci/server-porthop-values.yaml
+++ b/deploy/helm/tiredvpn/ci/server-porthop-values.yaml
@@ -1,4 +1,4 @@
-# Сервер с port-hopping + IPv6 dual-stack + NetworkPolicy.
+# Server with port-hopping + IPv6 dual-stack + NetworkPolicy.
 server:
   enabled: true
   service:

--- a/deploy/helm/tiredvpn/ci/server-redis-values.yaml
+++ b/deploy/helm/tiredvpn/ci/server-redis-values.yaml
@@ -1,4 +1,4 @@
-# Multi-client сервер с bitnami/redis subchart + ServiceMonitor + PDB.
+# Multi-client server with the bitnami/redis subchart + ServiceMonitor + PDB.
 server:
   enabled: true
   replicaCount: 2
@@ -10,7 +10,7 @@ server:
     cert: "-----BEGIN CERTIFICATE-----\nTEST\n-----END CERTIFICATE-----"
     key: "-----BEGIN PRIVATE KEY-----\nTEST\n-----END PRIVATE KEY-----"
   auth:
-    mode: external      # multi-client: клиенты добавляются через admin API → Redis
+    mode: external      # multi-client: clients are added via the admin API → Redis
   pdb:
     enabled: true
     minAvailable: 1

--- a/deploy/helm/tiredvpn/templates/NOTES.txt
+++ b/deploy/helm/tiredvpn/templates/NOTES.txt
@@ -1,4 +1,4 @@
-tiredvpn {{ .Chart.AppVersion }} установлен как release «{{ .Release.Name }}» в namespace «{{ .Release.Namespace }}».
+tiredvpn {{ .Chart.AppVersion }} installed as release "{{ .Release.Name }}" in namespace "{{ .Release.Namespace }}".
 
 {{- if .Values.server.enabled }}
 
@@ -16,12 +16,12 @@ Main Service ({{ .Values.server.service.main.type }}):  {{ include "tiredvpn.ser
 
 {{- if eq .Values.server.service.main.type "LoadBalancer" }}
 
-Узнать внешний адрес LoadBalancer:
+Get the LoadBalancer external address:
   kubectl -n {{ .Release.Namespace }} get svc {{ include "tiredvpn.server.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}{.status.loadBalancer.ingress[0].hostname}'
 
 {{- else if eq .Values.server.service.main.type "NodePort" }}
 
-Получить NodePort'ы:
+Get the NodePort assignments:
   kubectl -n {{ .Release.Namespace }} get svc {{ include "tiredvpn.server.fullname" . }} -o jsonpath='{.spec.ports}'
 
 {{- end }}
@@ -36,16 +36,16 @@ API / Health / Metrics ({{ include "tiredvpn.server.fullname" . }}-api):
 
 {{- if eq .Values.server.auth.mode "secret" }}
 
-Auth (single-client). Чтобы получить shared secret:
+Auth (single-client). Retrieve the shared secret:
   kubectl -n {{ .Release.Namespace }} get secret {{ include "tiredvpn.server.authSecretName" . }} -o jsonpath='{.data.{{ include "tiredvpn.server.authSecretKey" . }}}' | base64 -d
 {{- end }}
 
 {{- if and .Values.server.redis.addr (not .Values.redis.enabled) }}
 
-Redis: используется внешний {{ .Values.server.redis.addr }}.
+Redis: using external address {{ .Values.server.redis.addr }}.
 {{- else if .Values.redis.enabled }}
 
-Redis subchart (bitnami) поднят как {{ .Release.Name }}-redis-master:6379.
+Redis subchart (bitnami) is running as {{ .Release.Name }}-redis-master:6379.
 {{- end }}
 {{- end }}
 
@@ -58,25 +58,25 @@ CLIENT (mode={{ .Values.client.mode }})
 
 SOCKS5 proxy:
   Service: {{ include "tiredvpn.client.socks.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.client.socks.service.port }}
-  Из других подов: socks5://{{ include "tiredvpn.client.socks.fullname" . }}:{{ .Values.client.socks.service.port }}
-  Локальный port-forward для теста:
+  From other pods: socks5://{{ include "tiredvpn.client.socks.fullname" . }}:{{ .Values.client.socks.service.port }}
+  Local port-forward for testing:
     kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "tiredvpn.client.socks.fullname" . }} 1080:{{ .Values.client.socks.service.port }}
     curl -x socks5h://localhost:1080 https://ifconfig.me
 {{- end }}
 
 {{- if include "tiredvpn.client.tun.enabled" . }}
 
-TUN tunnel (DaemonSet на каждом linux-узле):
-  ⚠️  Дефолтный образ tiredvpn/tiredvpn собран FROM scratch и НЕ содержит `ip`/`iptables`,
-      которые клиент использует для настройки TUN. Перед использованием TUN-режима соберите
-      собственный образ на базе alpine с iproute2+iptables и задайте его в
-      client.tun.image.repository (или global.image.repository).
+TUN tunnel (DaemonSet on each linux node):
+  ⚠️  The default tiredvpn/tiredvpn image is built FROM scratch and does NOT contain
+      `ip`/`iptables`, which the client uses to configure the TUN device. Build your own
+      image based on alpine with iproute2+iptables and set it via
+      client.tun.image.repository (or global.image.repository).
   Routes: {{ .Values.client.tun.routes }}
-  Логи:
+  Logs:
     kubectl -n {{ .Release.Namespace }} logs -l app.kubernetes.io/component=client-tun -f
 {{- end }}
 {{- end }}
 
-Документация по флагам бинаря:
+Binary flag reference:
   https://github.com/tiredvpn/tiredvpn-oss/blob/main/docs/server.md
   https://github.com/tiredvpn/tiredvpn-oss/blob/main/docs/client.md

--- a/deploy/helm/tiredvpn/templates/_helpers.tpl
+++ b/deploy/helm/tiredvpn/templates/_helpers.tpl
@@ -45,7 +45,7 @@ Chart label string.
 {{- end -}}
 
 {{/*
-Base labels (применяются ко всем ресурсам).
+Base labels (applied to every resource).
 */}}
 {{- define "tiredvpn.labels" -}}
 helm.sh/chart: {{ include "tiredvpn.chart" . }}
@@ -108,7 +108,7 @@ ServiceAccount name.
 {{- end -}}
 
 {{/*
-Image reference (с возможностью override через workload-specific image).
+Image reference (with optional override via a workload-specific image).
 */}}
 {{- define "tiredvpn.image" -}}
 {{- $repo := .Values.global.image.repository -}}
@@ -131,7 +131,7 @@ Image reference (с возможностью override через workload-specif
 {{- end -}}
 
 {{/*
-ImagePullSecrets list (для шаблонизации в pod spec).
+ImagePullSecrets list (rendered into the pod spec).
 */}}
 {{- define "tiredvpn.imagePullSecrets" -}}
 {{- with .Values.global.imagePullSecrets }}
@@ -141,7 +141,7 @@ imagePullSecrets:
 {{- end -}}
 
 {{/*
-Имя Secret-а с TLS для сервера.
+Name of the server's TLS Secret.
 */}}
 {{- define "tiredvpn.server.tlsSecretName" -}}
 {{- if .Values.server.tls.existingSecret -}}
@@ -152,7 +152,7 @@ imagePullSecrets:
 {{- end -}}
 
 {{/*
-Имя Secret-а с auth для сервера (когда mode=secret или mode=tokens).
+Name of the server's auth Secret (when mode=secret or mode=tokens).
 */}}
 {{- define "tiredvpn.server.authSecretName" -}}
 {{- if .Values.server.auth.existingSecret -}}
@@ -163,14 +163,14 @@ imagePullSecrets:
 {{- end -}}
 
 {{/*
-Ключ secret-а с авторизацией.
+Key inside the auth Secret.
 */}}
 {{- define "tiredvpn.server.authSecretKey" -}}
 {{- default "secret" .Values.server.auth.existingSecretKey -}}
 {{- end -}}
 
 {{/*
-Имя Secret-а с upstream secret-ом.
+Name of the Secret holding the upstream secret.
 */}}
 {{- define "tiredvpn.server.upstreamSecretName" -}}
 {{- if .Values.server.config.upstream.existingSecret -}}
@@ -181,7 +181,7 @@ imagePullSecrets:
 {{- end -}}
 
 {{/*
-Имя Secret-а клиента (server addr + secret).
+Name of the client credentials Secret (server addr + secret).
 */}}
 {{- define "tiredvpn.client.secretName" -}}
 {{- if .Values.client.server.existingSecret -}}
@@ -200,10 +200,10 @@ imagePullSecrets:
 {{- end -}}
 
 {{/*
-Эффективный Redis-адрес для сервера.
-Если server.redis.addr задан — используется как есть.
-Иначе если bitnami/redis subchart enabled — {release}-redis-master:6379.
-Иначе пусто (single-client mode).
+Effective Redis address for the server.
+If server.redis.addr is set — used as-is.
+Otherwise, if the bitnami/redis subchart is enabled — {release}-redis-master:6379.
+Otherwise empty (single-client mode).
 */}}
 {{- define "tiredvpn.server.redisAddr" -}}
 {{- if .Values.server.redis.addr -}}
@@ -214,11 +214,11 @@ imagePullSecrets:
 {{- end -}}
 
 {{/*
-Проверка инвариантов перед рендером.
+Pre-render invariant checks.
 */}}
 {{- define "tiredvpn.validate" -}}
 {{- if and .Values.server.enabled .Values.server.tomlConfig .Values.server.config -}}
-{{/* TOML и config взаимоисключающи де-факто, но мы не падаем — TOML просто переопределит. */}}
+{{/* TOML and config are de-facto mutually exclusive, but we don't fail — TOML simply overrides. */}}
 {{- end -}}
 {{- if and .Values.server.enabled (eq .Values.server.auth.mode "secret") (not .Values.server.tomlConfig) -}}
 {{- if and (not .Values.server.auth.secret) (not .Values.server.auth.existingSecret) -}}
@@ -246,7 +246,7 @@ imagePullSecrets:
 {{- end -}}
 
 {{/*
-Хелпер: shouldRenderClientSocks
+Helper: shouldRenderClientSocks.
 */}}
 {{- define "tiredvpn.client.socks.enabled" -}}
 {{- if and .Values.client.enabled (or (eq .Values.client.mode "socks") (eq .Values.client.mode "both")) -}}
@@ -262,8 +262,8 @@ true
 
 {{/*
 =================== ARGS RENDER ===================
-Рендер CLI args для server и client из values.*.config.
-Если задан tomlConfig — используется -config /etc/tiredvpn/{server,client}.toml.
+Render CLI args for server and client from values.*.config.
+If tomlConfig is set, use -config /etc/tiredvpn/{server,client}.toml instead.
 */}}
 
 {{- define "tiredvpn.server.args" -}}

--- a/deploy/helm/tiredvpn/templates/server-networkpolicy.yaml
+++ b/deploy/helm/tiredvpn/templates/server-networkpolicy.yaml
@@ -18,7 +18,7 @@ spec:
     - Ingress
     - Egress
   ingress:
-    # Main listener — публичный.
+    # Main listener — public.
     - ports:
         - port: {{ $mainPort }}
           protocol: TCP
@@ -41,7 +41,7 @@ spec:
         {{- end }}
       {{- end }}
     {{- if .Values.server.config.api.enabled }}
-    # API/metrics — только из мониторинг-namespace.
+    # API/metrics — monitoring namespaces only.
     - ports:
         - port: {{ $apiPort }}
           protocol: TCP
@@ -64,6 +64,6 @@ spec:
           protocol: UDP
         - port: 53
           protocol: TCP
-    # Redis / upstream / весь мир (для multi-hop клиента).
+    # Redis / upstream / the world (for the multi-hop client).
     - {}
 {{- end }}

--- a/deploy/helm/tiredvpn/values.yaml
+++ b/deploy/helm/tiredvpn/values.yaml
@@ -1,31 +1,31 @@
-# Default values for tiredvpn Helm chart.
-# Сервер и/или клиент включаются независимыми toggle:
-#   server.enabled — поднимает exit-node (Deployment + Service main TCP/UDP + API ClusterIP).
-#   client.enabled + client.mode (socks|tun|both) — поднимает SOCKS5-proxy и/или TUN-DaemonSet.
+# Default values for the tiredvpn Helm chart.
+# Server and/or client are turned on by independent toggles:
+#   server.enabled — runs the exit node (Deployment + main TCP/UDP Service + api ClusterIP).
+#   client.enabled + client.mode (socks|tun|both) — runs SOCKS5 proxy and/or TUN DaemonSet.
 
 # ---------------- global ----------------
 global:
   image:
     repository: tiredvpn/tiredvpn
-    # tag по умолчанию = .Chart.AppVersion; override здесь.
+    # Defaults to .Chart.AppVersion; override here.
     tag: ""
     pullPolicy: IfNotPresent
-  # Список ссылок на kubernetes.io/dockerconfigjson Secret-ы.
+  # List of references to kubernetes.io/dockerconfigjson Secrets.
   imagePullSecrets: []
   # [{ name: ghcr-pull }]
 
-# Переопределить имя release; по умолчанию = release name.
+# Override resource name; defaults to the release name.
 nameOverride: ""
 fullnameOverride: ""
 
-# Один ServiceAccount шарится server-ом и client-ом.
+# A single ServiceAccount is shared by server and client.
 serviceAccount:
   create: true
   name: ""
   annotations: {}
   automount: true
 
-# Метки/аннотации применяемые ко всем подам.
+# Labels / annotations applied to all pods.
 commonLabels: {}
 commonAnnotations: {}
 
@@ -36,8 +36,8 @@ server:
   enabled: true
   replicaCount: 1
 
-  # Конфиг через CLI-флаги (рекомендуется). Если задан server.tomlConfig — этот блок игнорируется.
-  # Поля соответствуют флагам `tiredvpn server` (см. cmd/tiredvpn/main.go).
+  # CLI-flag configuration (recommended). If server.tomlConfig is set, this block is ignored.
+  # Fields map to `tiredvpn server` flags (see cmd/tiredvpn/main.go).
   config:
     # -listen :443
     listen: ":443"
@@ -47,12 +47,12 @@ server:
       enabled: true   # -enable-v6
       dualStack: true # -dual-stack
     quic:
-      enabled: true             # инвертируется в -no-quic если false
-      listen: ""                # -quic-listen (пусто = по умолчанию)
+      enabled: true             # mapped to -no-quic if false
+      listen: ""                # -quic-listen (empty = default, same port as main)
       sniReassembly: false      # -quic-sni-reassembly
     portHopping:
       enabled: false
-      range: ""                 # -port-range "47000-47100" или "995"
+      range: ""                 # -port-range "47000-47100" or "995"
       maxPorts: 50              # -port-range-max
       interval: 60s             # -port-hop-interval
       strategy: random          # -port-hop-strategy: random|sequential|fibonacci
@@ -60,65 +60,65 @@ server:
     tun:
       ip: 10.8.0.1              # -tun-ip
       name: tiredvpn0           # -tun-name
-      ipPool: ""                # -ip-pool "10.8.0.0/24" (включает выдачу IP клиентам)
+      ipPool: ""                # -ip-pool "10.8.0.0/24" (enables IP issuance to clients)
       ipPoolLease: 24h          # -ip-pool-lease
     upstream:
       addr: ""                  # -upstream
-      secret: ""                # -upstream-secret (можно через server.upstream.existingSecret)
+      secret: ""                # -upstream-secret (can be sourced via existingSecret)
       existingSecret: ""
       existingSecretKey: upstream-secret
     fakeRoot:
-      # Путь в контейнере; в образе уже есть /var/www/html/index.html.
-      path: "./www"             # -fake-root (default образа — ./www)
-      # Inline-HTML, который смонтируется как ConfigMap. Если пусто — используется уже встроенный.
+      # Path inside the container; the image already ships /var/www/html/index.html.
+      path: "./www"             # -fake-root (binary default — ./www)
+      # Inline HTML mounted as a ConfigMap. Empty = use the image's built-in.
       inline: ""
     api:
-      enabled: true             # без api нет /health, /metrics, и admin API
-      listen: ":8080"           # -api-addr (0.0.0.0 чтобы быть доступным в кластере)
+      enabled: true             # without api there's no /health, /metrics, or admin API
+      listen: ":8080"           # -api-addr (use 0.0.0.0 so it's reachable in-cluster)
     pprof:
       enabled: false
       listen: ":6060"           # -pprof
     debug: false                # -debug
 
-  # Альтернатива config.* — сырое содержимое TOML (см. configs/server.example.toml).
-  # Если задано, монтируется в /etc/tiredvpn/server.toml и запускается: `tiredvpn server -config /etc/tiredvpn/server.toml`.
+  # Alternative to config.* — raw TOML content (see configs/server.example.toml).
+  # When set, mounted at /etc/tiredvpn/server.toml and started as `tiredvpn server -config /etc/tiredvpn/server.toml`.
   tomlConfig: ""
 
   tls:
-    # Готовый Secret типа kubernetes.io/tls с ключами tls.crt / tls.key (например, от cert-manager).
+    # Existing kubernetes.io/tls Secret with tls.crt / tls.key (e.g., issued by cert-manager).
     existingSecret: ""
-    # Альтернатива: создать Secret из inline-значений.
+    # Alternative: create a Secret from inline values.
     create: false
     cert: ""                    # PEM
     key: ""                     # PEM
 
   auth:
-    # secret  → single-client mode (-secret), значение из values.secret или existingSecret.
-    # tokens  → multi-client tokens (без Redis нужен либо tokens-file через TOML, либо API).
-    # external→ ни secret ни tokens не добавляются в args (используется внешний Redis/API).
+    # secret  → single-client mode (-secret), value from values.secret or existingSecret.
+    # tokens  → multi-client tokens (without Redis you need either tokens-file via TOML or admin API).
+    # external→ neither secret nor tokens are passed in args (use external Redis/API).
     mode: secret                # secret | tokens | external
-    # Готовый Secret с ключом `secret` (для mode=secret).
+    # Existing Secret with the `secret` key (for mode=secret).
     existingSecret: ""
     existingSecretKey: secret
-    # Inline-секрет.
+    # Inline secret.
     secret: ""
-    # tokens — список строк (для mode=tokens), монтируется как файл /etc/tiredvpn/tokens.txt.
+    # tokens — list of strings (for mode=tokens), mounted as /etc/tiredvpn/tokens.txt.
     tokens: []
 
   redis:
-    # Адрес Redis. Если пусто и .Values.redis.enabled=true — подставляется {release}-redis-master:6379.
-    # Если задано — используется как-есть; subchart-redis отключаем.
+    # Redis address. If empty and .Values.redis.enabled=true — defaulted to {release}-redis-master:6379.
+    # If set — used as-is; the redis subchart should be disabled.
     addr: ""
 
   service:
     main:
-      # Основной listener — обычно LoadBalancer/NodePort для внешнего доступа.
+      # Main listener — usually LoadBalancer/NodePort for external access.
       type: LoadBalancer
       annotations: {}
       externalTrafficPolicy: Local
       loadBalancerIP: ""
       loadBalancerSourceRanges: []
-      # Если указан tcpNodePort/udpNodePort, и type=NodePort — биндится этот порт.
+      # When type=NodePort and tcpNodePort/udpNodePort are set, bind those node ports.
       tcpNodePort: ""
       udpNodePort: ""
     api:
@@ -157,14 +157,14 @@ server:
 
   priorityClassName: ""
 
-  # Дополнительные env переменные.
+  # Extra environment variables.
   extraEnv: []
   extraEnvFrom: []
-  # Дополнительные volume / volumeMounts (например для логов).
+  # Extra volumes / volumeMounts (e.g., for logs).
   extraVolumes: []
   extraVolumeMounts: []
 
-  # Дополнительные CLI args. Полезно для флагов, явно не покрытых config.*.
+  # Extra CLI args. Useful for flags not exposed through config.*.
   extraArgs: []
 
   pdb:
@@ -174,13 +174,13 @@ server:
 
   networkPolicy:
     enabled: false
-    # Доп. namespace, откуда разрешён trafic в API (например, для Prometheus).
+    # Extra namespaces allowed to scrape the api port (e.g., for Prometheus).
     allowedMonitoringNamespaces: []
-    # Доп. peers для main listener (по умолчанию — мир).
+    # Extra peers for the main listener (default — world).
     allowedFromMain:
       - podSelector: {}
       - namespaceSelector: {}
-    # ipBlock для main listener (по умолчанию — 0.0.0.0/0).
+    # ipBlock for the main listener (default — 0.0.0.0/0).
     allowAllExternal: true
 
   metrics:
@@ -195,7 +195,7 @@ server:
       honorLabels: false
 
   autoscaling:
-    # Имеет смысл только при server.redis.addr / .Values.redis.enabled (общий state).
+    # Only meaningful when server.redis.addr or .Values.redis.enabled (shared state).
     enabled: false
     minReplicas: 2
     maxReplicas: 10
@@ -207,12 +207,12 @@ server:
 # =========================================================
 client:
   enabled: false
-  # socks → Deployment с SOCKS5 на 0.0.0.0:1080 + ClusterIP Service (доступно другим подам).
-  # tun   → DaemonSet с TUN-туннелем (требует privileged или NET_ADMIN/NET_RAW).
-  # both  → и то, и другое.
+  # socks → Deployment with SOCKS5 on 0.0.0.0:1080 + ClusterIP Service (reachable by other pods).
+  # tun   → DaemonSet with a TUN tunnel (requires privileged or NET_ADMIN/NET_RAW).
+  # both  → both workloads.
   mode: socks
 
-  # Адрес и секрет VPN-сервера. Можно через existingSecret (ключи: address, secret).
+  # VPN server address and secret. Can come from existingSecret (keys: address, secret).
   server:
     address: ""                 # vpn.example.com:443  (-server)
     secret: ""                  # (-secret)
@@ -220,31 +220,31 @@ client:
     existingSecretAddressKey: address
     existingSecretSecretKey: secret
 
-  # Конфиг через CLI-флаги (рекомендуется). Если задан client.tomlConfig — этот блок игнорируется.
-  # Поля соответствуют флагам `tiredvpn client` (см. cmd/tiredvpn/main.go).
+  # CLI-flag configuration (recommended). If client.tomlConfig is set, this block is ignored.
+  # Fields map to `tiredvpn client` flags (see cmd/tiredvpn/main.go).
   config:
     debug: false                # -debug
-    strategy: ""                # -strategy (пусто = автовыбор)
-    cover: ""                   # -cover (пусто = api.googleapis.com по умолчанию бинаря)
-    fallback: true              # -fallback (по умолчанию true)
+    strategy: ""                # -strategy (empty = auto)
+    cover: ""                   # -cover (empty = binary default api.googleapis.com)
+    fallback: true              # -fallback (default true)
     quic:
       enabled: false            # -quic
-      port: 0                   # -quic-port (0 = не передавать, оставить дефолт 443)
+      port: 0                   # -quic-port (0 = don't pass, leave default 443)
       sniFrag: false            # -quic-sni-frag
     ech:
       enabled: false            # -ech
       config: ""                # -ech-config (base64)
-      publicName: ""            # -ech-public-name (пусто = дефолт бинаря)
+      publicName: ""            # -ech-public-name (empty = binary default)
     pq:
       enabled: false            # -pq
       serverKey: ""             # -pq-server-key (base64)
     rttMasking:
       enabled: false            # -rtt-masking
-      profile: ""               # -rtt-profile (пусто = дефолт moscow-yandex)
+      profile: ""               # -rtt-profile (empty = default moscow-yandex)
     ipv6:
       serverV6: ""              # -server-v6 [2001:db8::1]:995
-      preferV6: true            # -prefer-ipv6 (дефолт true)
-      fallbackV4: true          # -fallback-v4 (дефолт true)
+      preferV6: true            # -prefer-ipv6 (default true)
+      fallbackV4: true          # -fallback-v4 (default true)
     portHop:
       enabled: false            # -port-hop
       start: 47000              # -port-hop-start
@@ -253,24 +253,24 @@ client:
       strategy: random          # -port-hop-strategy
       seed: ""                  # -port-hop-seed
     adaptive:
-      reprobeInterval: ""       # -reprobe-interval (пусто = дефолт 5m)
-      circuitThreshold: 0       # -circuit-threshold (0 = не передавать)
+      reprobeInterval: ""       # -reprobe-interval (empty = default 5m)
+      circuitThreshold: 0       # -circuit-threshold (0 = don't pass)
       circuitReset: ""          # -circuit-reset
     api:
-      enabled: false            # включить /metrics, /health
+      enabled: false            # exposes /metrics, /health
       listen: ":8080"           # -api-addr
     pprof:
       enabled: false
       listen: ":6060"           # -pprof
 
-  # Альтернатива config.* — сырое содержимое TOML (см. configs/client.example.toml).
+  # Alternative to config.* — raw TOML content (see configs/client.example.toml).
   tomlConfig: ""
 
   # -------- SOCKS5 mode (Deployment) --------
   socks:
     replicaCount: 1
-    listen: "0.0.0.0:1080"      # -listen (нужно 0.0.0.0 для доступа из других подов)
-    httpListen: ""              # -http-listen (опц. отдельный HTTP proxy порт)
+    listen: "0.0.0.0:1080"      # -listen (must be 0.0.0.0 for in-cluster access)
+    httpListen: ""              # -http-listen (optional separate HTTP proxy port)
     service:
       type: ClusterIP
       port: 1080
@@ -304,10 +304,10 @@ client:
       minAvailable: 1
 
   # -------- TUN mode (DaemonSet) --------
-  # ВНИМАНИЕ: дефолтный образ tiredvpn собран FROM scratch и НЕ содержит `ip`/`iptables`,
-  # которые требуются клиенту для настройки TUN. Перед использованием TUN-режима соберите
-  # собственный образ на базе alpine/debian с iproute2+iptables или используйте global.image
-  # для указания такого образа.
+  # NOTE: the default tiredvpn image is FROM scratch and does NOT contain `ip`/`iptables`,
+  # which the client needs to configure the TUN device. Before using TUN mode, build your
+  # own image based on alpine/debian with iproute2+iptables, or override global.image
+  # to point at such an image.
   tun:
     name: tiredvpn0             # -tun-name
     ip: 10.8.0.2                # -tun-ip
@@ -317,7 +317,7 @@ client:
     hostNetwork: true
     # true → privileged: true; false → drop ALL + add NET_ADMIN,NET_RAW.
     usePrivileged: false
-    # Образ override (рекомендуется собрать свой с iproute2). Пусто = global.image.
+    # Image override (recommended — build your own with iproute2). Empty = global.image.
     image:
       repository: ""
       tag: ""
@@ -340,7 +340,7 @@ client:
     podAnnotations: {}
     podLabels: {}
 
-  # Доп. env / volumes для обоих режимов.
+  # Extra env / volumes shared by both modes.
   extraEnv: []
   extraEnvFrom: []
   extraVolumes: []
@@ -360,22 +360,22 @@ client:
 
   networkPolicy:
     enabled: false
-    # Откуда разрешено коннектиться к SOCKS-порту.
+    # Where SOCKS port traffic is allowed from.
     allowedClientNamespaces: []
     allowedClientPodSelectors: []
-    # Куда разрешён egress (по умолчанию весь мир — VPN-сервер обычно публичный).
+    # Where egress is allowed to (default — world; the VPN server is usually public).
     allowAllEgress: true
 
 # =========================================================
 # REDIS subchart (bitnami)
 # =========================================================
-# Включается только для multi-client сервера. Когда redis.enabled=true и
-# server.redis.addr пусто — server подключается к <release>-redis-master:6379.
+# Enable for the multi-client server. When redis.enabled=true and
+# server.redis.addr is empty, the server connects to <release>-redis-master:6379.
 redis:
   enabled: false
   architecture: standalone
   auth:
-    # tiredvpn server (текущая версия) не передаёт пароль в Redis — оставляем без auth.
+    # The current tiredvpn server doesn't pass a password to Redis — leave auth off.
     enabled: false
   master:
     persistence:


### PR DESCRIPTION
## Summary

- README.md, values.yaml, NOTES.txt, `_helpers.tpl`, `server-networkpolicy.yaml`, all six `ci/*-values.yaml` fixtures, and the `chart-release.yml` workflow_dispatch input description are now in english.
- No template logic was changed; `helm template` output is byte-equivalent across all fixtures.

## Test plan

- [x] `grep -r '[А-Яа-я]'` clean across `deploy/helm/tiredvpn/` and `.github/workflows/chart-release.yml`.
- [x] `helm lint` clean on all 6 ci fixtures.
- [x] `helm template` succeeds on all 6 ci fixtures.
- [ ] CI `helm_chart` job green on this PR.