### PR TITLE
docs(readme): add helm install one-liner to Install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,15 @@ Available platforms: `linux-amd64`, `linux-arm64`. Other installation
 methods are described in the [Docker](#docker) and
 [Building from Source](#building-from-source) sections below.
 
+Kubernetes via Helm (server and/or client from a single release):
+
+```bash
+helm install my-tiredvpn oci://ghcr.io/tiredvpn/charts/tiredvpn --version 0.1.0 \
+  -f my-values.yaml
+```
+
+See [deploy/helm/tiredvpn/README.md](deploy/helm/tiredvpn/README.md) for values, examples, and TLS/auth/Redis/HPA options.
+
 ### Generate a shared secret
 
 ```bash


### PR DESCRIPTION
## Summary

Adds a short \`helm install oci://ghcr.io/tiredvpn/charts/tiredvpn\` snippet to the Install section of the main README, plus a link to \`deploy/helm/tiredvpn/README.md\` for values, examples, and the TLS/auth/Redis/HPA options.

## Test plan

- [x] Renders correctly in Markdown preview.
- [x] Link to \`deploy/helm/tiredvpn/README.md\` is valid.