### PR TITLE
Key the IP lease on where the identity came from, not how it is spelled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Clients sharing one secret still shared one tunnel IP, and evicted each
+  other every thirty seconds.** 1.3.26 qualified the IP-pool lease with the
+  client's address, but only for the identity spelled `global`. REALITY derives
+  its identity as an HMAC of the secret and nothing else, so every client on a
+  shared secret authenticates as the same `reality:<hex>`; HTTP polling builds
+  `polling:global` the same way. Those never matched the check, so the flap the
+  earlier fix was written for carried on unnoticed under a different name: one
+  Dubai exit had three addresses on a single `reality:` identity taking
+  10.8.2.4 from each other, each eviction landing on a connection that had
+  carried traffic a moment earlier, until the client gave up on REALITY and
+  fell back to a slower transport. Whether an identity can key a lease is now
+  recorded where the identity is derived - registry clients are per-client,
+  anything derived from the shared secret is not - instead of being guessed
+  from how the string is spelled. An identity nobody classified counts as
+  shared, so the next transport to be added fails safe. Registry clients are
+  unaffected and keep their address across a change of network.
+
 ## [1.4.2] - 2026-08-25
 
 ### Fixed

--- a/internal/server/camouflage_handshake_test.go
+++ b/internal/server/camouflage_handshake_test.go
@@ -209,8 +209,11 @@ func TestVerifyIMAPAuth(t *testing.T) {
 		if !ok {
 			t.Fatal("a token minted from a registered client's secret was rejected")
 		}
-		if id != "c1" {
-			t.Errorf("clientID = %q, want c1", id)
+		if id.id != "c1" {
+			t.Errorf("clientID = %q, want c1", id.id)
+		}
+		if !id.perClient {
+			t.Error("a registry client must be marked per-client, or its lease gets qualified and it loses its stable IP")
 		}
 		if string(secret) != perClient {
 			t.Errorf("returned secret = %q, want the client's own", secret)
@@ -222,8 +225,11 @@ func TestVerifyIMAPAuth(t *testing.T) {
 		if !ok {
 			t.Fatal("a token minted from the global secret was rejected")
 		}
-		if id != "global" {
-			t.Errorf("clientID = %q, want global", id)
+		if id.id != "global" {
+			t.Errorf("clientID = %q, want global", id.id)
+		}
+		if id.perClient {
+			t.Error("the global secret identifies nobody; marking it per-client is what lets two clients share one lease")
 		}
 		if string(secret) != string(global) {
 			t.Errorf("returned secret = %q, want the global secret", secret)
@@ -263,11 +269,11 @@ func TestVerifySSHAuth(t *testing.T) {
 	r.byID["c1"] = &ClientConfig{ID: "c1", Secret: perClient, Enabled: true}
 	srvCtx.registry = r
 
-	if id, _, ok := verifySSHAuth(strategy.GenerateSSHAuthToken([]byte(perClient)), srvCtx); !ok || id != "c1" {
-		t.Errorf("per-client token: id=%q ok=%v, want c1/true", id, ok)
+	if id, _, ok := verifySSHAuth(strategy.GenerateSSHAuthToken([]byte(perClient)), srvCtx); !ok || id.id != "c1" || !id.perClient {
+		t.Errorf("per-client token: id=%q perClient=%v ok=%v, want c1/true/true", id.id, id.perClient, ok)
 	}
-	if id, _, ok := verifySSHAuth(strategy.GenerateSSHAuthToken(global), srvCtx); !ok || id != "global" {
-		t.Errorf("global token: id=%q ok=%v, want global/true", id, ok)
+	if id, _, ok := verifySSHAuth(strategy.GenerateSSHAuthToken(global), srvCtx); !ok || id.id != "global" || id.perClient {
+		t.Errorf("global token: id=%q perClient=%v ok=%v, want global/false/true", id.id, id.perClient, ok)
 	}
 	if _, _, ok := verifySSHAuth(strategy.GenerateSSHAuthToken([]byte("nope-nope-nope-nope-nope-nope!!")), srvCtx); ok {
 		t.Error("an unknown secret authenticated")
@@ -338,7 +344,7 @@ func TestIMAPServerHandshakeSuccess(t *testing.T) {
 	defer clientConn.Close()
 
 	type result struct {
-		clientID string
+		clientID clientIdentity
 		err      error
 	}
 	done := make(chan result, 1)
@@ -359,8 +365,11 @@ func TestIMAPServerHandshakeSuccess(t *testing.T) {
 		if res.err != nil {
 			t.Fatalf("imapServerHandshake: %v", res.err)
 		}
-		if res.clientID != "global" {
-			t.Errorf("clientID = %q, want global", res.clientID)
+		if res.clientID.id != "global" {
+			t.Errorf("clientID = %q, want global", res.clientID.id)
+		}
+		if res.clientID.perClient {
+			t.Error("the global secret must not come back marked per-client")
 		}
 	case <-time.After(15 * time.Second):
 		t.Fatal("imapServerHandshake did not return")
@@ -499,7 +508,7 @@ func TestSSHServerHandshakeSuccess(t *testing.T) {
 	defer clientConn.Close()
 
 	type result struct {
-		clientID string
+		clientID clientIdentity
 		err      error
 	}
 	done := make(chan result, 1)
@@ -551,8 +560,11 @@ func TestSSHServerHandshakeSuccess(t *testing.T) {
 		if res.err != nil {
 			t.Fatalf("sshServerHandshake: %v", res.err)
 		}
-		if res.clientID != "global" {
-			t.Errorf("clientID = %q, want global", res.clientID)
+		if res.clientID.id != "global" {
+			t.Errorf("clientID = %q, want global", res.clientID.id)
+		}
+		if res.clientID.perClient {
+			t.Error("the global secret must not come back marked per-client")
 		}
 	case <-time.After(15 * time.Second):
 		t.Fatal("sshServerHandshake did not return")

--- a/internal/server/h2_stego_handshake_test.go
+++ b/internal/server/h2_stego_handshake_test.go
@@ -51,7 +51,7 @@ func TestH2StegoHandshakeEndToEnd(t *testing.T) {
 		}
 		hpackDec := hpack.NewDecoder(4096, nil)
 		authenticated := false
-		var authClientID string
+		var authClientID clientIdentity
 		var tunnel *h2TunnelState
 		var connTracked bool
 		serverErr <- nil

--- a/internal/server/icmp_server.go
+++ b/internal/server/icmp_server.go
@@ -235,7 +235,7 @@ func (s *ICMPServer) getOrCreateSession(
 	// pipeConnToSend is not left blocking on serverConn.Read until TTL eviction.
 	// removeSession uses sync.Once internally so duplicate calls are harmless.
 	go func() {
-		handleRawTunnel(clientConn, s.srvCtx, logger, "")
+		handleRawTunnel(clientConn, s.srvCtx, logger, clientIdentity{})
 		s.removeSession(sess.sessionID)
 	}()
 

--- a/internal/server/imap_handler.go
+++ b/internal/server/imap_handler.go
@@ -61,7 +61,7 @@ func handleIMAPCamouflage(conn net.Conn, srvCtx *serverContext, logger *log.Logg
 // imapServerHandshake reads the client greeting, answers CAPABILITY, verifies
 // the LOGIN auth token and answers SELECT INBOX. On success it returns the
 // matched client ID (or "global") and the buffered reader for the tunnel phase.
-func imapServerHandshake(conn net.Conn, srvCtx *serverContext, logger *log.Logger) (string, *bufio.Reader, error) {
+func imapServerHandshake(conn net.Conn, srvCtx *serverContext, logger *log.Logger) (clientIdentity, *bufio.Reader, error) {
 	conn.SetDeadline(time.Now().Add(15 * time.Second))
 	defer conn.SetDeadline(time.Time{})
 
@@ -70,68 +70,68 @@ func imapServerHandshake(conn net.Conn, srvCtx *serverContext, logger *log.Logge
 	// 1. Read the unsolicited greeting line the client opened with.
 	greeting, err := br.ReadString('\n')
 	if err != nil {
-		return "", nil, fmt.Errorf("reading client greeting: %w", err)
+		return clientIdentity{}, nil, fmt.Errorf("reading client greeting: %w", err)
 	}
 	if !strings.HasPrefix(greeting, "* OK") {
-		return "", nil, fmt.Errorf("not an IMAP greeting")
+		return clientIdentity{}, nil, fmt.Errorf("not an IMAP greeting")
 	}
 
 	// 2. CAPABILITY.
 	capLine, err := br.ReadString('\n')
 	if err != nil {
-		return "", nil, fmt.Errorf("reading CAPABILITY: %w", err)
+		return clientIdentity{}, nil, fmt.Errorf("reading CAPABILITY: %w", err)
 	}
 	capTag := imapTag(capLine)
 	if capTag == "" || !strings.Contains(capLine, "CAPABILITY") {
-		return "", nil, fmt.Errorf("expected CAPABILITY command")
+		return clientIdentity{}, nil, fmt.Errorf("expected CAPABILITY command")
 	}
 	if _, err := conn.Write([]byte(strategy.IMAPPreLoginCaps())); err != nil {
-		return "", nil, err
+		return clientIdentity{}, nil, err
 	}
 	if _, err := conn.Write([]byte(capTag + " OK Pre-login capabilities listed, post-login capabilities have more.\r\n")); err != nil {
-		return "", nil, err
+		return clientIdentity{}, nil, err
 	}
 
 	// 3. LOGIN <user> <base64-token>.
 	loginLine, err := br.ReadString('\n')
 	if err != nil {
-		return "", nil, fmt.Errorf("reading LOGIN: %w", err)
+		return clientIdentity{}, nil, fmt.Errorf("reading LOGIN: %w", err)
 	}
 	fields := strings.Fields(loginLine)
 	if len(fields) < 4 || !strings.EqualFold(fields[1], "LOGIN") {
-		return "", nil, fmt.Errorf("malformed LOGIN command")
+		return clientIdentity{}, nil, fmt.Errorf("malformed LOGIN command")
 	}
 	loginTag := fields[0]
 	token, err := base64DecodeToken(fields[3])
 	if err != nil {
-		return "", nil, fmt.Errorf("decoding LOGIN token: %w", err)
+		return clientIdentity{}, nil, fmt.Errorf("decoding LOGIN token: %w", err)
 	}
 
 	clientID, _, ok := verifyIMAPAuth(token, srvCtx)
 	if !ok {
 		// Look like a real auth rejection before bailing out.
 		_, _ = conn.Write([]byte(loginTag + " NO [AUTHENTICATIONFAILED] Authentication failed.\r\n"))
-		return "", nil, fmt.Errorf("auth token verification failed")
+		return clientIdentity{}, nil, fmt.Errorf("auth token verification failed")
 	}
 
 	if _, err := conn.Write([]byte(strategy.IMAPPostLoginCaps())); err != nil {
-		return "", nil, err
+		return clientIdentity{}, nil, err
 	}
 	if _, err := fmt.Fprintf(conn, "%s OK [CAPABILITY %s] Logged in\r\n", loginTag, strategy.IMAPCapsInline()); err != nil {
-		return "", nil, err
+		return clientIdentity{}, nil, err
 	}
 
 	// 4. SELECT INBOX.
 	selectLine, err := br.ReadString('\n')
 	if err != nil {
-		return "", nil, fmt.Errorf("reading SELECT: %w", err)
+		return clientIdentity{}, nil, fmt.Errorf("reading SELECT: %w", err)
 	}
 	selectTag := imapTag(selectLine)
 	if selectTag == "" || !strings.Contains(strings.ToUpper(selectLine), "SELECT") {
-		return "", nil, fmt.Errorf("expected SELECT command")
+		return clientIdentity{}, nil, fmt.Errorf("expected SELECT command")
 	}
 	if _, err := conn.Write([]byte(buildIMAPSelectResponse(selectTag))); err != nil {
-		return "", nil, err
+		return clientIdentity{}, nil, err
 	}
 
 	conn.SetDeadline(time.Time{})
@@ -173,17 +173,17 @@ func buildIMAPSelectResponse(tag string) string {
 // verifyIMAPAuth checks the token against per-client secrets (registry) and
 // then the global secret. Returns the matched client ID, the secret used, and
 // whether authentication succeeded.
-func verifyIMAPAuth(token []byte, srvCtx *serverContext) (string, []byte, bool) {
+func verifyIMAPAuth(token []byte, srvCtx *serverContext) (clientIdentity, []byte, bool) {
 	if srvCtx.registry != nil {
 		for _, client := range srvCtx.registry.ListClients() {
 			secret := []byte(client.Secret)
 			if strategy.VerifyIMAPAuthToken(token, secret) {
-				return client.ID, secret, true
+				return registryIdentity(client.ID), secret, true
 			}
 		}
 	}
 	if len(srvCtx.cfg.Secret) > 0 && strategy.VerifyIMAPAuthToken(token, srvCtx.cfg.Secret) {
-		return "global", srvCtx.cfg.Secret, true
+		return sharedIdentity(globalClientID), srvCtx.cfg.Secret, true
 	}
-	return "", nil, false
+	return clientIdentity{}, nil, false
 }

--- a/internal/server/ktls_relay_test.go
+++ b/internal/server/ktls_relay_test.go
@@ -66,7 +66,7 @@ func TestRawTunnelKTLSHandover(t *testing.T) {
 			tlsConn.Close()
 			return
 		}
-		handleRawTunnel(tlsConn, srvCtx, logger, "")
+		handleRawTunnel(tlsConn, srvCtx, logger, clientIdentity{})
 	}()
 
 	// Client: dial, complete TLS handshake, send tired-raw frame.

--- a/internal/server/reality.go
+++ b/internal/server/reality.go
@@ -1,10 +1,7 @@
 package server
 
 import (
-	"crypto/hmac"
 	"crypto/rand"
-	"crypto/sha256"
-	"fmt"
 	"io"
 	"net"
 	"time"
@@ -385,11 +382,7 @@ func handleREALITYAuthenticated(conn net.Conn, srvCtx *serverContext, logger *lo
 	// Close connection to real destination (we only needed the certificate)
 	destConn.Close()
 
-	// Derive stable clientID from the shared secret — same user reconnects with the same secret,
-	// so gets the same clientID and same IP from the pool.
-	mac := hmac.New(sha256.New, usedSecret)
-	mac.Write([]byte("tiredvpn-client-id-v1"))
-	clientID := fmt.Sprintf("reality:%x", mac.Sum(nil)[:8])
+	clientID := realityClientIdentity(usedSecret)
 
 	logger.Info("REALITY: Tunnel established for %s (client: %s)", conn.RemoteAddr(), clientID)
 
@@ -448,7 +441,7 @@ func dataLayerVersion(v2 bool) int {
 // after its TypeMux write. params non-nil selects the v2 AEAD layer keyed by
 // this connection's X25519 exchange; nil is a v1 client, still keyed by
 // HKDF(secret, salt=clientPubKey).
-func handleREALITYMuxSession(conn net.Conn, srvCtx *serverContext, logger *log.Logger, clientID string, usedSecret []byte, clientPubKey [32]byte, params *strategy.RealityV2Params) {
+func handleREALITYMuxSession(conn net.Conn, srvCtx *serverContext, logger *log.Logger, clientID clientIdentity, usedSecret []byte, clientPubKey [32]byte, params *strategy.RealityV2Params) {
 	// Mirror the client-side wrap: server is !isClient so write/read keys are reversed.
 	var (
 		dataConn net.Conn

--- a/internal/server/reality_b1_test.go
+++ b/internal/server/reality_b1_test.go
@@ -21,7 +21,7 @@ type b1Fixture struct {
 	srvCtx    *serverContext
 	serverPub [32]byte
 	secret    []byte
-	clientID  string
+	clientID  clientIdentity
 }
 
 // newB1Fixture loads a static server key and builds a gate holding one client.
@@ -62,7 +62,7 @@ func newB1Fixture(t *testing.T, extraClients int) b1Fixture {
 		srvCtx:    &serverContext{cfg: cfg},
 		serverPub: serverPub,
 		secret:    secret,
-		clientID:  "alice",
+		clientID:  registryIdentity("alice"),
 	}
 }
 
@@ -166,7 +166,7 @@ func TestB1GateAcceptsValidHello(t *testing.T) {
 		t.Fatalf("valid hello did not authenticate: %s", verdict.reason)
 	}
 	if verdict.entry.clientID != f.clientID {
-		t.Fatalf("clientID = %q, want %q", verdict.entry.clientID, f.clientID)
+		t.Fatalf("clientID = %+v, want %+v", verdict.entry.clientID, f.clientID)
 	}
 	if string(verdict.entry.secret) != string(f.secret) {
 		t.Fatal("gate returned the wrong secret")
@@ -592,7 +592,7 @@ func TestShortIDIndexRebuildSkipsUnusableClients(t *testing.T) {
 		nil,
 	}, global)
 
-	if e, ok := idx.Lookup(customtls.ShortIDFor([]byte("good-secret"))); !ok || e.clientID != "ok" {
+	if e, ok := idx.Lookup(customtls.ShortIDFor([]byte("good-secret"))); !ok || e.clientID.id != "ok" || !e.clientID.perClient {
 		t.Fatal("an enabled client is missing from the index")
 	}
 	if _, ok := idx.Lookup(customtls.ShortIDFor([]byte("disabled-secret"))); ok {
@@ -601,7 +601,7 @@ func TestShortIDIndexRebuildSkipsUnusableClients(t *testing.T) {
 	if _, ok := idx.Lookup(customtls.ShortIDFor([]byte("expired-secret"))); ok {
 		t.Fatal("an expired client can still authenticate")
 	}
-	if e, ok := idx.Lookup(customtls.ShortIDFor(global)); !ok || e.clientID != "global" {
+	if e, ok := idx.Lookup(customtls.ShortIDFor(global)); !ok || e.clientID.id != "global" || e.clientID.perClient {
 		t.Fatal("the global secret is missing from the index")
 	}
 }

--- a/internal/server/reality_b1_tls.go
+++ b/internal/server/reality_b1_tls.go
@@ -118,7 +118,7 @@ func b1TLSFor(srvCtx *serverContext) (*tls.Config, *certMinter) {
 // conn is the buffered connection that still replays the ClientHello, so
 // crypto/tls reads the same bytes the gate already inspected - the same
 // mechanism the plain TLS path uses.
-func handleREALITYB1(conn net.Conn, peekBuf []byte, clientID string, secret []byte, clientFlags byte, srvCtx *serverContext, logger *log.Logger) {
+func handleREALITYB1(conn net.Conn, peekBuf []byte, clientID clientIdentity, secret []byte, clientFlags byte, srvCtx *serverContext, logger *log.Logger) {
 	cfg, _ := b1TLSFor(srvCtx)
 
 	// Bound the handshake explicitly. Until now the only thing stopping a

--- a/internal/server/reality_b1_tls_test.go
+++ b/internal/server/reality_b1_tls_test.go
@@ -363,7 +363,7 @@ func TestB1HandshakeIsBoundedAndTheTunnelIsNot(t *testing.T) {
 			return
 		}
 		rec := &deadlineRecorder{Conn: raw}
-		handleREALITYB1(rec, peek, "test-client", secret, customtls.AuthFlagExporterBinding, srvCtx, log.WithPrefix("test"))
+		handleREALITYB1(rec, peek, registryIdentity("test-client"), secret, customtls.AuthFlagExporterBinding, srvCtx, log.WithPrefix("test"))
 		recorded <- rec.seen()
 	}()
 

--- a/internal/server/reality_shortid.go
+++ b/internal/server/reality_shortid.go
@@ -1,6 +1,9 @@
 package server
 
 import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"fmt"
 	"sync"
 	"time"
 
@@ -10,7 +13,7 @@ import (
 // shortIDEntry is what a successful short-ID lookup yields: which client sent
 // the ClientHello, and the secret the rest of the session is keyed with.
 type shortIDEntry struct {
-	clientID string
+	clientID clientIdentity
 	secret   []byte
 }
 
@@ -65,7 +68,7 @@ func (i *shortIDIndex) Rebuild(clients []*ClientConfig, globalSecret []byte) {
 			continue
 		}
 		secret := []byte(c.Secret)
-		next[customtls.ShortIDFor(secret)] = shortIDEntry{clientID: c.ID, secret: secret}
+		next[customtls.ShortIDFor(secret)] = shortIDEntry{clientID: registryIdentity(c.ID), secret: secret}
 	}
 
 	if len(globalSecret) > 0 {
@@ -74,7 +77,7 @@ func (i *shortIDIndex) Rebuild(clients []*ClientConfig, globalSecret []byte) {
 		// being silently merged into "global".
 		id := customtls.ShortIDFor(globalSecret)
 		if _, taken := next[id]; !taken {
-			next[id] = shortIDEntry{clientID: "global", secret: globalSecret}
+			next[id] = shortIDEntry{clientID: sharedIdentity(globalClientID), secret: globalSecret}
 		}
 	}
 
@@ -220,4 +223,18 @@ func (c *replayCache) sweepLocked(now time.Time) {
 			delete(c.seen, id)
 		}
 	}
+}
+
+// realityClientIdentity derives the identity a REALITY client is known by from
+// the secret it authenticated with.
+//
+// The value depends on the secret and on nothing else, which is the point: one
+// user reconnecting is recognised across sessions. The consequence is that it
+// says nothing about WHICH client is holding that secret - on the global secret
+// every client in the world produces this same string. It is therefore shared,
+// and a lease keyed on it alone collides. See clientIdentity.
+func realityClientIdentity(secret []byte) clientIdentity {
+	mac := hmac.New(sha256.New, secret)
+	mac.Write([]byte("tiredvpn-client-id-v1"))
+	return sharedIdentity(fmt.Sprintf("reality:%x", mac.Sum(nil)[:8]))
 }

--- a/internal/server/relay_dualstack_test.go
+++ b/internal/server/relay_dualstack_test.go
@@ -295,7 +295,7 @@ func TestRelayChainForwardsDualStack(t *testing.T) {
 		}
 		hpackDec := hpack.NewDecoder(4096, nil)
 		authenticated := false
-		var authClientID string
+		var authClientID clientIdentity
 		var tunnel *h2TunnelState
 		var connTracked bool
 		runH2FrameLoop(&conn, &framer, hpackDec, relayCtx, logger, &authenticated, &authClientID, &connTracked, &tunnel, nil)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -951,17 +951,21 @@ func handleQUICConnection(conn net.Conn, srvCtx *serverContext, connID uint64) {
 	logger.Info("QUIC connection from %s (authenticated)", remoteAddr)
 
 	// Extract clientID from QUICServerConn if available
-	clientID := ""
+	var clientID clientIdentity
 	if qc, ok := conn.(*strategy.QUICServerConn); ok {
-		clientID = qc.ClientID
+		if qc.ClientIDFromRegistry {
+			clientID = registryIdentity(qc.ClientID)
+		} else {
+			clientID = sharedIdentity(qc.ClientID)
+		}
 	}
 
 	// Track per-client connection for metrics
-	if srvCtx.registry != nil && clientID != "" {
-		if err := srvCtx.registry.AddConnection(clientID, conn); err != nil {
+	if srvCtx.registry != nil && clientID.id != "" {
+		if err := srvCtx.registry.AddConnection(clientID.id, conn); err != nil {
 			logger.Warn("Failed to track QUIC connection for client %s: %v", clientID, err)
 		} else {
-			defer srvCtx.registry.RemoveConnection(clientID, conn)
+			defer srvCtx.registry.RemoveConnection(clientID.id, conn)
 		}
 	}
 
@@ -1068,8 +1072,8 @@ func handleQUICConnection(conn net.Conn, srvCtx *serverContext, connID uint64) {
 	}
 
 	// Update per-client metrics
-	if srvCtx.registry != nil && clientID != "" {
-		srvCtx.registry.AddBytes(clientID, bytesUp, bytesDown)
+	if srvCtx.registry != nil && clientID.id != "" {
+		srvCtx.registry.AddBytes(clientID.id, bytesUp, bytesDown)
 	}
 }
 
@@ -1356,7 +1360,7 @@ func handleTLSConnection(conn *tls.Conn, srvCtx *serverContext, connID uint64) {
 	case protocol.TypeStego:
 		handleHTTP2WithALPN(conn, srvCtx, logger)
 	case protocol.TypeRaw:
-		handleRawTunnel(conn, srvCtx, logger, "")
+		handleRawTunnel(conn, srvCtx, logger, clientIdentity{})
 	case protocol.TypeConfusion:
 		handleProtocolConfusion(conn, srvCtx, logger)
 	case protocol.TypeAntiProbe:
@@ -1490,7 +1494,7 @@ func handleHTTP2WithALPN(conn net.Conn, srvCtx *serverContext, logger *log.Logge
 
 	hpackDec := hpack.NewDecoder(4096, nil)
 	authenticated := false
-	var authClientID string
+	var authClientID clientIdentity
 	var tunnel *h2TunnelState
 	var connTracked bool
 
@@ -1521,7 +1525,7 @@ func handleMorphConnectionWithALPN(conn net.Conn, srvCtx *serverContext, logger 
 type h2TunnelState struct {
 	targetConn      net.Conn
 	streamID        uint32
-	clientID        string // Client ID for IP pool allocation
+	clientID        clientIdentity // Client identity for IP pool allocation
 	remoteAddr      string // Peer host, used to qualify the IP-pool lease key
 	mu              sync.Mutex
 	sharedTUNWriter *ClientWriter // For shared TUN mode
@@ -1552,7 +1556,7 @@ func handleHTTP2(conn net.Conn, srvCtx *serverContext, logger *log.Logger) {
 	hpackDec := hpack.NewDecoder(4096, nil)
 
 	authenticated := false
-	var authClientID string
+	var authClientID clientIdentity
 	var tunnel *h2TunnelState
 	var connTracked bool
 	defer cleanupH2Conn(conn, srvCtx, &tunnel, &connTracked, &authClientID)
@@ -1578,15 +1582,15 @@ func initH2Framer(conn net.Conn, logger *log.Logger) (*http2.Framer, error) {
 }
 
 // cleanupH2Conn closes tunnel target and removes per-client connection tracking on defer.
-func cleanupH2Conn(conn net.Conn, srvCtx *serverContext, tunnel **h2TunnelState, connTracked *bool, authClientID *string) {
+func cleanupH2Conn(conn net.Conn, srvCtx *serverContext, tunnel **h2TunnelState, connTracked *bool, authClientID *clientIdentity) {
 	if *tunnel != nil && (*tunnel).targetConn != nil {
 		(*tunnel).targetConn.Close()
 	}
 	if *tunnel != nil && (*tunnel).sink != nil {
 		(*tunnel).sink.Close()
 	}
-	if *connTracked && srvCtx.registry != nil && *authClientID != "" {
-		srvCtx.registry.RemoveConnection(*authClientID, conn)
+	if *connTracked && srvCtx.registry != nil && authClientID.id != "" {
+		srvCtx.registry.RemoveConnection(authClientID.id, conn)
 	}
 }
 
@@ -1597,7 +1601,7 @@ func cleanupH2Conn(conn net.Conn, srvCtx *serverContext, tunnel **h2TunnelState,
 // (legacy non-ALPN path), in which case no kTLS upgrade happens. When set, it
 // is invoked exactly once — immediately after auth succeeds — and returns the
 // connection and framer to use for the subsequent relay phase.
-func runH2FrameLoop(connPtr *net.Conn, framerPtr **http2.Framer, hpackDec *hpack.Decoder, srvCtx *serverContext, logger *log.Logger, authenticated *bool, authClientID *string, connTracked *bool, tunnel **h2TunnelState, handover func(net.Conn) (net.Conn, *http2.Framer)) {
+func runH2FrameLoop(connPtr *net.Conn, framerPtr **http2.Framer, hpackDec *hpack.Decoder, srvCtx *serverContext, logger *log.Logger, authenticated *bool, authClientID *clientIdentity, connTracked *bool, tunnel **h2TunnelState, handover func(net.Conn) (net.Conn, *http2.Framer)) {
 	cfg := srvCtx.cfg
 	for {
 		conn := *connPtr
@@ -1645,7 +1649,7 @@ func runH2FrameLoop(connPtr *net.Conn, framerPtr **http2.Framer, hpackDec *hpack
 }
 
 // processH2HeadersFrame extracts auth headers and, if valid, marks the connection authenticated.
-func processH2HeadersFrame(conn net.Conn, f *http2.HeadersFrame, framer *http2.Framer, hpackDec *hpack.Decoder, srvCtx *serverContext, logger *log.Logger, authenticated *bool, authClientID *string, connTracked *bool) {
+func processH2HeadersFrame(conn net.Conn, f *http2.HeadersFrame, framer *http2.Framer, hpackDec *hpack.Decoder, srvCtx *serverContext, logger *log.Logger, authenticated *bool, authClientID *clientIdentity, connTracked *bool) {
 	var apiKey, requestID string
 	hpackDec.SetEmitFunc(func(hf hpack.HeaderField) {
 		logger.Debug("  Header: %s = %s", hf.Name, truncate(hf.Value, 50))
@@ -1672,8 +1676,8 @@ func processH2HeadersFrame(conn net.Conn, f *http2.HeadersFrame, framer *http2.F
 	*authClientID = clientID
 	sendH2AuthAck(framer, f.StreamID, secret)
 
-	if !*connTracked && srvCtx.registry != nil && clientID != "" {
-		if err := srvCtx.registry.AddConnection(clientID, conn); err != nil {
+	if !*connTracked && srvCtx.registry != nil && clientID.id != "" {
+		if err := srvCtx.registry.AddConnection(clientID.id, conn); err != nil {
 			logger.Warn("Failed to track H2 connection for client %s: %v", clientID, err)
 		} else {
 			*connTracked = true
@@ -1683,24 +1687,24 @@ func processH2HeadersFrame(conn net.Conn, f *http2.HeadersFrame, framer *http2.F
 
 // verifyH2AuthMulti checks per-client secrets then global secret for HTTP/2 stego auth.
 // Returns (ok, clientID, usedSecret).
-func verifyH2AuthMulti(srvCtx *serverContext, apiKey, requestID string, logger *log.Logger) (bool, string, []byte) {
+func verifyH2AuthMulti(srvCtx *serverContext, apiKey, requestID string, logger *log.Logger) (bool, clientIdentity, []byte) {
 	if srvCtx.registry != nil {
 		for _, client := range srvCtx.registry.ListClients() {
 			if verifyH2Auth(apiKey, requestID, []byte(client.Secret)) {
 				logger.Info("HTTP/2 steganography authenticated (client: %s, id: %s)", client.Name, client.ID)
-				return true, client.ID, []byte(client.Secret)
+				return true, registryIdentity(client.ID), []byte(client.Secret)
 			}
 		}
 	}
 	if len(srvCtx.cfg.Secret) > 0 && verifyH2Auth(apiKey, requestID, srvCtx.cfg.Secret) {
 		logger.Info("HTTP/2 steganography authenticated (global secret)")
-		return true, "global", srvCtx.cfg.Secret
+		return true, sharedIdentity(globalClientID), srvCtx.cfg.Secret
 	}
-	return false, "", nil
+	return false, clientIdentity{}, nil
 }
 
 // handleH2DataFrame processes an authenticated HTTP/2 DATA frame.
-func handleH2DataFrame(conn net.Conn, f *http2.DataFrame, framer *http2.Framer, cfg *Config, srvCtx *serverContext, _ *h2TunnelState, authClientID string, logger *log.Logger, tunnelPtr **h2TunnelState) {
+func handleH2DataFrame(conn net.Conn, f *http2.DataFrame, framer *http2.Framer, cfg *Config, srvCtx *serverContext, _ *h2TunnelState, authClientID clientIdentity, logger *log.Logger, tunnelPtr **h2TunnelState) {
 	data := f.Data()
 	logger.Debug("Received DATA: %d bytes", len(data))
 
@@ -1959,7 +1963,7 @@ func handleMorphConnection(conn net.Conn, srvCtx *serverContext, logger *log.Log
 	// Verify auth token against per-client secrets and global secret
 	authenticated := false
 	var usedSecret []byte
-	var clientID string // For IP pool allocation
+	var clientID clientIdentity // For IP pool allocation
 
 	// 1. Try per-client secrets from Redis (if registry exists)
 	if srvCtx.registry != nil {
@@ -1972,7 +1976,7 @@ func handleMorphConnection(conn net.Conn, srvCtx *serverContext, logger *log.Log
 				logger.Info("Traffic Morph authenticated (client: %s, id: %s)", client.Name, client.ID)
 				authenticated = true
 				usedSecret = secretBytes
-				clientID = client.ID
+				clientID = registryIdentity(client.ID)
 				break
 			}
 		}
@@ -1986,7 +1990,7 @@ func handleMorphConnection(conn net.Conn, srvCtx *serverContext, logger *log.Log
 			logger.Info("Traffic Morph authenticated (global secret)")
 			authenticated = true
 			usedSecret = srvCtx.cfg.Secret
-			clientID = "global" // Use "global" as clientID for global secret users
+			clientID = sharedIdentity(globalClientID) // every client on the shared secret lands here
 		}
 	}
 
@@ -2008,12 +2012,12 @@ func handleMorphConnection(conn net.Conn, srvCtx *serverContext, logger *log.Log
 	// Track per-client connection for metrics. Use a closure on the conn
 	// variable so the defer picks up the kTLS-wrapped value if we hand
 	// the socket over later via ktls.TryEnable + registry.SwapConn.
-	if srvCtx.registry != nil && clientID != "" {
-		if err := srvCtx.registry.AddConnection(clientID, conn); err != nil {
+	if srvCtx.registry != nil && clientID.id != "" {
+		if err := srvCtx.registry.AddConnection(clientID.id, conn); err != nil {
 			logger.Warn("Failed to track connection for client %s: %v", clientID, err)
 		} else {
 			defer func() {
-				srvCtx.registry.RemoveConnection(clientID, conn)
+				srvCtx.registry.RemoveConnection(clientID.id, conn)
 			}()
 		}
 	}
@@ -2033,10 +2037,10 @@ func handleMorphConnection(conn net.Conn, srvCtx *serverContext, logger *log.Log
 	// frame reads (target addr) and writes (relay data) go through kTLS.
 	preSwap := conn
 	conn = ktls.TryEnable(conn, "tired-morph")
-	if conn != preSwap && srvCtx.registry != nil && clientID != "" {
+	if conn != preSwap && srvCtx.registry != nil && clientID.id != "" {
 		// Replace the stored *tls.Conn with the live *ktls.Conn so
 		// forced-disconnect Close() targets the right socket wrapper.
-		srvCtx.registry.SwapConn(clientID, preSwap, conn)
+		srvCtx.registry.SwapConn(clientID.id, preSwap, conn)
 	}
 
 	// Read first morph packet containing target address
@@ -2283,8 +2287,8 @@ func handleMorphConnection(conn net.Conn, srvCtx *serverContext, logger *log.Log
 	}
 
 	// Update per-client metrics
-	if srvCtx.registry != nil && clientID != "" {
-		srvCtx.registry.AddBytes(clientID, bytesUp, bytesDown)
+	if srvCtx.registry != nil && clientID.id != "" {
+		srvCtx.registry.AddBytes(clientID.id, bytesUp, bytesDown)
 	}
 }
 
@@ -2320,16 +2324,16 @@ func morphFramePacket(pkt []byte) []byte {
 }
 
 // handleMorphTUNMode handles TUN mode over Morph protocol
-func handleMorphTUNMode(conn net.Conn, remainingData []byte, srvCtx *serverContext, logger *log.Logger, clientID string) {
+func handleMorphTUNMode(conn net.Conn, remainingData []byte, srvCtx *serverContext, logger *log.Logger, clientID clientIdentity) {
 	cfg := srvCtx.cfg
 	logger.Debug("Processing Morph TUN mode, remaining data: %d bytes, hex=%x", len(remainingData), remainingData)
 
 	// Track per-client connection for metrics
-	if srvCtx.registry != nil && clientID != "" {
-		if err := srvCtx.registry.AddConnection(clientID, conn); err != nil {
+	if srvCtx.registry != nil && clientID.id != "" {
+		if err := srvCtx.registry.AddConnection(clientID.id, conn); err != nil {
 			logger.Warn("Failed to track connection for client %s: %v", clientID, err)
 		} else {
-			defer srvCtx.registry.RemoveConnection(clientID, conn)
+			defer srvCtx.registry.RemoveConnection(clientID.id, conn)
 		}
 	}
 
@@ -2411,7 +2415,7 @@ func handleMorphTUNMode(conn net.Conn, remainingData []byte, srvCtx *serverConte
 		serverIP = cfg.TunIP
 
 		// Register client with shared TUN using Morph framing
-		writer := srvCtx.sharedTUN.RegisterClient(clientIP, clientID, conn, morphFramePacket)
+		writer := srvCtx.sharedTUN.RegisterClient(clientIP, clientID.id, conn, morphFramePacket)
 		localSink := newLocalTUNSink(srvCtx.sharedTUN, writer, clientIP)
 		sink = localSink
 		defer func() {
@@ -2717,7 +2721,7 @@ func handleWebSocket(conn net.Conn, srvCtx *serverContext, logger *log.Logger) {
 				Conn:   conn,
 				reader: io.MultiReader(bytes.NewReader(payload), conn),
 			}
-			handleRawTunnel(wsConn, srvCtx, logger, "")
+			handleRawTunnel(wsConn, srvCtx, logger, clientIdentity{})
 			return
 		}
 	}
@@ -2762,7 +2766,7 @@ func handleAntiProbeDispatch(conn net.Conn, srvCtx *serverContext, logger *log.L
 }
 
 // handleAntiProbeAuth handles anti-probe authenticated connections
-func handleAntiProbeAuth(conn net.Conn, srvCtx *serverContext, secret []byte, clientID string, logger *log.Logger) {
+func handleAntiProbeAuth(conn net.Conn, srvCtx *serverContext, secret []byte, clientID clientIdentity, logger *log.Logger) {
 	cfg := srvCtx.cfg
 	logger.Debug("Processing anti-probe authentication (client: %s)", clientID)
 
@@ -3023,7 +3027,9 @@ func handleConfusionTUNMode(conn net.Conn, remainingData []byte, srvCtx *serverC
 	// Use only client IP (without port) for clientID to prevent IP pool exhaustion
 	// when client reconnects on different ports (e.g., port hopping)
 	clientHost, _, _ := net.SplitHostPort(conn.RemoteAddr().String())
-	clientID := fmt.Sprintf("confusion:%s", clientHost)
+	// Behind a relay this is the relay's address, the same for every client
+	// it forwards, so it cannot key a lease on its own.
+	clientID := sharedIdentity(fmt.Sprintf("confusion:%s", clientHost))
 
 	// Check for version byte (v2 clients send 7 bytes total)
 	var clientVersion uint8 = 1 // Default to v1 for backwards compatibility
@@ -3083,7 +3089,7 @@ func handleConfusionTUNMode(conn net.Conn, remainingData []byte, srvCtx *serverC
 		serverIP = cfg.TunIP
 
 		// Register client with shared TUN (default framing: [length:4][packet:N])
-		writer := srvCtx.sharedTUN.RegisterClient(clientIP, clientID, conn, nil)
+		writer := srvCtx.sharedTUN.RegisterClient(clientIP, clientID.id, conn, nil)
 		localSink := newLocalTUNSink(srvCtx.sharedTUN, writer, clientIP)
 		sink = localSink
 		defer func() {
@@ -3197,7 +3203,7 @@ func tunnelIdentity(clientID string) string {
 
 // handleRawTunnel handles raw tunnel connections
 // clientID is used for TUN mode to track IP allocation (e.g. "reality:abcd1234")
-func handleRawTunnel(conn net.Conn, srvCtx *serverContext, logger *log.Logger, clientID string) {
+func handleRawTunnel(conn net.Conn, srvCtx *serverContext, logger *log.Logger, clientID clientIdentity) {
 	logger.Debug("Starting raw tunnel mode")
 
 	// Node ceiling. Here rather than at accept on purpose: every transport
@@ -3207,7 +3213,7 @@ func handleRawTunnel(conn net.Conn, srvCtx *serverContext, logger *log.Logger, c
 	//
 	// A refused client currently has nowhere to go - see nodeCapNoFailover - so
 	// this only fires when an operator has deliberately set a ceiling.
-	release, admitted := nodeCapacity.admit(tunnelIdentity(clientID), time.Now())
+	release, admitted := nodeCapacity.admit(tunnelIdentity(clientID.id), time.Now())
 	if !admitted {
 		logger.Warn("Node ceiling reached, refusing a new session (client: %s)", clientID)
 		return
@@ -3217,12 +3223,12 @@ func handleRawTunnel(conn net.Conn, srvCtx *serverContext, logger *log.Logger, c
 	// Track per-client connection for metrics. Use a closure on the conn
 	// variable so the defer picks up the kTLS-wrapped value if we hand
 	// the socket over later via ktls.TryEnable + registry.SwapConn.
-	if srvCtx.registry != nil && clientID != "" {
-		if err := srvCtx.registry.AddConnection(clientID, conn); err != nil {
+	if srvCtx.registry != nil && clientID.id != "" {
+		if err := srvCtx.registry.AddConnection(clientID.id, conn); err != nil {
 			logger.Warn("Failed to track connection for client %s: %v", clientID, err)
 		} else {
 			defer func() {
-				srvCtx.registry.RemoveConnection(clientID, conn)
+				srvCtx.registry.RemoveConnection(clientID.id, conn)
 			}()
 		}
 	}
@@ -3301,10 +3307,10 @@ func handleRawTunnel(conn net.Conn, srvCtx *serverContext, logger *log.Logger, c
 	// the kernel send buffer.
 	preSwap := conn
 	conn = ktls.TryEnable(conn, "tired-raw")
-	if conn != preSwap && srvCtx.registry != nil && clientID != "" {
+	if conn != preSwap && srvCtx.registry != nil && clientID.id != "" {
 		// Replace the stored *tls.Conn pointer so forced-disconnect Close()
 		// targets the live ktls.Conn wrapper rather than the stale *tls.Conn.
-		srvCtx.registry.SwapConn(clientID, preSwap, conn)
+		srvCtx.registry.SwapConn(clientID.id, preSwap, conn)
 	}
 
 	// Relay data
@@ -3338,8 +3344,8 @@ func handleRawTunnel(conn net.Conn, srvCtx *serverContext, logger *log.Logger, c
 	}
 
 	// Update per-client metrics
-	if srvCtx.registry != nil && clientID != "" {
-		srvCtx.registry.AddBytes(clientID, bytesUp, bytesDown)
+	if srvCtx.registry != nil && clientID.id != "" {
+		srvCtx.registry.AddBytes(clientID.id, bytesUp, bytesDown)
 	}
 }
 
@@ -3349,7 +3355,7 @@ func handleTUNMode(conn net.Conn, cfg *Config, logger *log.Logger) {
 }
 
 // handleTUNModeWithHandshake handles TUN mode with pre-read handshake data (for QUIC)
-func handleTUNModeWithHandshake(conn net.Conn, srvCtx *serverContext, logger *log.Logger, handshake []byte, clientID string) {
+func handleTUNModeWithHandshake(conn net.Conn, srvCtx *serverContext, logger *log.Logger, handshake []byte, clientID clientIdentity) {
 	handleTUNModeCore(conn, srvCtx.cfg, srvCtx, logger, handshake, clientID)
 }
 
@@ -3366,7 +3372,7 @@ func handleTUNModeWithContext(conn net.Conn, cfg *Config, srvCtx *serverContext,
 		return
 	}
 
-	handleTUNModeCore(conn, cfg, srvCtx, logger, handshake[:n], "")
+	handleTUNModeCore(conn, cfg, srvCtx, logger, handshake[:n], clientIdentity{})
 }
 
 // resolveTunMTU returns the configured TUN MTU, falling back to the package
@@ -3391,7 +3397,7 @@ func negotiateMTU(clientMTU, serverMTU int) int {
 
 // handleTUNModeCore is the core TUN mode handler
 // authClientID is the authenticated client ID from QUIC/etc (empty if not available)
-func handleTUNModeCore(conn net.Conn, cfg *Config, srvCtx *serverContext, logger *log.Logger, handshake []byte, authClientID string) {
+func handleTUNModeCore(conn net.Conn, cfg *Config, srvCtx *serverContext, logger *log.Logger, handshake []byte, authClientID clientIdentity) {
 	requestedIP := net.IP(handshake[0:4])
 	clientMTU := int(binary.BigEndian.Uint16(handshake[4:6]))
 	// Negotiate MTU: use min(clientMTU, serverMTU) as effective MTU.
@@ -3416,12 +3422,14 @@ func handleTUNModeCore(conn net.Conn, cfg *Config, srvCtx *serverContext, logger
 	isAutoRequest := requestedIP.Equal(net.IPv4zero) || requestedIP.Equal(net.IPv4(0, 0, 0, 0))
 
 	// Use authenticated clientID if available, otherwise fallback to connection-based ID
-	var clientID string
-	if authClientID != "" {
-		// Use stable clientID from authentication (e.g. from Redis/API)
-		clientID = authClientID
-	} else {
-		clientID = fmt.Sprintf("tun:%s", conn.RemoteAddr().String())
+	// A client that authenticated carries whatever identity that transport
+	// resolved, including whether it distinguishes one client from another.
+	// Without one, fall back to the peer address - which on a relay is the
+	// relay's own address and therefore the same for every client behind it,
+	// so it is shared rather than per-client.
+	clientID := authClientID
+	if clientID.id == "" {
+		clientID = sharedIdentity(fmt.Sprintf("tun:%s", conn.RemoteAddr().String()))
 	}
 
 	logger.Info("TUN client request: IP=%s, clientID=%s", requestedIP, clientID)
@@ -3518,7 +3526,7 @@ func handleTUNModeCore(conn net.Conn, cfg *Config, srvCtx *serverContext, logger
 
 	// Register client with shared TUN
 	// Default framing: [length:4][packet:N]
-	writer := srvCtx.sharedTUN.RegisterClient(clientIP, clientID, conn, nil)
+	writer := srvCtx.sharedTUN.RegisterClient(clientIP, clientID.id, conn, nil)
 	defer func() {
 		srvCtx.sharedTUN.UnregisterClient(clientIP, writer)
 		// Don't release IP - it stays allocated for reconnects
@@ -3967,7 +3975,7 @@ func setupH2TUNTunnel(tunnel *h2TunnelState, framer *http2.Framer, data []byte, 
 
 		// Register client with shared TUN using custom frame function
 		// Note: For H2, we send directly in frameFunc, so it returns nil
-		writer := srvCtx.sharedTUN.RegisterClient(clientIP, tunnel.clientID, h2Conn, func(pkt []byte) []byte {
+		writer := srvCtx.sharedTUN.RegisterClient(clientIP, tunnel.clientID.id, h2Conn, func(pkt []byte) []byte {
 			sendPacketDown(pkt)
 			return nil // Already sent directly
 		})
@@ -4035,7 +4043,7 @@ func handleConfusionData(conn net.Conn, data []byte, srvCtx *serverContext, logg
 	conn.Write([]byte("TIRED"))
 
 	// Continue as raw tunnel
-	handleRawTunnel(conn, srvCtx, logger, "")
+	handleRawTunnel(conn, srvCtx, logger, clientIdentity{})
 }
 
 // Helper functions
@@ -4081,13 +4089,13 @@ func detectTimingKnock(data []byte, secret []byte) bool {
 
 // detectTimingKnockWithRegistry checks timing knock against per-client secrets and global secret
 // Returns (matched, secret, clientID)
-func detectTimingKnockWithRegistry(data []byte, srvCtx *serverContext) (bool, []byte, string) {
+func detectTimingKnockWithRegistry(data []byte, srvCtx *serverContext) (bool, []byte, clientIdentity) {
 	// 1. Try per-client secrets
 	if srvCtx.registry != nil {
 		for _, client := range srvCtx.registry.ListClients() {
 			if detectTimingKnock(data, []byte(client.Secret)) {
 				log.Debug("Timing knock matched client: %s (id: %s)", client.Name, client.ID)
-				return true, []byte(client.Secret), client.ID
+				return true, []byte(client.Secret), registryIdentity(client.ID)
 			}
 		}
 	}
@@ -4095,10 +4103,10 @@ func detectTimingKnockWithRegistry(data []byte, srvCtx *serverContext) (bool, []
 	// 2. Fallback to global secret
 	if len(srvCtx.cfg.Secret) > 0 && detectTimingKnock(data, srvCtx.cfg.Secret) {
 		log.Debug("Timing knock matched global secret")
-		return true, srvCtx.cfg.Secret, "global"
+		return true, srvCtx.cfg.Secret, sharedIdentity(globalClientID)
 	}
 
-	return false, nil, ""
+	return false, nil, clientIdentity{}
 }
 
 func verifyFullKnockSequence(conn net.Conn, secret []byte, logger *log.Logger) bool {
@@ -4367,7 +4375,7 @@ func handleWebSocketPadded(conn net.Conn, srvCtx *serverContext, logger *log.Log
 	// Verify X-Auth-Token against per-client secrets and global secret
 	authTokenHex, hasAuthToken := headers["X-Auth-Token"]
 	var usedSecret []byte
-	var clientID string
+	var clientID clientIdentity
 
 	if hasAuthToken {
 		authToken, err := hex.DecodeString(authTokenHex)
@@ -4383,7 +4391,7 @@ func handleWebSocketPadded(conn net.Conn, srvCtx *serverContext, logger *log.Log
 				if verifyMorphAuth(authToken, []byte(client.Secret)) {
 					logger.Info("WebSocket Padded authenticated (client: %s, id: %s)", client.Name, client.ID)
 					usedSecret = []byte(client.Secret)
-					clientID = client.ID
+					clientID = registryIdentity(client.ID)
 					break
 				}
 			}
@@ -4394,7 +4402,7 @@ func handleWebSocketPadded(conn net.Conn, srvCtx *serverContext, logger *log.Log
 			if verifyMorphAuth(authToken, srvCtx.cfg.Secret) {
 				logger.Info("WebSocket Padded authenticated (global secret)")
 				usedSecret = srvCtx.cfg.Secret
-				clientID = "global"
+				clientID = sharedIdentity(globalClientID)
 			}
 		}
 
@@ -4406,7 +4414,7 @@ func handleWebSocketPadded(conn net.Conn, srvCtx *serverContext, logger *log.Log
 		// No auth token - fallback to global secret for backward compatibility
 		if len(srvCtx.cfg.Secret) > 0 {
 			usedSecret = srvCtx.cfg.Secret
-			clientID = "global-legacy"
+			clientID = sharedIdentity("global-legacy")
 			logger.Debug("WebSocket Padded: No auth token, using global secret (legacy mode)")
 		} else {
 			logger.Error("WebSocket Padded: No auth token and no global secret configured")
@@ -4440,8 +4448,8 @@ func handleWebSocketPadded(conn net.Conn, srvCtx *serverContext, logger *log.Log
 	// the kernel send buffer.
 	preSwap := conn
 	conn = ktls.TryEnable(conn, "tired-ws")
-	if conn != preSwap && srvCtx.registry != nil && clientID != "" {
-		srvCtx.registry.SwapConn(clientID, preSwap, conn)
+	if conn != preSwap && srvCtx.registry != nil && clientID.id != "" {
+		srvCtx.registry.SwapConn(clientID.id, preSwap, conn)
 	}
 
 	// Wrap with SalamanderConn using the authenticated secret
@@ -4469,7 +4477,7 @@ func computeWebSocketAccept(key string) string {
 // HTTPPollingSession represents a single polling session
 type HTTPPollingSession struct {
 	ID         string
-	ClientID   string
+	ClientID   clientIdentity
 	Origin     string // Peer host of the request that opened the session
 	Secret     []byte
 	Created    time.Time
@@ -4543,7 +4551,7 @@ func (pm *HTTPPollingManager) cleanup() {
 }
 
 // GetOrCreate gets or creates a session
-func (pm *HTTPPollingManager) GetOrCreate(sessionID string, secret []byte, clientID, origin string) (*HTTPPollingSession, bool) {
+func (pm *HTTPPollingManager) GetOrCreate(sessionID string, secret []byte, clientID clientIdentity, origin string) (*HTTPPollingSession, bool) {
 	pm.mu.Lock()
 	defer pm.mu.Unlock()
 
@@ -4833,7 +4841,7 @@ func processHTTPPollingRequest(conn net.Conn, reader *bufio.Reader, srvCtx *serv
 	existingSess := pollingManager.Get(sessionID)
 
 	var usedSecret []byte
-	var clientID string
+	var clientID clientIdentity
 
 	if existingSess != nil {
 		// Session exists - verify auth against session's secret
@@ -4870,7 +4878,7 @@ func processHTTPPollingRequest(conn net.Conn, reader *bufio.Reader, srvCtx *serv
 				secretBytes := []byte(c.Secret)
 				if verifyPollingAuth(authToken, sessionID, secretBytes) {
 					usedSecret = secretBytes
-					clientID = c.ID
+					clientID = registryIdentity(c.ID)
 					logger.Debug("HTTP Polling: Auth matched client '%s' (id=%s)", c.Name, c.ID)
 					break
 				}
@@ -4880,7 +4888,7 @@ func processHTTPPollingRequest(conn net.Conn, reader *bufio.Reader, srvCtx *serv
 		if usedSecret == nil && len(srvCtx.cfg.Secret) > 0 {
 			if verifyPollingAuth(authToken, sessionID, srvCtx.cfg.Secret) {
 				usedSecret = srvCtx.cfg.Secret
-				clientID = "global"
+				clientID = sharedIdentity(globalClientID)
 				logger.Debug("HTTP Polling: Auth matched global secret")
 			}
 		}
@@ -5113,7 +5121,7 @@ func runPollingTUNMode(sess *HTTPPollingSession, remainingData []byte, srvCtx *s
 	}
 
 	requestedIP := net.IP(remainingData[0:4])
-	clientID := fmt.Sprintf("polling:%s", sess.ClientID)
+	clientID := sess.ClientID.prefixed("polling")
 	logger.Debug("HTTP Polling TUN: requestedIP=%s, clientID=%s", requestedIP, clientID)
 
 	// Check for version byte (v2 clients send 7 bytes total)
@@ -5175,7 +5183,7 @@ func runPollingTUNMode(sess *HTTPPollingSession, remainingData []byte, srvCtx *s
 
 		// Register client with shared TUN using custom framer for polling
 		// Polling uses [length:4][packet:N] framing
-		writer := srvCtx.sharedTUN.RegisterClient(clientIP, clientID, pollConn, nil)
+		writer := srvCtx.sharedTUN.RegisterClient(clientIP, clientID.id, pollConn, nil)
 		localSink := newLocalTUNSink(srvCtx.sharedTUN, writer, clientIP)
 		sink = localSink
 		defer func() {

--- a/internal/server/ssh_handler.go
+++ b/internal/server/ssh_handler.go
@@ -50,7 +50,7 @@ func handleSSHCamouflage(conn net.Conn, srvCtx *serverContext, logger *log.Logge
 // sshServerHandshake performs banner exchange, KEXINIT negotiation and the ECDH
 // round trip, verifying the client auth token. On success it returns the matched
 // client ID (or "global" for the global secret).
-func sshServerHandshake(conn net.Conn, srvCtx *serverContext, logger *log.Logger) (string, error) {
+func sshServerHandshake(conn net.Conn, srvCtx *serverContext, logger *log.Logger) (clientIdentity, error) {
 	conn.SetDeadline(time.Now().Add(15 * time.Second))
 	defer conn.SetDeadline(time.Time{})
 
@@ -59,43 +59,43 @@ func sshServerHandshake(conn net.Conn, srvCtx *serverContext, logger *log.Logger
 	// 1. Read the client banner line.
 	line, err := br.ReadString('\n')
 	if err != nil {
-		return "", fmt.Errorf("reading client banner: %w", err)
+		return clientIdentity{}, fmt.Errorf("reading client banner: %w", err)
 	}
 	if !bytes.HasPrefix([]byte(line), []byte("SSH-2.0")) {
-		return "", fmt.Errorf("not an SSH-2.0 banner")
+		return clientIdentity{}, fmt.Errorf("not an SSH-2.0 banner")
 	}
 	// 2. Send our banner.
 	if _, err := conn.Write([]byte(strategy.SSHBanner)); err != nil {
-		return "", err
+		return clientIdentity{}, err
 	}
 	// 3. Read the client KEXINIT (discard contents).
 	if _, err := strategy.ReadSSHPacket(br); err != nil {
-		return "", fmt.Errorf("reading client KEXINIT: %w", err)
+		return clientIdentity{}, fmt.Errorf("reading client KEXINIT: %w", err)
 	}
 	// 4. Send our KEXINIT.
 	if err := strategy.WriteSSHPacket(conn, strategy.BuildSSHKexInit()); err != nil {
-		return "", err
+		return clientIdentity{}, err
 	}
 	// 5. Read the client ECDH init carrying the auth token.
 	payload, err := strategy.ReadSSHPacket(br)
 	if err != nil {
-		return "", fmt.Errorf("reading client ECDH init: %w", err)
+		return clientIdentity{}, fmt.Errorf("reading client ECDH init: %w", err)
 	}
 	token, err := strategy.ParseSSHKexPubKey(payload, 30) // SSH_MSG_KEX_ECDH_INIT
 	if err != nil {
-		return "", err
+		return clientIdentity{}, err
 	}
 
 	clientID, secret, ok := verifySSHAuth(token, srvCtx)
 	if !ok {
-		return "", fmt.Errorf("auth token verification failed")
+		return clientIdentity{}, fmt.Errorf("auth token verification failed")
 	}
 
 	// 6. Send the ECDH reply carrying our token derived from the same secret so
 	//    the client can confirm the server understands the protocol.
 	serverToken := strategy.GenerateSSHAuthToken(secret)
 	if err := strategy.WriteSSHPacket(conn, strategy.BuildSSHKexECDH(31, serverToken)); err != nil { // SSH_MSG_KEX_ECDH_REPLY
-		return "", err
+		return clientIdentity{}, err
 	}
 
 	conn.SetDeadline(time.Time{})
@@ -105,17 +105,17 @@ func sshServerHandshake(conn net.Conn, srvCtx *serverContext, logger *log.Logger
 // verifySSHAuth checks the token against per-client secrets (registry) and then
 // the global secret. Returns the matched client ID, the secret used, and whether
 // authentication succeeded.
-func verifySSHAuth(token []byte, srvCtx *serverContext) (string, []byte, bool) {
+func verifySSHAuth(token []byte, srvCtx *serverContext) (clientIdentity, []byte, bool) {
 	if srvCtx.registry != nil {
 		for _, client := range srvCtx.registry.ListClients() {
 			secret := []byte(client.Secret)
 			if strategy.VerifySSHAuthToken(token, secret) {
-				return client.ID, secret, true
+				return registryIdentity(client.ID), secret, true
 			}
 		}
 	}
 	if len(srvCtx.cfg.Secret) > 0 && strategy.VerifySSHAuthToken(token, srvCtx.cfg.Secret) {
-		return "global", srvCtx.cfg.Secret, true
+		return sharedIdentity(globalClientID), srvCtx.cfg.Secret, true
 	}
-	return "", nil, false
+	return clientIdentity{}, nil, false
 }

--- a/internal/server/tun_origin.go
+++ b/internal/server/tun_origin.go
@@ -64,20 +64,82 @@ func originOf(addr net.Addr) string {
 	return host
 }
 
-// allocationKey qualifies the IP-pool lease key with the client's origin when
-// the client has no identity of its own.
+// clientIdentity is a client's identity together with where it came from.
 //
-// Every client on the global secret authenticates as "global", and IPPool
-// leases are sticky per client key, so keying on "global" alone hands the SAME
-// tunnel IP to every such client: the second one to connect takes over the
-// first one's address, the first reconnects and takes it back, and the two
-// flap against each other indefinitely (once per keepalive interval). Adding
-// the origin gives two boxes on one secret two different leases. Named clients
-// (Redis/panel identities) are already unique and keep their stable key, so
-// their IP survives a change of address.
-func allocationKey(clientID, origin string) string {
-	if clientID != globalClientID || origin == "" {
-		return clientID
+// The origin of an identity, not its spelling, decides whether it can key a
+// lease. The first version of this asked whether the string equalled "global",
+// which covered exactly one of the several identities the server derives from
+// the shared secret: REALITY builds "reality:<hmac-of-secret>", HTTP polling
+// builds "polling:global". Those are the same value for every client that
+// presents that secret, so they collided exactly the way "global" did - the
+// fix looked complete for six weeks while Dubai flapped every thirty seconds
+// under one reality:<hmac> shared by three different addresses.
+//
+// A list of known prefixes would have gone stale with the next transport. The
+// answer is to record what the identity was derived from where it is derived,
+// which is the only place that knows.
+type clientIdentity struct {
+	// id is the identity as it appears in logs, metrics and the TUN registry.
+	id string
+
+	// perClient is true when id distinguishes this client from every other
+	// one - it came from the client registry, where each client has its own
+	// secret and its own name.
+	//
+	// The zero value is the safe one on purpose. An identity nobody classified
+	// is treated as shared and gets qualified, which at worst costs a client a
+	// second lease after it changes address; the opposite default hands two
+	// clients one tunnel IP and they evict each other until one gives up.
+	perClient bool
+}
+
+// sharedIdentity marks an identity derived from a credential every client
+// presents - the server's global secret. Two different clients can carry the
+// same value, so it cannot key a lease by itself.
+func sharedIdentity(id string) clientIdentity {
+	return clientIdentity{id: id}
+}
+
+// registryIdentity marks an identity that came from the client registry. It is
+// unique to one client, so it keys a lease on its own and that client keeps its
+// address across a change of network.
+func registryIdentity(id string) clientIdentity {
+	return clientIdentity{id: id, perClient: true}
+}
+
+// String lets an identity be logged where the bare id used to be.
+func (c clientIdentity) String() string { return c.id }
+
+// prefixed labels an identity with the transport that carried it, keeping where
+// the identity came from. Prefixing is relabelling, not re-deriving: putting
+// "polling:" in front of a shared id leaves it just as shared.
+func (c clientIdentity) prefixed(transport string) clientIdentity {
+	if c.id == "" {
+		return c
 	}
-	return clientID + "@" + origin
+	return clientIdentity{id: transport + ":" + c.id, perClient: c.perClient}
+}
+
+// allocationKey qualifies the IP-pool lease key with the client's origin when
+// the identity cannot tell two clients apart.
+//
+// IPPool leases are sticky per key, so keying on a shared identity hands the
+// SAME tunnel IP to every client carrying it: the second one to connect takes
+// over the first one's address, the first reconnects and takes it back, and
+// the two flap against each other indefinitely, once per keepalive interval.
+// Adding the origin gives two boxes on one secret two different leases.
+//
+// The origin is the downstream client's address, which on a relay arrives in
+// the TRO1 trailer rather than from the socket - qualifying at the point of
+// authentication instead would collapse every client behind one relay back
+// into a single lease.
+func allocationKey(id clientIdentity, origin string) string {
+	// An empty identity keys nothing, and "@1.2.3.4" would be a key rather than
+	// the absence of one. Callers that have no identity resolve one of their own
+	// before they get here; this keeps the function honest for the ones that do
+	// not, which is what it did before it learned about provenance.
+	if id.id == "" || id.perClient || origin == "" {
+		return id.id
+	}
+	return id.id + "@" + origin
 }

--- a/internal/server/tun_origin_test.go
+++ b/internal/server/tun_origin_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"net"
+	"strings"
 	"testing"
 )
 
@@ -58,26 +59,70 @@ func TestAppendTUNOriginEmpty(t *testing.T) {
 
 func TestAllocationKey(t *testing.T) {
 	cases := []struct {
-		name     string
-		clientID string
-		origin   string
-		want     string
+		name   string
+		id     clientIdentity
+		origin string
+		want   string
 	}{
 		// Two boxes on the global secret must not share a lease - this is the
 		// flap that had usa2 handing 10.8.5.2 to both the laptop and the RU hop.
-		{"global gets qualified", "global", "79.139.165.170", "global@79.139.165.170"},
-		{"global other origin", "global", "185.22.60.152", "global@185.22.60.152"},
-		// A named client keeps its identity so its IP survives an address change.
-		{"named client untouched", "reality:4d5e13abbf0e8fd3", "79.139.165.170", "reality:4d5e13abbf0e8fd3"},
-		{"global without origin", "global", "", "global"},
-		{"empty client", "", "1.2.3.4", ""},
+		{"global gets qualified", sharedIdentity("global"), "79.139.165.170", "global@79.139.165.170"},
+		{"global other origin", sharedIdentity("global"), "185.22.60.152", "global@185.22.60.152"},
+
+		// This case is why the first fix did not work. It used to be written
+		// as a "named client" that must keep its identity, and it passed under
+		// the old rule for exactly the wrong reason: reality:<hex> is an HMAC
+		// of the shared secret, so it is the same string for everyone holding
+		// that secret. Dubai ran three different addresses under
+		// reality:d3d70b6371709943 and they evicted each other every thirty
+		// seconds while this test was green.
+		{"reality id off a shared secret is not per-client",
+			sharedIdentity("reality:4d5e13abbf0e8fd3"), "79.139.165.170", "reality:4d5e13abbf0e8fd3@79.139.165.170"},
+		{"polling id off a shared secret is not per-client",
+			sharedIdentity("polling:global"), "185.22.60.152", "polling:global@185.22.60.152"},
+
+		// A registry client is unique by construction, so its lease must NOT be
+		// qualified: that is what keeps its IP across a change of address.
+		{"registry client untouched", registryIdentity("c1"), "79.139.165.170", "c1"},
+		{"registry client keeps id on a new address", registryIdentity("c1"), "1.2.3.4", "c1"},
+
+		{"shared without origin", sharedIdentity("global"), "", "global"},
+		{"empty client", clientIdentity{}, "1.2.3.4", ""},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if got := allocationKey(c.clientID, c.origin); got != c.want {
-				t.Errorf("allocationKey(%q, %q) = %q, want %q", c.clientID, c.origin, got, c.want)
+			if got := allocationKey(c.id, c.origin); got != c.want {
+				t.Errorf("allocationKey(%+v, %q) = %q, want %q", c.id, c.origin, got, c.want)
 			}
 		})
+	}
+}
+
+// TestUnclassifiedIdentityIsTreatedAsShared pins the default. Whoever adds the
+// next transport gets a zero clientIdentity if they forget to say where the id
+// came from, and the cost of that mistake has to be a spare lease rather than
+// two clients on one tunnel IP.
+func TestUnclassifiedIdentityIsTreatedAsShared(t *testing.T) {
+	var forgotten clientIdentity
+	forgotten.id = "newtransport:whatever"
+
+	if got := allocationKey(forgotten, "79.139.165.170"); got != "newtransport:whatever@79.139.165.170" {
+		t.Errorf("an unclassified identity was not qualified: %q", got)
+	}
+}
+
+// TestPrefixedKeepsProvenance covers the relabelling the polling path does. The
+// prefix says which transport carried the identity; it cannot turn a secret
+// every client shares into one that identifies a client.
+func TestPrefixedKeepsProvenance(t *testing.T) {
+	if got := sharedIdentity("global").prefixed("polling"); got.id != "polling:global" || got.perClient {
+		t.Errorf("shared identity became %+v, want polling:global still shared", got)
+	}
+	if got := registryIdentity("c1").prefixed("polling"); got.id != "polling:c1" || !got.perClient {
+		t.Errorf("registry identity became %+v, want polling:c1 still per-client", got)
+	}
+	if got := (clientIdentity{}).prefixed("polling"); got.id != "" {
+		t.Errorf("an empty identity gained an id: %+v", got)
 	}
 }
 
@@ -94,14 +139,78 @@ func TestOriginOf(t *testing.T) {
 	}
 }
 
+// TestSharedSecretClientsGetDistinctIPs is the Dubai case against a real pool.
+// Three addresses authenticated with one global secret and got one
+// reality:<hmac>, so all three asked for 10.8.2.4 and the pool handed it to all
+// three: each new session evicted the live one, the evicted client reconnected
+// within its keepalive window and evicted the next, and the exit logged
+// "replacing LIVE connection ... last_seen=0s ago" every thirty seconds.
+func TestSharedSecretClientsGetDistinctIPs(t *testing.T) {
+	pool, err := NewIPPool(IPPoolConfig{Network: "10.8.2.0/24", ServerIP: "10.8.2.1"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// One identity, because one secret. Three different clients.
+	id := sharedIdentity("reality:d3d70b6371709943")
+	addrs := []string{"79.139.161.161", "176.112.205.147", "185.22.60.152"}
+
+	seen := make(map[string]string, len(addrs))
+	for _, addr := range addrs {
+		got, err := pool.Allocate(allocationKey(id, addr), net.ParseIP("10.8.2.4"), "")
+		if err != nil {
+			t.Fatalf("%s: %v", addr, err)
+		}
+		if other, clash := seen[got.String()]; clash {
+			t.Fatalf("%s and %s both got %s under one shared identity", other, addr, got)
+		}
+		seen[got.String()] = addr
+	}
+
+	// Sticky per client: the same box reconnecting keeps its address, which is
+	// what stops the eviction loop rather than merely spreading it out.
+	first := allocationKey(id, addrs[0])
+	again, err := pool.Allocate(first, net.ParseIP("10.8.2.99"), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if seen[again.String()] != addrs[0] {
+		t.Errorf("reconnect from %s got %s, which belongs to %q", addrs[0], again, seen[again.String()])
+	}
+}
+
+// TestRegistryClientKeepsOneLeaseAcrossAddresses is the control for the case
+// above: qualifying everything would be a trivially "safe" fix that quietly
+// breaks the clients that already work, by giving a named client a fresh IP
+// every time its address changes.
+func TestRegistryClientKeepsOneLeaseAcrossAddresses(t *testing.T) {
+	pool, err := NewIPPool(IPPoolConfig{Network: "10.8.2.0/24", ServerIP: "10.8.2.1"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	named := registryIdentity("c1")
+	home, err := pool.Allocate(allocationKey(named, "79.139.165.170"), net.ParseIP("10.8.2.7"), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	roaming, err := pool.Allocate(allocationKey(named, "185.22.60.152"), net.ParseIP("10.8.2.7"), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !home.Equal(roaming) {
+		t.Errorf("named client moved address and got %s instead of keeping %s", roaming, home)
+	}
+}
+
 func TestGlobalClientsGetDistinctIPs(t *testing.T) {
 	pool, err := NewIPPool(IPPoolConfig{Network: "10.8.5.0/24", ServerIP: "10.8.5.1"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	laptop := allocationKey(globalClientID, "79.139.165.170")
-	ruhop := allocationKey(globalClientID, "185.22.60.152")
+	laptop := allocationKey(sharedIdentity(globalClientID), "79.139.165.170")
+	ruhop := allocationKey(sharedIdentity(globalClientID), "185.22.60.152")
 
 	first, err := pool.Allocate(laptop, net.ParseIP("10.8.5.2"), "")
 	if err != nil {
@@ -122,5 +231,35 @@ func TestGlobalClientsGetDistinctIPs(t *testing.T) {
 	}
 	if !again.Equal(first) {
 		t.Errorf("reconnect got %s, want the sticky %s", again, first)
+	}
+}
+
+// TestRealityIdentityIsShared covers the classification at the point it is made
+// rather than at the point it is used. allocationKey can only be as right as
+// what it is handed, and the reason Dubai flapped was not the rule - it was
+// that reality:<hmac> arrived claiming to identify somebody.
+func TestRealityIdentityIsShared(t *testing.T) {
+	secret := []byte("a-shared-secret-for-everyone-32b")
+
+	id := realityClientIdentity(secret)
+	if id.perClient {
+		t.Fatal("an identity derived from a secret alone cannot be per-client: every holder of that secret produces it")
+	}
+	if !strings.HasPrefix(id.id, "reality:") {
+		t.Errorf("id = %q, want the reality: prefix", id.id)
+	}
+
+	// Two different clients, one secret: the identity is the same string, which
+	// is exactly why it must not key a lease on its own.
+	if other := realityClientIdentity(secret); other.id != id.id {
+		t.Fatalf("the same secret gave two identities, %q and %q", id.id, other.id)
+	}
+	if allocationKey(id, "79.139.161.161") == allocationKey(id, "185.22.60.152") {
+		t.Error("two addresses on one secret produced one lease key")
+	}
+
+	// A different secret is a different user and keeps its own identity.
+	if diff := realityClientIdentity([]byte("a-different-secret-also-32-bytes")); diff.id == id.id {
+		t.Error("two different secrets collapsed to one identity")
 	}
 }

--- a/internal/strategy/quic.go
+++ b/internal/strategy/quic.go
@@ -839,6 +839,13 @@ type QUICServerConn struct {
 	ClientID   string
 	ClientName string
 
+	// ClientIDFromRegistry records where ClientID came from. A registry client
+	// has its own secret and its own id, so that id identifies one client. The
+	// global-secret fallback gives every client the same id, and a caller that
+	// keys anything per client on it - an IP-pool lease, for one - has to know
+	// the difference. The zero value is the shared case on purpose.
+	ClientIDFromRegistry bool
+
 	mu     sync.Mutex
 	closed bool
 }
@@ -876,6 +883,7 @@ func (c *QUICServerConn) VerifyClient() error {
 			if verifyWithSecret(info.Secret) {
 				c.secret = info.Secret
 				c.ClientID = info.ClientID
+				c.ClientIDFromRegistry = true
 				c.ClientName = info.Name
 				log.Info("QUIC authenticated (client: %s, id: %s)", info.Name, info.ClientID)
 				return c.sendAck()


### PR DESCRIPTION
Two clients sharing one secret land on the same tunnel IP and evict each other roughly every 30 seconds. This was supposed to be fixed in 1.3.26 — the fix qualified the lease key with the connection's origin, but only when the client ID was the literal string `global`.

REALITY derives its client ID as an HMAC of the secret and nothing else, so on a shared secret every client gets the same `reality:<hex>`. That never equals `global`, so it stayed unqualified: same lease, mutual eviction, and on the client side a storm detector firing on "repeated short-lived sessions" and failing over to a slow transport.

Observed on the Dubai exit: three distinct source addresses (7316, 228 and 226 sessions) under one identity, all claiming `10.8.2.4`, server-side sessions living 31-32 seconds — that is the eviction interval, not a network property.

## What changes

Provenance is recorded where the identity is derived, which is the only place that knows it. `clientIdentity` carries the ID together with whether it distinguishes one client from another: identities from the registry do, identities derived from a shared secret do not. The lease key qualifies the second kind and leaves the first alone. No prefix matching and no string comparisons remain.

The zero value is "shared" on purpose: whoever adds the next transport and forgets to classify it gets an extra lease, not two clients on one IP.

Every path that reaches allocation was walked rather than sampled — raw tunnel, morph, confusion, h2 stego, polling, websocket-padded, anti-probe, QUIC, imap, ssh, REALITY, B1. QUIC carries the flag across a package boundary through a field on the connection, since `internal/strategy` cannot import `internal/server`.

## Tests

The previous `TestAllocationKey` called `reality:4d5e13abbf0e8fd3` a "named client" and asserted it must *not* be qualified — it had been pinning the defect as correct behaviour for six weeks. Rewritten.

New cases: the Dubai situation against a real pool (three addresses, one identity, three distinct leases, plus stickiness across reconnect); a control that a registry client keeps a single lease across two addresses; classification at the point where the REALITY identity is born; and the safe default. Each assertion was shown to fail against a deliberately broken variant, individually rather than in bulk.