### PR TITLE
fix(salamander): widen the UDP verification tag from 2 bytes to 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Salamander's UDP framing now carries an 8-byte authenticity tag instead of
+  2.** The tag is what tells the receiver a packet was encrypted under the
+  secret it is holding, and at two bytes a packet from a foreign secret passed
+  the check once every 65536 attempts. That is not a rounding error on a server
+  that trials every registered client secret against every unmatched packet: a
+  false accept caches the wrong secret for that address and corrupts everything
+  written back to it. At eight bytes the odds are 2^-64.
+  - **This is a wire-format change for the QUIC/Salamander UDP transport, and
+    it is not negotiated.** A client and an exit on different sides of this
+    change will not talk to each other at all - the tag never matches, every
+    packet is dropped. There is nothing to negotiate against, because the
+    transport is not enabled anywhere: no exit runs QUIC-Salamander and no
+    client passes `-quic`. A version byte in the header would have bought
+    compatibility with zero peers at the price of a fixed-position field in
+    every datagram, which is the kind of thing this padding exists to avoid.
+  - Datagram sizes on the wire are unchanged for the packet sizes QUIC
+    actually sends. The tag lives inside the padded region, so a wider tag eats
+    into the random padding rather than the bucket. The exception is payloads
+    within six bytes below a bucket boundary (383-388, 783-788, 1183-1188,
+    1383-1388 at the `Balanced` level), which move up one bucket.
+
 ## [1.5.1] - 2026-08-26
 
 ### Fixed

--- a/internal/padding/salamander.go
+++ b/internal/padding/salamander.go
@@ -2,6 +2,7 @@ package padding
 
 import (
 	"crypto/rand"
+	"crypto/subtle"
 	"errors"
 	"fmt"
 
@@ -144,39 +145,61 @@ func (sp *SalamanderPadder) Decrypt(ciphertext []byte) ([]byte, error) {
 	return plaintext, nil
 }
 
-// keyTag derives a deterministic 2-byte verification tag from the secret and
-// salt. It is used by the UDP/QUIC framing to confirm that a packet was
-// encrypted with the same secret before trusting the (XOR-only, unauthenticated)
-// length prefix. A wrong secret yields a different keystream and therefore a
-// different tag, so mismatches are rejected deterministically instead of being
-// guessed at via header heuristics.
-func (sp *SalamanderPadder) keyTag(salt []byte) ([2]byte, error) {
+// udpTagLen is the width of the keyed authenticity tag carried by the UDP/QUIC
+// framing. It sets the odds that a packet encrypted under a foreign secret
+// survives the check: 2^-udpTagLen*8. The previous width of 2 bytes gave 2^-16,
+// i.e. one bogus accept per ~65k trials - a server holding a few thousand
+// per-client secrets trials each of them against every unmatched packet, so at
+// that width false accepts are an operational event, not a theoretical one. At
+// 8 bytes the same server needs on the order of 10^19 trials before the first
+// one, which is out of reach of any traffic volume this code will ever see.
+//
+// The six extra bytes cost nothing on the wire in the common case: EncryptUDP
+// pads to a fixed size bucket, so a wider tag only eats into the random padding
+// and the datagram an observer measures is unchanged. The exceptions are
+// payloads within six bytes below a bucket boundary, which move up one bucket,
+// and payloads above the largest bucket, where no padding applies at all and
+// the datagram grows by six. See TestSalamanderUDPWireSizeStable.
+const udpTagLen = 8
+
+// udpHeaderLen is the framing that precedes the payload inside the masked
+// region: [tag:udpTagLen][lenHi][lenLo].
+const udpHeaderLen = udpTagLen + 2
+
+// keyTag derives a deterministic verification tag from the secret and salt. It
+// is used by the UDP/QUIC framing to confirm that a packet was encrypted with
+// the same secret before trusting the (XOR-only, unauthenticated) length
+// prefix. A wrong secret yields a different keystream and therefore a different
+// tag, so mismatches are rejected deterministically instead of being guessed at
+// via header heuristics.
+func (sp *SalamanderPadder) keyTag(salt []byte) ([udpTagLen]byte, error) {
+	var tag [udpTagLen]byte
 	h, err := blake2b.New256(sp.secret)
 	if err != nil {
-		return [2]byte{}, err
+		return tag, err
 	}
 	// Domain-separate the tag from the XOR keystream so the tag never leaks
 	// keystream bytes used to mask the payload.
 	h.Write([]byte("tag"))
 	h.Write(salt)
-	sum := h.Sum(nil)
-	return [2]byte{sum[0], sum[1]}, nil
+	copy(tag[:], h.Sum(nil))
+	return tag, nil
 }
 
 // EncryptUDP frames a single UDP/QUIC payload for transmission. The inner
-// plaintext layout is [tag:2][lenHi][lenLo][payload], which Encrypt then masks
-// with the keystream and pads to a bucket. The tag lets the receiver verify the
-// secret deterministically.
+// plaintext layout is [tag:udpTagLen][lenHi][lenLo][payload], which is then
+// masked with the keystream and padded to a bucket. The tag lets the receiver
+// verify the secret deterministically.
 func (sp *SalamanderPadder) EncryptUDP(payload []byte) ([]byte, error) {
 	if len(payload) > 65535 {
 		return nil, fmt.Errorf("salamander: payload too large (%d > 65535)", len(payload))
 	}
 
-	inner := make([]byte, 4+len(payload))
+	inner := make([]byte, udpHeaderLen+len(payload))
 	// tag is filled after we know the salt, so encrypt manually below.
-	inner[2] = byte(len(payload) >> 8)
-	inner[3] = byte(len(payload))
-	copy(inner[4:], payload)
+	inner[udpTagLen] = byte(len(payload) >> 8)
+	inner[udpTagLen+1] = byte(len(payload))
+	copy(inner[udpHeaderLen:], payload)
 
 	// Generate salt + keystream exactly like Encrypt, but inject the tag.
 	salt := make([]byte, 8)
@@ -187,8 +210,7 @@ func (sp *SalamanderPadder) EncryptUDP(payload []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	inner[0] = tag[0]
-	inner[1] = tag[1]
+	copy(inner[:udpTagLen], tag[:])
 
 	h, err := blake2b.New256(sp.secret)
 	if err != nil {
@@ -226,7 +248,7 @@ func (sp *SalamanderPadder) EncryptUDP(payload []byte) ([]byte, error) {
 // embedded tag matches the secret; otherwise ok is false. This is the
 // authoritative secret-match check for the UDP/QUIC transport.
 func (sp *SalamanderPadder) DecryptUDP(ciphertext []byte) (payload []byte, ok bool) {
-	if len(ciphertext) < 8+4 {
+	if len(ciphertext) < 8+udpHeaderLen {
 		return nil, false
 	}
 	salt := ciphertext[:8]
@@ -245,21 +267,24 @@ func (sp *SalamanderPadder) DecryptUDP(ciphertext []byte) (payload []byte, ok bo
 
 	enc := ciphertext[8:]
 	// Decrypt just the header first (tag + length) to validate cheaply.
-	var hdr [4]byte
-	for i := 0; i < 4; i++ {
+	var hdr [udpHeaderLen]byte
+	for i := 0; i < udpHeaderLen; i++ {
 		hdr[i] = enc[i] ^ hash[i%32]
 	}
-	if hdr[0] != wantTag[0] || hdr[1] != wantTag[1] {
+	// Constant-time so the number of leading tag bytes an attacker got right is
+	// not readable from how long the reject took. MultiSecret trials this per
+	// registered secret, which would otherwise be a convenient amplifier.
+	if subtle.ConstantTimeCompare(hdr[:udpTagLen], wantTag[:]) != 1 {
 		return nil, false
 	}
-	dataLen := int(hdr[2])<<8 | int(hdr[3])
-	if dataLen < 0 || 4+dataLen > len(enc) {
+	dataLen := int(hdr[udpTagLen])<<8 | int(hdr[udpTagLen+1])
+	if udpHeaderLen+dataLen > len(enc) {
 		return nil, false
 	}
 
 	payload = make([]byte, dataLen)
 	for i := 0; i < dataLen; i++ {
-		payload[i] = enc[4+i] ^ hash[(4+i)%32]
+		payload[i] = enc[udpHeaderLen+i] ^ hash[(udpHeaderLen+i)%32]
 	}
 	return payload, true
 }

--- a/internal/padding/salamander_test.go
+++ b/internal/padding/salamander_test.go
@@ -552,7 +552,19 @@ func TestSalamanderUDPRoundtrip(t *testing.T) {
 // false-accept a UDP packet. This is the regression guard for the QUIC
 // Salamander "no matching secret" / per-address cache poisoning bug, where the
 // old length-prefix + 0x80 long-header heuristic accepted ~50% of garbage.
+//
+// The zero threshold is only meaningful because the tag is udpTagLen bytes
+// wide. At 8 bytes the expected number of false accepts over n trials is
+// n*2^-64 ~ 1e-15, so a single accept here means the check is broken, not
+// unlucky. At the earlier width of 2 bytes the expectation was n*2^-16 ~ 0.3
+// and this test failed roughly one run in four - it was a coin flip, and it did
+// come up heads in CI. The assertion below is therefore deliberately exact; do
+// not "fix" a failure by allowing a nonzero budget.
 func TestSalamanderUDPWrongSecretRejected(t *testing.T) {
+	if udpTagLen < 8 {
+		t.Fatalf("udpTagLen=%d: a tag narrower than 8 bytes makes this test statistical, not deterministic", udpTagLen)
+	}
+
 	right := NewSalamanderPadder([]byte("the-correct-secret-AAAAA"), Balanced)
 	wrong := NewSalamanderPadder([]byte("a-different-secret-BBBBB"), Balanced)
 
@@ -571,6 +583,206 @@ func TestSalamanderUDPWrongSecretRejected(t *testing.T) {
 	}
 	if falseAccepts != 0 {
 		t.Fatalf("wrong secret false-accepted %d/%d packets, want 0", falseAccepts, n)
+	}
+
+	// Positive control: the same loop with the right secret must accept every
+	// packet. Without it, "zero false accepts" is indistinguishable from
+	// DecryptUDP rejecting everything unconditionally.
+	for i := 0; i < 100; i++ {
+		payload := make([]byte, 1200)
+		rand.Read(payload)
+		enc, err := right.EncryptUDP(payload)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, ok := right.DecryptUDP(enc); !ok {
+			t.Fatalf("right secret rejected its own packet at iteration %d", i)
+		}
+	}
+}
+
+// TestSalamanderUDPTagCheckedInFull verifies that every byte of the tag takes
+// part in the accept decision. A comparison that stops early - or a tag widened
+// in EncryptUDP but still compared two bytes deep in DecryptUDP - would leave
+// the trailing bytes free, silently restoring the old 2^-16 odds while the
+// constant says 8. Corrupting each tag position in turn is the only way to see
+// that; a single flip at position 0 would pass either way.
+func TestSalamanderUDPTagCheckedInFull(t *testing.T) {
+	padder := NewSalamanderPadder([]byte("tag-coverage-secret"), Balanced)
+	payload := []byte("payload under a fully checked tag")
+
+	for i := 0; i < udpTagLen; i++ {
+		enc, err := padder.EncryptUDP(payload)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Tag byte i sits at offset 8+i: the 8-byte salt is sent in the clear
+		// and the masked header follows it, so flipping a ciphertext bit there
+		// flips exactly one decrypted tag byte.
+		enc[8+i] ^= 0x01
+		if _, ok := padder.DecryptUDP(enc); ok {
+			t.Errorf("tag byte %d corrupted, packet still accepted: tag not compared in full", i)
+		}
+	}
+}
+
+// TestSalamanderUDPWireSizeStable pins the observable datagram sizes that the
+// UDP framing produces. This is the property Salamander exists for, and it is
+// what a wider tag threatens: the tag lives inside the padded region, so a
+// packet that no longer fits its bucket jumps to the next one and the size
+// distribution on the wire moves.
+//
+// Two claims are checked. First, that for the payload sizes QUIC actually
+// emits - small ACK/control datagrams and full-size packets around the
+// quic-go default of 1280 - the datagram size is exactly what it was with the
+// old 2-byte tag. Second, that below the largest bucket the size alphabet is
+// the bucket list and nothing else, which is what makes the first claim more
+// than a lookup table.
+func TestSalamanderUDPWireSizeStable(t *testing.T) {
+	padder := NewSalamanderPadder([]byte("wire-size-secret"), Balanced)
+	buckets := padder.GetBuckets() // 400, 800, 1200, 1400
+
+	// Sizes a quic-go connection puts on the wire: bare ACKs and probes at the
+	// low end, Initial and full data packets at InitialPacketSize=1280. The
+	// wanted values were produced by the 2-byte-tag build and are frozen here.
+	quicSizes := []struct {
+		payload  int
+		wantWire int
+	}{
+		{21, 400}, {25, 400}, {33, 400}, {42, 400}, {55, 400}, {68, 400},
+		{120, 400}, {256, 400}, {512, 800}, {700, 800}, {900, 1200},
+		{1024, 1200}, {1200, 1400}, {1252, 1400}, {1280, 1400},
+	}
+	for _, tc := range quicSizes {
+		enc, err := padder.EncryptUDP(make([]byte, tc.payload))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(enc) != tc.wantWire {
+			t.Errorf("payload %d: datagram %d bytes, want %d - the tag widening moved this size into another bucket",
+				tc.payload, len(enc), tc.wantWire)
+		}
+	}
+
+	// Every payload that still fits the largest bucket must come out as one of
+	// the bucket values. Anything else means padding stopped normalising and
+	// the payload length is leaking directly.
+	maxPadded := buckets[len(buckets)-1] - 8 - udpHeaderLen
+	inBucket := make(map[int]bool, len(buckets))
+	for _, b := range buckets {
+		inBucket[b] = true
+	}
+	for n := 1; n <= maxPadded; n++ {
+		enc, err := padder.EncryptUDP(make([]byte, n))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !inBucket[len(enc)] {
+			t.Fatalf("payload %d: datagram %d bytes is not a bucket %v", n, len(enc), buckets)
+		}
+	}
+}
+
+// TestSalamanderUDPBucketBoundaries records exactly where the payload-to-bucket
+// boundaries sit now, so the shift caused by the wider tag is written down
+// rather than discovered later on a packet capture. Each boundary moved down by
+// six bytes (2-byte tag -> 8-byte tag), which means payloads in the six-byte
+// window below each old boundary - 383..388, 783..788, 1183..1188, 1383..1388 -
+// now travel one bucket up. None of those windows carries QUIC traffic in the
+// configurations this code ships with, see TestSalamanderUDPWireSizeStable.
+//
+// Above the largest bucket the padder gives up and sends payload+8+udpHeaderLen
+// verbatim, so there the datagram grew by the full six bytes and the exact
+// payload length is on the wire. That leak predates this change; the tag only
+// shifted it by six.
+func TestSalamanderUDPBucketBoundaries(t *testing.T) {
+	padder := NewSalamanderPadder([]byte("boundary-secret"), Balanced)
+
+	cases := []struct {
+		payload  int
+		wantWire int
+	}{
+		{382, 400}, {383, 800}, // was 388/389
+		{782, 800}, {783, 1200}, // was 788/789
+		{1182, 1200}, {1183, 1400}, // was 1188/1189
+		{1382, 1400}, {1383, 1401}, // was 1388/1389, and 1389 went out as 1401 too
+	}
+	for _, tc := range cases {
+		enc, err := padder.EncryptUDP(make([]byte, tc.payload))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(enc) != tc.wantWire {
+			t.Errorf("payload %d: datagram %d bytes, want %d", tc.payload, len(enc), tc.wantWire)
+		}
+	}
+}
+
+// TestMultiSecretManySecretsNoFalseAccept exercises the path where a narrow tag
+// hurts most. ReadFrom walks the whole secret registry looking for a match, so
+// one unmatched packet costs one trial per registered secret and the odds of a
+// false accept scale with the registry size. With 512 secrets a 2-byte tag
+// would have accepted roughly one packet in 128 and cached the wrong secret for
+// that address, which then also corrupts every reply written back to it.
+//
+// The rejection half is paired with an acceptance half using a secret buried in
+// the middle of the registry: "nothing was accepted" would otherwise be
+// satisfied by a ReadFrom that rejects unconditionally.
+func TestMultiSecretManySecretsNoFalseAccept(t *testing.T) {
+	const numSecrets = 512
+
+	secrets := make([][]byte, numSecrets)
+	for i := range secrets {
+		s := make([]byte, 32)
+		rand.Read(s)
+		secrets[i] = s
+	}
+	provider := func() [][]byte { return secrets }
+
+	globalSecret := []byte("server-global-secret")
+	stranger := NewSalamanderPadder([]byte("secret-of-nobody-in-the-registry"), Balanced)
+
+	// Rejection: packets from a secret the server does not hold.
+	const rounds = 200
+	for i := 0; i < rounds; i++ {
+		enc, err := stranger.EncryptUDP(make([]byte, 1200))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mc := newChanPacketConn()
+		conn := NewMultiSecretSalamanderPacketConn(mc, globalSecret, Balanced, provider)
+		mc.inject(enc)
+
+		if _, _, err := conn.ReadFrom(make([]byte, 65536)); err == nil {
+			conn.Close()
+			t.Fatalf("round %d: packet from an unregistered secret accepted after %d trials", i, numSecrets)
+		}
+		conn.Close()
+	}
+
+	// Acceptance: a secret in the middle of the registry must still be found,
+	// and the payload must come back intact.
+	client := NewSalamanderPadder(secrets[numSecrets/2], Balanced)
+	payload := make([]byte, 1200)
+	rand.Read(payload)
+	enc, err := client.EncryptUDP(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mc := newChanPacketConn()
+	conn := NewMultiSecretSalamanderPacketConn(mc, globalSecret, Balanced, provider)
+	defer conn.Close()
+	mc.inject(enc)
+
+	buf := make([]byte, 65536)
+	n, _, err := conn.ReadFrom(buf)
+	if err != nil {
+		t.Fatalf("registered client secret rejected: %v", err)
+	}
+	if !bytes.Equal(buf[:n], payload) {
+		t.Error("payload corrupted through the multi-secret path")
 	}
 }
 


### PR DESCRIPTION
## Why

The UDP framing proved a packet came from the right secret by comparing **two bytes**, so a packet encrypted under a foreign secret passed the check about once in 65k.

That sounds theoretical until you count how the server uses it: `MultiSecretSalamanderPacketConn` trials every per-client secret in the registry against every unmatched packet. A server holding a few thousand secrets multiplies its own odds by that many. At two bytes, false accepts are an operational event rather than a curiosity.

It also made `TestSalamanderUDPWrongSecretRejected` a coin flip: it demanded zero false accepts out of 20000 packets while the expected count was ~0.3, so it was bound to fail roughly one run in four — and did, once, in CI. A test that is red a quarter of the time trains people to ignore red.

## What changed

The tag is 8 bytes, putting the first false accept on the order of 10^19 trials.

## The part that needed checking rather than assuming

Salamander exists so that packet sizes say nothing about the traffic inside. A wider tag could have pushed packets into neighbouring padding buckets and changed the size distribution on the wire — fixing one leak by opening a quieter one.

It does not, in the common case: `EncryptUDP` pads to a fixed bucket, so the six extra bytes eat into random padding and the datagram an observer measures is unchanged. Two exceptions are real and documented in the code:

- a payload within six bytes below a bucket boundary moves up one bucket;
- a payload above the largest bucket grows by six, since nothing pads it.

`TestSalamanderUDPWireSizeStable` pins the distribution, so a future change to either the tag width or the bucket table has to confront this question again.

## Compatibility

The format changes and old peers cannot read the new framing. Nothing is deployed on it: no exit runs QUIC-Salamander and no client passes `-quic`. Adding a negotiated version for a transport with no users would be ceremony, so this is a straight format change recorded in the CHANGELOG.

## Testing

`go build`, `go vet ./...`, `go test ./... -race` — 2157 tests, `golangci-lint` 0 issues. `internal/padding` run 25 times consecutively with no failure, which is what "not a coin flip" has to mean.

Both new tests were shown a broken implementation first: with the tag put back to 2 bytes, `TestSalamanderUDPWrongSecretRejected` fails on repeat runs exactly as it used to.
