### PR TITLE
fix(tun): give the IPv6 half-defaults a per-interface metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,26 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **A second dual-stack tunnel on the same machine no longer steals the first
+  one's IPv6 routes.** The two IPv6 half-defaults (`::/1`, `8000::/1`) went in
+  without a metric, so both tunnels got the kernel default of 1024 - and the
+  same destination at the same metric is one routing entry, not two. Bringing up
+  a second client (its own `-tun-name`, e.g. `tiredvpn1`) rewrote the first
+  client's entry to point at the second interface, and stopping the second
+  client deleted it outright. The first tunnel was left holding an IPv6 address
+  with no route through it: v6 traffic fell back to the RA-learned default and
+  went out unencrypted, past the tunnel, while v4 kept working and hid it.
+  Reproduces with two clients up at once on Linux; a single tunnel was never
+  affected. The half-defaults now carry a per-interface metric, so both tunnels
+  keep their own entries and teardown of one leaves the other alone.
+  - **Visible change:** `ip -6 route` now shows the half-defaults at
+    `metric 100 + <interface index>` instead of 1024. With two tunnels up, the
+    default v6 path belongs to whichever was started first (lower interface
+    index, hence lower metric) - deliberately, so a test client started later
+    cannot displace the primary tunnel. The base of 100 keeps our routes ahead
+    of another VPN's half-default at the kernel default; against the host's own
+    `::/0` nothing changes, since a `/1` wins on prefix length regardless of
+    metric. IPv4 route metrics are untouched.
 - **Breaking for dashboards: four `_seconds` histograms now really are in
   seconds.** `tiredvpn_tls_handshake_duration_seconds`,
   `tiredvpn_local_tls_handshake_duration_seconds`,

--- a/internal/tun/dualstack.go
+++ b/internal/tun/dualstack.go
@@ -13,6 +13,40 @@ import (
 // trick used on the IPv4 side.
 var dualStackRouteCIDRs = []string{"::/1", "8000::/1"}
 
+// v6HalfDefaultMetricBase is the metric floor for the half-default routes in
+// dualStackRouteCIDRs.
+//
+// Why 100 rather than the kernel's default 1024: another VPN on the same host
+// installs its own ::/1 with the kernel default, and ours has to win that
+// comparison or the full tunnel silently stops being full. Against the
+// RA-learned ::/0 the metric never comes into it — a /1 beats a /0 on prefix
+// length alone — so the choice of base does not affect that relationship in
+// either direction.
+const v6HalfDefaultMetricBase = 100
+
+// v6HalfDefaultPriority is the metric for a half-default route on the tunnel
+// with index linkIndex.
+//
+// The link index is the summand because it is unique across the interfaces
+// alive at any one moment: two tunnels on the same host therefore get two
+// distinct (dst, metric) pairs, which the kernel keeps as two separate routing
+// entries instead of collapsing them into one that the second RouteReplace
+// would steal from the first. It is also stable for the lifetime of an
+// interface, so RouteReplace on a reconnect still updates our own entry rather
+// than accumulating a new one per reconnect.
+//
+// The consequence is that the tunnel brought up first has the lower index,
+// hence the lower metric, hence the default: a deliberate choice in favour of
+// the primary tunnel over a test client started later.
+func v6HalfDefaultPriority(linkIndex int) int {
+	if linkIndex < 0 {
+		// Not a real index; keep the metric at the base rather than letting it
+		// slide below it.
+		linkIndex = 0
+	}
+	return v6HalfDefaultMetricBase + linkIndex
+}
+
 // dualStackRouteNets parses dualStackRouteCIDRs. The constants are known-good,
 // so a parse failure is a programmer error and reported as such.
 func dualStackRouteNets() ([]*net.IPNet, error) {

--- a/internal/tun/dualstack_plan_test.go
+++ b/internal/tun/dualstack_plan_test.go
@@ -224,6 +224,47 @@ func TestDualStackRouteNetsRejectsBadCIDR(t *testing.T) {
 	}
 }
 
+// TestV6HalfDefaultPriorityDistinctPerLink checks the property the metric
+// exists for: two tunnels on the same host must not produce the same
+// (destination, metric) pair, because that is one kernel routing entry and the
+// second tunnel's install would take it over from the first — leaving the first
+// with a v6 address and no route the moment the second one goes away.
+func TestV6HalfDefaultPriorityDistinctPerLink(t *testing.T) {
+	seen := make(map[int]int, 64)
+	for idx := 1; idx <= 64; idx++ {
+		p := v6HalfDefaultPriority(idx)
+		if p == 0 {
+			t.Fatalf("linkIndex %d: priority 0 leaves the kernel default (1024), which collides", idx)
+		}
+		if p < v6HalfDefaultMetricBase {
+			t.Errorf("linkIndex %d: priority %d is below the base %d, so a foreign ::/1 could outrank us",
+				idx, p, v6HalfDefaultMetricBase)
+		}
+		if prev, dup := seen[p]; dup {
+			t.Errorf("linkIndex %d and %d share priority %d", prev, idx, p)
+		}
+		seen[p] = idx
+	}
+
+	// The earlier-started tunnel has the lower index and must win.
+	if v6HalfDefaultPriority(3) >= v6HalfDefaultPriority(9) {
+		t.Errorf("lower link index must get the lower (better) metric: %d vs %d",
+			v6HalfDefaultPriority(3), v6HalfDefaultPriority(9))
+	}
+
+	// A metric below the base would let another VPN's kernel-default ::/1 or a
+	// hand-added low-metric route beat ours; the guard clamps instead.
+	if got := v6HalfDefaultPriority(-1); got != v6HalfDefaultMetricBase {
+		t.Errorf("v6HalfDefaultPriority(-1) = %d, want the base %d", got, v6HalfDefaultMetricBase)
+	}
+
+	// The base has to beat the kernel default another VPN's half-default gets,
+	// or a full tunnel stops being full.
+	if v6HalfDefaultMetricBase >= 1024 {
+		t.Errorf("base %d does not outrank the kernel default 1024", v6HalfDefaultMetricBase)
+	}
+}
+
 // TestDualStackRouteNetsCoverAddressSpace checks the property the two
 // half-defaults exist for: together they cover every address a client can
 // reach, while each is a /1 and so outranks an RA-learned ::/0 on prefix

--- a/internal/tun/route_metric_root_linux_test.go
+++ b/internal/tun/route_metric_root_linux_test.go
@@ -1,0 +1,222 @@
+//go:build linux
+
+package tun
+
+import (
+	"net"
+	"os"
+	"testing"
+
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+)
+
+// listV6Routes reads the main table. The nil-filter form of RouteListFiltered
+// panics in this netlink version, so the table filter is always supplied.
+func listV6Routes(t *testing.T) []netlink.Route {
+	t.Helper()
+	routes, err := netlink.RouteListFiltered(netlink.FAMILY_V6,
+		&netlink.Route{Table: unix.RT_TABLE_MAIN}, netlink.RT_FILTER_TABLE)
+	if err != nil {
+		t.Fatalf("RouteListFiltered: %v", err)
+	}
+	return routes
+}
+
+// The tests below talk to the real routing table and create interfaces, so
+// they are opt-in and want a network namespace of their own:
+//
+//	go test -c -o /tmp/tun.test ./internal/tun/
+//	sudo unshare -n env TIREDVPN_NETNS_TESTS=1 /tmp/tun.test -test.run TestRoot -test.v
+//
+// The opt-in is a separate switch from root because a root CI container would
+// otherwise have these adding dummy links to whatever namespace it shares.
+
+func rootOnly(t *testing.T) {
+	t.Helper()
+	if os.Getenv("TIREDVPN_NETNS_TESTS") != "1" {
+		t.Skip("opt-in: set TIREDVPN_NETNS_TESTS=1 and run inside a network namespace")
+	}
+	if os.Geteuid() != 0 {
+		t.Skip("needs root: creates links and routes")
+	}
+}
+
+// dummyLink creates an up dummy interface and returns its index. It is the
+// stand-in for a TUN: the half-defaults do not care what kind of link they
+// point at, only that two of them have different indices.
+func dummyLink(t *testing.T, name string) int {
+	t.Helper()
+	link := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: name}}
+	if err := netlink.LinkAdd(link); err != nil {
+		t.Skipf("cannot create dummy link %s (no dummy module?): %v", name, err)
+	}
+	t.Cleanup(func() { _ = netlink.LinkDel(link) })
+	if err := netlink.LinkSetUp(link); err != nil {
+		t.Fatalf("LinkSetUp(%s): %v", name, err)
+	}
+	l, err := netlink.LinkByName(name)
+	if err != nil {
+		t.Fatalf("LinkByName(%s): %v", name, err)
+	}
+	return l.Attrs().Index
+}
+
+// halfDefaultsOn returns the link indices carrying a ::/1 route right now.
+func halfDefaultsOn(t *testing.T) []int {
+	t.Helper()
+	var idx []int
+	for _, r := range listV6Routes(t) {
+		if r.Dst != nil && r.Dst.String() == "::/1" {
+			idx = append(idx, r.LinkIndex)
+		}
+	}
+	return idx
+}
+
+// TestRootTwoTunnelsKeepTheirHalfDefaults is the end-to-end check on the
+// defect: two dual-stack tunnels on one host must each keep their own ::/1,
+// and tearing one down must leave the other's route in place.
+//
+// It carries its own positive control. The same sequence is run first WITHOUT
+// the metric — the pre-fix behaviour — and the collision has to be visible
+// there, otherwise the test is not able to see the thing it claims to prove.
+func TestRootTwoTunnelsKeepTheirHalfDefaults(t *testing.T) {
+	rootOnly(t)
+
+	_, dst, err := net.ParseCIDR("::/1")
+	if err != nil {
+		t.Fatalf("ParseCIDR: %v", err)
+	}
+	idxA := dummyLink(t, "tvtesta")
+	idxB := dummyLink(t, "tvtestb")
+
+	// Positive control: no metric, exactly as the code did before this fix.
+	// The second install must swallow the first, leaving a single entry.
+	for _, idx := range []int{idxA, idxB} {
+		if err := netlink.RouteReplace(&netlink.Route{LinkIndex: idx, Dst: dst}); err != nil {
+			t.Fatalf("RouteReplace(no metric, link %d): %v", idx, err)
+		}
+	}
+	if got := halfDefaultsOn(t); len(got) != 1 {
+		t.Fatalf("control: metric-less installs produced %d ::/1 entries on links %v, "+
+			"want the 1 that made this a bug", len(got), got)
+	}
+	if got := halfDefaultsOn(t); got[0] != idxB {
+		t.Errorf("control: surviving ::/1 is on link %d, want the second installer %d", got[0], idxB)
+	}
+	// Clean the control's entry out before the real run.
+	if err := netlink.RouteDel(&netlink.Route{LinkIndex: idxB, Dst: dst}); err != nil {
+		t.Fatalf("RouteDel(control): %v", err)
+	}
+
+	// The fix: per-link metrics, so both entries live.
+	devA := &TUNDevice{name: "tvtesta"}
+	devB := &TUNDevice{name: "tvtestb"}
+	for _, c := range []struct {
+		dev *TUNDevice
+		idx int
+	}{{devA, idxA}, {devB, idxB}} {
+		route := v6HalfDefaultRoute(c.idx, dst)
+		c.dev.trackRoute(route)
+		if err := netlink.RouteReplace(route); err != nil {
+			t.Fatalf("RouteReplace(link %d): %v", c.idx, err)
+		}
+	}
+	got := halfDefaultsOn(t)
+	if len(got) != 2 {
+		t.Fatalf("::/1 present on %v, want both links %d and %d", got, idxA, idxB)
+	}
+
+	// A reconnect re-asserts the same route: it must refresh our entry, not add
+	// a third one.
+	if err := netlink.RouteReplace(v6HalfDefaultRoute(idxA, dst)); err != nil {
+		t.Fatalf("RouteReplace(re-add on link %d): %v", idxA, err)
+	}
+	if got := halfDefaultsOn(t); len(got) != 2 {
+		t.Errorf("re-add produced %d ::/1 entries on %v, want 2 (RouteReplace not idempotent)", len(got), got)
+	}
+
+	// Teardown of B: its own route goes, A's stays.
+	for _, spec := range devB.routeDelSpecs(idxB) {
+		if err := netlink.RouteDel(spec); err != nil {
+			t.Fatalf("RouteDel(link %d, metric %d): %v", spec.LinkIndex, spec.Priority, err)
+		}
+	}
+	got = halfDefaultsOn(t)
+	if len(got) != 1 || got[0] != idxA {
+		t.Fatalf("after tearing down link %d, ::/1 is on %v, want exactly [%d] — "+
+			"the surviving tunnel lost its route and its IPv6 leaks past the tunnel", idxB, got, idxA)
+	}
+
+	// Teardown of A removes the last one, so nothing is left behind.
+	for _, spec := range devA.routeDelSpecs(idxA) {
+		if err := netlink.RouteDel(spec); err != nil {
+			t.Fatalf("RouteDel(link %d, metric %d): %v", spec.LinkIndex, spec.Priority, err)
+		}
+	}
+	if got := halfDefaultsOn(t); len(got) != 0 {
+		t.Errorf("::/1 still present on %v after both teardowns", got)
+	}
+}
+
+// TestRootRouteDelMetricSemantics records what the kernel actually does with
+// the metric on deletion, measured rather than assumed.
+//
+// The assumption going in was that a deletion omitting the metric would not
+// match a route that has one, which would make carrying the metric through
+// addedRoutes load-bearing against a route outliving its tunnel. Measurement
+// says otherwise: with the destination and the interface given, the kernel
+// deletes the entry whatever its metric (checked here and, independently,
+// with `ip -6 route del`). So teardown was never at risk from the metric.
+//
+// The metric is still carried into the deletion, and the test pins that it
+// works, because reproducing the install exactly is an invariant that does not
+// depend on how lenient the matcher happens to be. This test is what would
+// notice if that leniency ever went away.
+func TestRootRouteDelMetricSemantics(t *testing.T) {
+	rootOnly(t)
+
+	_, dst, err := net.ParseCIDR("8000::/1")
+	if err != nil {
+		t.Fatalf("ParseCIDR: %v", err)
+	}
+	idx := dummyLink(t, "tvtestc")
+
+	present := func() bool {
+		for _, r := range listV6Routes(t) {
+			if r.Dst != nil && r.Dst.String() == "8000::/1" && r.LinkIndex == idx {
+				return true
+			}
+		}
+		return false
+	}
+
+	// The deletion our code builds must remove the route it installed. This is
+	// the assertion the shipped teardown path depends on.
+	route := v6HalfDefaultRoute(idx, dst)
+	if err := netlink.RouteReplace(route); err != nil {
+		t.Fatalf("RouteReplace: %v", err)
+	}
+	if !present() {
+		t.Fatal("route not installed, nothing to conclude from the deletion")
+	}
+	if err := netlink.RouteDel(route); err != nil {
+		t.Fatalf("RouteDel with the install spec: %v", err)
+	}
+	if present() {
+		t.Error("route survived a deletion carrying its own metric")
+	}
+
+	// And the measured leniency, recorded so a future kernel that tightens it
+	// turns this into a failure instead of a silent stranded route somewhere.
+	if err := netlink.RouteReplace(route); err != nil {
+		t.Fatalf("RouteReplace (leniency case): %v", err)
+	}
+	err = netlink.RouteDel(&netlink.Route{LinkIndex: idx, Dst: dst})
+	if err != nil || present() {
+		t.Errorf("metric-less RouteDel no longer matches a route with a metric "+
+			"(err=%v, still present=%v); deletions must now be built from the "+
+			"install spec everywhere, or routes outlive their tunnel", err, present())
+	}
+}

--- a/internal/tun/tun_cleanup_linux_test.go
+++ b/internal/tun/tun_cleanup_linux_test.go
@@ -5,6 +5,8 @@ package tun
 import (
 	"net"
 	"testing"
+
+	"github.com/vishvananda/netlink"
 )
 
 // TestMSSTableNamePerInterface verifies each interface gets a distinct nftables
@@ -23,32 +25,142 @@ func TestMSSTableNamePerInterface(t *testing.T) {
 	}
 }
 
+func mustCIDR(t *testing.T, s string) *net.IPNet {
+	t.Helper()
+	_, n, err := net.ParseCIDR(s)
+	if err != nil {
+		t.Fatalf("ParseCIDR(%q): %v", s, err)
+	}
+	return n
+}
+
+// TestRouteBuildersSetMetricPerFamily verifies the two install builders: the
+// IPv6 half-defaults carry a per-link metric (so two tunnels coexist), while
+// IPv4 routes keep metric 0 — the tunnel's v4 default is expected to beat a
+// DHCP-installed one at metric 600, and raising our v4 metric would break that.
+func TestRouteBuildersSetMetricPerFamily(t *testing.T) {
+	for _, cidr := range dualStackRouteCIDRs {
+		dst := mustCIDR(t, cidr)
+
+		r5 := v6HalfDefaultRoute(5, dst)
+		if r5.Priority == 0 {
+			t.Errorf("%s: Priority = 0, want the per-link metric (0 means the kernel default 1024)", cidr)
+		}
+		if want := v6HalfDefaultPriority(5); r5.Priority != want {
+			t.Errorf("%s: Priority = %d, want %d", cidr, r5.Priority, want)
+		}
+
+		r6 := v6HalfDefaultRoute(6, dst)
+		if r5.Priority == r6.Priority {
+			t.Errorf("%s: link 5 and 6 both got metric %d, so both are one routing entry",
+				cidr, r5.Priority)
+		}
+	}
+
+	for _, cidr := range []string{"0.0.0.0/1", "128.0.0.0/1", "10.0.0.0/24"} {
+		if r := tunRoute(5, mustCIDR(t, cidr)); r.Priority != 0 {
+			t.Errorf("%s: IPv4 Priority = %d, want 0", cidr, r.Priority)
+		}
+	}
+}
+
 // TestTrackRouteRecordsAndDedups verifies that route tracking records each
-// destination once, so teardown deletes exactly the routes this device added
-// (and reconnect re-adds do not grow the list unbounded).
+// routing entry once, so teardown deletes exactly the routes this device added
+// (and reconnect re-adds do not grow the list unbounded). The key is the
+// (destination, metric) pair, matching what the kernel keys an entry on.
 func TestTrackRouteRecordsAndDedups(t *testing.T) {
 	dev := &TUNDevice{name: "tiredvpn0"}
 
-	mustCIDR := func(s string) *net.IPNet {
-		_, n, err := net.ParseCIDR(s)
-		if err != nil {
-			t.Fatalf("ParseCIDR(%q): %v", s, err)
-		}
-		return n
+	dev.trackRoute(tunRoute(3, mustCIDR(t, "10.0.0.0/24")))
+	dev.trackRoute(tunRoute(3, mustCIDR(t, "142.132.151.126/32")))
+	dev.trackRoute(tunRoute(3, mustCIDR(t, "10.0.0.0/24"))) // duplicate (reconnect re-add)
+	dev.trackRoute(v6HalfDefaultRoute(3, mustCIDR(t, "::/1")))
+	dev.trackRoute(v6HalfDefaultRoute(3, mustCIDR(t, "::/1"))) // duplicate
+
+	if len(dev.addedRoutes) != 3 {
+		t.Fatalf("addedRoutes = %d entries, want 3 (deduped): %v", len(dev.addedRoutes), dev.addedRoutes)
 	}
 
-	dev.trackRoute(mustCIDR("10.0.0.0/24"))
-	dev.trackRoute(mustCIDR("142.132.151.126/32"))
-	dev.trackRoute(mustCIDR("10.0.0.0/24")) // duplicate (reconnect re-add)
-
-	if len(dev.addedRoutes) != 2 {
-		t.Fatalf("addedRoutes = %d entries, want 2 (deduped): %v", len(dev.addedRoutes), dev.addedRoutes)
+	want := map[string]bool{
+		"10.0.0.0/24":        true,
+		"142.132.151.126/32": true,
+		"::/1 metric 103":    true,
 	}
-
-	want := map[string]bool{"10.0.0.0/24": true, "142.132.151.126/32": true}
 	for _, r := range dev.addedRoutes {
 		if !want[r.String()] {
 			t.Errorf("unexpected tracked route %q", r.String())
+		}
+	}
+
+	// Same destination on a different link index is a different kernel entry
+	// (different metric), so it must be recorded separately rather than
+	// swallowed by the dedup.
+	dev.trackRoute(v6HalfDefaultRoute(4, mustCIDR(t, "::/1")))
+	if len(dev.addedRoutes) != 4 {
+		t.Errorf("::/1 at another metric should be tracked separately, got %d entries: %v",
+			len(dev.addedRoutes), dev.addedRoutes)
+	}
+}
+
+// TestUntrackRouteMatchesMetric verifies untracking uses the same key as
+// tracking, so DisableIPv6 drops the half-default it just deleted and leaves
+// everything else in place for teardown.
+func TestUntrackRouteMatchesMetric(t *testing.T) {
+	dev := &TUNDevice{name: "tiredvpn0"}
+	dev.trackRoute(tunRoute(7, mustCIDR(t, "10.0.0.0/24")))
+	dev.trackRoute(v6HalfDefaultRoute(7, mustCIDR(t, "::/1")))
+
+	// Same destination, another link's metric: a different kernel entry, so
+	// untracking it must not drop ours (which would leave our route installed
+	// and unrecorded, i.e. surviving teardown).
+	dev.untrackRoute(v6HalfDefaultRoute(9, mustCIDR(t, "::/1")))
+	if len(dev.addedRoutes) != 2 {
+		t.Fatalf("untracking ::/1 at another metric dropped our entry: %v", dev.addedRoutes)
+	}
+
+	dev.untrackRoute(v6HalfDefaultRoute(7, mustCIDR(t, "::/1")))
+
+	if len(dev.addedRoutes) != 1 {
+		t.Fatalf("addedRoutes = %d entries, want 1: %v", len(dev.addedRoutes), dev.addedRoutes)
+	}
+	if got := dev.addedRoutes[0].String(); got != "10.0.0.0/24" {
+		t.Errorf("remaining tracked route = %q, want 10.0.0.0/24", got)
+	}
+}
+
+// TestRouteDelSpecsMatchInstall is the guard against a route outliving the
+// tunnel: netlink matches a deletion on the metric too, so every deletion
+// request must carry the metric its install went in with. It compares the
+// deletion specs against the very routes that were installed.
+func TestRouteDelSpecsMatchInstall(t *testing.T) {
+	const linkIndex = 12
+	dev := &TUNDevice{name: "tiredvpn0"}
+
+	installed := []*netlink.Route{
+		tunRoute(linkIndex, mustCIDR(t, "0.0.0.0/1")),
+		tunRoute(linkIndex, mustCIDR(t, "128.0.0.0/1")),
+		v6HalfDefaultRoute(linkIndex, mustCIDR(t, "::/1")),
+		v6HalfDefaultRoute(linkIndex, mustCIDR(t, "8000::/1")),
+	}
+	for _, r := range installed {
+		dev.trackRoute(r)
+	}
+
+	specs := dev.routeDelSpecs(linkIndex)
+	if len(specs) != len(installed) {
+		t.Fatalf("routeDelSpecs = %d specs, want %d", len(specs), len(installed))
+	}
+	for i, spec := range specs {
+		want := installed[i]
+		if spec.Dst.String() != want.Dst.String() {
+			t.Errorf("spec %d: Dst = %s, want %s", i, spec.Dst, want.Dst)
+		}
+		if spec.Priority != want.Priority {
+			t.Errorf("spec %d (%s): delete Priority = %d, install Priority = %d "+
+				"(mismatch means the route survives teardown)", i, want.Dst, spec.Priority, want.Priority)
+		}
+		if spec.LinkIndex != linkIndex {
+			t.Errorf("spec %d: LinkIndex = %d, want %d", i, spec.LinkIndex, linkIndex)
 		}
 	}
 }
@@ -61,7 +173,7 @@ func TestDelRoutesClearsTracking(t *testing.T) {
 	// lookup gracefully and leave addedRoutes intact (nothing was deleted).
 	dev := &TUNDevice{name: "tiredvpn-doesnotexist-xyz"}
 	_, n, _ := net.ParseCIDR("10.0.0.0/24")
-	dev.addedRoutes = []*net.IPNet{n}
+	dev.addedRoutes = []trackedRoute{{dst: n}}
 
 	dev.delRoutes() // link lookup fails -> returns without clearing
 

--- a/internal/tun/tun_linux.go
+++ b/internal/tun/tun_linux.go
@@ -55,12 +55,17 @@ type TUNDevice struct {
 	remoteIP  net.IP
 	routes    []string
 
-	// addedRoutes records the destinations actually installed on this link so
+	// addedRoutes records the routes actually installed on this link so
 	// teardown can remove exactly its own routes (netlink.RouteDel) instead of
 	// relying on the kernel's cascade delete from LinkDel. On a multi-tunnel
 	// host that cascade is fine, but explicit scoped deletion keeps cleanup
 	// from ever touching the main table / default route or another tunnel.
-	addedRoutes []*net.IPNet
+	//
+	// The metric is part of the record, not just the destination, because that
+	// is what the kernel keys an entry on: the same destination at two metrics
+	// is two routes. Teardown then deletes exactly what install created rather
+	// than relying on the matcher to fill the metric in for it.
+	addedRoutes []trackedRoute
 
 	// serverBypassIPs are every server transport address this client may dial.
 	// When the installed route set covers one of them (a default route, or the
@@ -134,6 +139,45 @@ type TUNDevice struct {
 	// matches on the whole address, so deleting the wrong form fails and
 	// leaves the stale address behind.
 	v6PeerForm bool
+}
+
+// trackedRoute is one route this device installed: its destination and the
+// metric it went in with. Both are needed to delete it again.
+type trackedRoute struct {
+	dst      *net.IPNet
+	priority int
+}
+
+// sameAs reports whether two records name the same kernel routing entry.
+func (r trackedRoute) sameAs(other trackedRoute) bool {
+	return r.priority == other.priority && r.dst.String() == other.dst.String()
+}
+
+func (r trackedRoute) String() string {
+	if r.priority == 0 {
+		return r.dst.String()
+	}
+	return fmt.Sprintf("%s metric %d", r.dst, r.priority)
+}
+
+// tunRoute builds an install request for a route pointed at the tunnel. The
+// metric is left at 0 (the kernel picks its default) — deliberately, for the
+// IPv4 side: the tunnel's v4 default is expected to beat a DHCP-installed one
+// with metric 600, and moving our v4 metrics up would break that comparison.
+func tunRoute(linkIndex int, dst *net.IPNet) *netlink.Route {
+	return &netlink.Route{LinkIndex: linkIndex, Dst: dst}
+}
+
+// v6HalfDefaultRoute builds the request for one of the IPv6 half-defaults on
+// this tunnel. Install and delete both go through it, so the metric that makes
+// two tunnels coexist (see v6HalfDefaultPriority) cannot be present on one side
+// and missing on the other.
+func v6HalfDefaultRoute(linkIndex int, dst *net.IPNet) *netlink.Route {
+	return &netlink.Route{
+		LinkIndex: linkIndex,
+		Dst:       dst,
+		Priority:  v6HalfDefaultPriority(linkIndex),
+	}
 }
 
 // SetDeferRoutes requests that Configure NOT install routes immediately, leaving
@@ -359,13 +403,33 @@ func (t *TUNDevice) delRoutes() {
 		log.Warn("Cannot delete routes, link %s lookup failed: %v", t.name, err)
 		return
 	}
-	idx := link.Attrs().Index
-	for _, dst := range t.addedRoutes {
-		if err := netlink.RouteDel(&netlink.Route{LinkIndex: idx, Dst: dst}); err != nil {
-			log.Debug("Failed to delete route %s on %s: %v", dst, t.name, err)
+	for _, route := range t.routeDelSpecs(link.Attrs().Index) {
+		if err := netlink.RouteDel(route); err != nil {
+			log.Debug("Failed to delete route %s on %s: %v", route.Dst, t.name, err)
 		}
 	}
 	t.addedRoutes = nil
+}
+
+// routeDelSpecs turns the tracked set into deletion requests scoped to
+// linkIndex, each carrying the metric its route was installed with.
+//
+// Measured, not assumed (see TestRootRouteDelMetricSemantics): given the
+// destination and the interface, the kernel deletes the entry whatever metric
+// the request names, so omitting it would work today. The metric is included
+// anyway — reproducing the install exactly is an invariant that holds no
+// matter how lenient the matcher is, and it is the tracked set, not the
+// kernel, that decides what teardown touches.
+func (t *TUNDevice) routeDelSpecs(linkIndex int) []*netlink.Route {
+	specs := make([]*netlink.Route, 0, len(t.addedRoutes))
+	for _, r := range t.addedRoutes {
+		specs = append(specs, &netlink.Route{
+			LinkIndex: linkIndex,
+			Dst:       r.dst,
+			Priority:  r.priority,
+		})
+	}
+	return specs
 }
 
 func (t *TUNDevice) File() *os.File {
@@ -545,10 +609,13 @@ func (t *TUNDevice) EnableDualStack(clientIP6, serverIP6 net.IP) error {
 	t.addServerBypass6()
 
 	// Routes: installed together with the address, idempotently. Tracking
-	// them in addedRoutes makes Close remove exactly these.
+	// them in addedRoutes makes Close remove exactly these. The per-link metric
+	// keeps a second dual-stack tunnel on this host from replacing our entries
+	// with its own (same Dst plus same metric is one entry, not two).
 	for _, dst := range routes6 {
-		t.trackRoute(dst)
-		if err := netlink.RouteReplace(&netlink.Route{LinkIndex: link.Attrs().Index, Dst: dst}); err != nil {
+		route := v6HalfDefaultRoute(link.Attrs().Index, dst)
+		t.trackRoute(route)
+		if err := netlink.RouteReplace(route); err != nil {
 			return fmt.Errorf("failed to add route %s: %w", dst, err)
 		}
 	}
@@ -642,10 +709,13 @@ func (t *TUNDevice) DisableIPv6() {
 	if t.v6Enabled {
 		if link, err := netlink.LinkByName(t.name); err == nil {
 			for _, dst := range t.routes6 {
-				if err := netlink.RouteDel(&netlink.Route{LinkIndex: link.Attrs().Index, Dst: dst}); err != nil {
+				// Built by the same helper as the install, so the deletion
+				// carries the metric netlink needs to match the entry.
+				route := v6HalfDefaultRoute(link.Attrs().Index, dst)
+				if err := netlink.RouteDel(route); err != nil {
 					log.Debug("Failed to delete v6 route %s on %s: %v", dst, t.name, err)
 				}
-				t.untrackRoute(dst)
+				t.untrackRoute(route)
 			}
 			if err := t.delV6Addr(link, t.localIP6); err != nil {
 				log.Debug("Failed to delete v6 addr %s on %s: %v", t.localIP6, t.name, err)
@@ -956,12 +1026,13 @@ func (t *TUNDevice) addRoutes(link netlink.Link, routes []string) {
 			log.Warn("Failed to parse route %s: %v", route, err)
 			continue
 		}
-		t.trackRoute(dst)
+		r := tunRoute(link.Attrs().Index, dst)
+		t.trackRoute(r)
 		// RouteReplace is idempotent: it installs the route if absent and is a
 		// no-op (no EEXIST) if it already exists. addRoutes runs on the initial
 		// install and again on every reconnect, so RouteAdd here used to spam
 		// "file exists" warnings once the route was already present.
-		if err := netlink.RouteReplace(&netlink.Route{LinkIndex: link.Attrs().Index, Dst: dst}); err != nil {
+		if err := netlink.RouteReplace(r); err != nil {
 			log.Warn("Failed to add route %s: %v", route, err)
 		}
 	}
@@ -1001,22 +1072,31 @@ func (t *TUNDevice) InstallRoutes() {
 	log.Info("Routes installed on %s after successful server connection", t.name)
 }
 
-// trackRoute records dst in t.addedRoutes for scoped teardown, deduping so
-// reconnect re-adds do not grow the list unbounded.
-func (t *TUNDevice) trackRoute(dst *net.IPNet) {
+// trackRoute records an installed route in t.addedRoutes for scoped teardown,
+// deduping so reconnect re-adds do not grow the list unbounded. It takes the
+// very route that was handed to netlink, so what teardown deletes cannot drift
+// from what install created.
+//
+// The dedup key is the (destination, metric) pair, because that pair is what
+// the kernel keys a routing entry on: two entries differing only in metric are
+// two routes and both need deleting.
+func (t *TUNDevice) trackRoute(route *netlink.Route) {
+	entry := trackedRoute{dst: route.Dst, priority: route.Priority}
 	for _, existing := range t.addedRoutes {
-		if existing.String() == dst.String() {
+		if existing.sameAs(entry) {
 			return
 		}
 	}
-	t.addedRoutes = append(t.addedRoutes, dst)
+	t.addedRoutes = append(t.addedRoutes, entry)
 }
 
-// untrackRoute drops dst from t.addedRoutes (used when a route is removed
-// ahead of teardown, e.g. DisableIPv6 tearing down the v6 half-defaults).
-func (t *TUNDevice) untrackRoute(dst *net.IPNet) {
+// untrackRoute drops a route from t.addedRoutes (used when it is removed ahead
+// of teardown, e.g. DisableIPv6 tearing down the v6 half-defaults). It takes
+// the same route the deletion was built from, metric included.
+func (t *TUNDevice) untrackRoute(route *netlink.Route) {
+	entry := trackedRoute{dst: route.Dst, priority: route.Priority}
 	for i, existing := range t.addedRoutes {
-		if existing.String() == dst.String() {
+		if existing.sameAs(entry) {
 			t.addedRoutes = append(t.addedRoutes[:i], t.addedRoutes[i+1:]...)
 			return
 		}
@@ -1044,10 +1124,11 @@ func (t *TUNDevice) reAddRoutes(link netlink.Link, reason string) {
 			log.Warn("Failed to parse route %s: %v", route, err)
 			continue
 		}
-		t.trackRoute(dst)
+		r := tunRoute(link.Attrs().Index, dst)
+		t.trackRoute(r)
 		// RouteReplace keeps re-adds idempotent across reconnects / IP changes:
 		// an already-present route is refreshed rather than failing with EEXIST.
-		if err := netlink.RouteReplace(&netlink.Route{LinkIndex: link.Attrs().Index, Dst: dst}); err != nil {
+		if err := netlink.RouteReplace(r); err != nil {
 			log.Warn("Failed to re-add route %s: %v", route, err)
 		} else {
 			log.Debug("Re-added route %s after %s", route, reason)
@@ -1055,11 +1136,14 @@ func (t *TUNDevice) reAddRoutes(link netlink.Link, reason string) {
 	}
 	// The v6 half-defaults are not part of t.routes (they are implied by the
 	// negotiated dual-stack, not user-supplied), so re-assert them separately
-	// with the same idempotent RouteReplace.
+	// with the same idempotent RouteReplace — and the same per-link metric they
+	// were installed with, or the replace would land on a second entry instead
+	// of refreshing ours.
 	if t.v6Enabled {
 		for _, dst := range t.routes6 {
-			t.trackRoute(dst)
-			if err := netlink.RouteReplace(&netlink.Route{LinkIndex: link.Attrs().Index, Dst: dst}); err != nil {
+			r := v6HalfDefaultRoute(link.Attrs().Index, dst)
+			t.trackRoute(r)
+			if err := netlink.RouteReplace(r); err != nil {
 				log.Warn("Failed to re-add v6 route %s: %v", dst, err)
 			}
 		}


### PR DESCRIPTION
## What was broken

The `::/1` and `8000::/1` routes went in through `RouteReplace` with no `Priority`, so the kernel gave both tunnels its default metric of 1024. Same destination at the same metric is **one** routing entry: a second dual-stack client on the host rewrote the first client's entry to point at its own interface, and its teardown then deleted that entry outright.

The first tunnel was left holding a v6 address with no route. IPv6 fell through to the RA-learned default and left the machine unencrypted, while IPv4 kept working and masked the failure — the worst shape of failure for a censorship-resistant transport.

The existing scoping on teardown (`delRoutes` deletes only by its own LinkIndex) is honest but irrelevant here: the damage happens at install time, not teardown.

## Fix

Metric is now `100 + link index`.

- **Base 100, not the kernel's 1024** — another VPN's `::/1` arrives at the kernel default and ours has to win it, or the full tunnel silently stops being full. Against the RA `::/0` the metric never participates: a /1 beats a /0 on prefix length.
- **Link index as the summand** — unique among simultaneously live interfaces, so two tunnels never collapse into one entry; stable per interface, so `RouteReplace` on reconnect still refreshes our own entry instead of accumulating one per reconnect.

Consequence: the tunnel brought up first has the lower index, hence the default. Deliberate — the primary tunnel outranks a test client started later.

`addedRoutes` now records `(dst, priority)` so teardown reproduces the install exactly. IPv4 routes keep priority 0 and are untouched: the v4 default at metric 0 deliberately beats a DHCP default at 600, and shifting v4 metrics would break that.

## Verification

Beyond the unit tests, two opt-in netns tests (`TIREDVPN_NETNS_TESTS=1`, run inside a network namespace) exercise real netlink against a real kernel.

Shown to broken code, not just to fixed code — with `Priority` forced back to 0, `TestRootTwoTunnelsKeepTheirHalfDefaults` fails with `::/1 present on [3], want both links 2 and 3`, which is the original defect reproduced in the routing table. Unit tests were broken one site at a time as well.

Gate: `go build`, `go vet`, `go test ./... -race -short` all clean, `golangci-lint run` 0 issues.