### PR TITLE
fix: derive -listen-v6 from -listen, and log facts instead of intentions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,35 @@ Versions follow [Semantic Versioning](https://semver.org/).
     its own port - open that port for IPv6 in the firewall, and drop 995 if it
     was opened only for this. An explicit `-listen-v6` is honored exactly as
     before, including the Helm chart, which sets it.
+- **`VPN started on <iface> (IP: ...)` now prints the address the interface
+  carries.** It printed the address from the client config, which is the one
+  requested at handshake time; by the time the line is reached the exit has
+  already assigned an address and the TUN device has been moved to it. On a
+  server that hands out addresses from a pool the two differ on every start, and
+  the log showed three consecutive lines that contradicted each other. The line
+  is what operators read when diagnosing address assignment, and it was once
+  read as evidence of two clients sharing one tunnel address - a defect that did
+  not exist.
+- **The client no longer reports a local proxy it is not running.** `Listening
+  on <addr> (SOCKS5/HTTP)` was printed at startup, before any socket was opened
+  and before the mode was even chosen, so it appeared in every run that never
+  listens: all four benchmark modes, Android control-socket mode, TUN mode with
+  an empty `-listen` (a deliberate configuration where another process owns the
+  local port), and any run where the listen failed - that last one leaving the
+  log asserting both that the proxy listens and that it could not start. The
+  claim is now made where the socket is, once, and carries the address the
+  listener is bound to rather than the configured string. A proxy switched off
+  with an empty `-listen` says so explicitly instead of printing an empty
+  address. The same treatment covers the `HTTP proxy on <addr>` line, and proxy
+  mode - which had no success line at all and relied on the startup claim - now
+  reports its own listeners.
+  - **Behavior change in one corner:** proxy mode (no `-tun`) with an empty
+    `-listen` now fails at startup with an explanation. It used to reach
+    `net.Listen("tcp", "")`, which binds a random port on every interface - an
+    unauthenticated proxy reachable from outside, on a port nothing in the log
+    named. TUN mode is unaffected: an empty `-listen` there means the local
+    proxy is off, which is a supported configuration.
+
 ## [1.6.0] - 2026-08-26
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **The IPv6 listener now follows the `-listen` port instead of always trying
+  995.** `-listen-v6` defaulted to the literal `[::]:995`, and `-enable-v6` is
+  on by default, so every server told to listen anywhere other than 995 asked
+  for IPv6 on a port its operator never named. Where 995 was taken the listener
+  simply failed and left a line in the log - three units on one host, on 994,
+  996 and 997, all had no IPv6 entry at all while appearing configured for it.
+  Where 995 was free the process quietly opened it, adding observable surface
+  that only `ss -ltn` would reveal. An empty `-listen-v6` now takes the port
+  from `-listen` and binds `[::]` on it: `-listen :443` gives `[::]:443`,
+  `-listen 1.2.3.4:994` gives `[::]:994`. The log states the address and that it
+  was derived. IPv6 stays off, with the reason logged, when `-listen` already
+  names an IPv6 address or has no usable port.
+  - **This changes behavior for deployments that relied on the default.** A
+    server on a non-995 port used to attempt IPv6 on 995 and will now listen on
+    its own port - open that port for IPv6 in the firewall, and drop 995 if it
+    was opened only for this. An explicit `-listen-v6` is honored exactly as
+    before, including the Helm chart, which sets it.
 ## [1.6.0] - 2026-08-26
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ Run `tiredvpn server -help` or `tiredvpn client -help` for the full flag list.
 |------|---------|-------------|
 | `-config` | | Path to a TOML config; CLI flags override it |
 | `-listen` | `:443` | IPv4 listen address |
-| `-listen-v6` | `[::]:995` | IPv6 listen address |
+| `-listen-v6` | | IPv6 listen address (default: `[::]` on the `-listen` port) |
 | `-dual-stack` | `true` | Listen on both IPv4 and IPv6 |
 | `-cert` | `server.crt` | TLS certificate file |
 | `-key` | `server.key` | TLS private key file |

--- a/cmd/tiredvpn/main.go
+++ b/cmd/tiredvpn/main.go
@@ -103,8 +103,8 @@ Examples:
   Server (second instance on the same Redis, isolated namespace):
     tiredvpn server -listen :994 -redis localhost:6379 -redis-db 1 -redis-prefix tiredvpn-relay:
 
-  Server (dual-stack IPv4 + IPv6):
-    tiredvpn server -listen :443 -listen-v6 [::]:995 -dual-stack -cert server.crt -key server.key
+  Server (dual-stack IPv4 + IPv6; v6 follows the -listen port unless overridden):
+    tiredvpn server -listen :443 -cert server.crt -key server.key
 
   Client (SOCKS5 proxy):
     tiredvpn client -server host:443 -secret <secret> -listen 127.0.0.1:1080
@@ -137,7 +137,7 @@ CORE OPTIONS:
   -listen string
         Listen address for IPv4 (default ":443")
   -listen-v6 string
-        IPv6 listen address (default "[::]:995")
+        IPv6 listen address (default: same port as -listen on [::])
   -cert string
         TLS certificate file (default "server.crt")
   -key string
@@ -517,7 +517,7 @@ func registerServerFlags(fs *flag.FlagSet, cfg *server.Config) *serverFlagOpts {
 	fs.StringVar(&cfg.IPPoolV6, "ip-pool-v6", "", "IPv6 prefix for TUN dual-stack clients (e.g., 'fd00:10:8::/64'). Enables IPv6 inside the tunnel for v0x04 clients.")
 
 	// IPv6 Transport flags
-	fs.StringVar(&cfg.ListenAddrV6, "listen-v6", "[::]:995", "IPv6 listen address")
+	fs.StringVar(&cfg.ListenAddrV6, "listen-v6", "", "IPv6 listen address (default: same port as -listen on [::])")
 	fs.BoolVar(&cfg.EnableIPv6, "enable-v6", true, "Enable IPv6 listener")
 	fs.BoolVar(&cfg.DualStack, "dual-stack", true, "Listen on both IPv4 and IPv6")
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -372,8 +372,9 @@ firewall-cmd --permanent --add-port=443/udp
 firewall-cmd --reload
 ```
 
-With `-enable-v6` (default on) the server also listens on `-listen-v6`, default
-`[::]:995` — open 995/tcp and 995/udp too, or change the address.
+With `-enable-v6` (default on) the server also listens on `-listen-v6`. Left
+unset, that is `[::]` on the `-listen` port, so the rules above already cover it.
+Set `-listen-v6` to put IPv6 on a different port, and open that port too.
 
 If you use port hopping (`-port-range`), open the whole range:
 
@@ -496,7 +497,7 @@ The server listens on IPv6 by default:
 | Flag | Default |
 |---|---|
 | `-enable-v6` | `true` |
-| `-listen-v6` | `[::]:995` |
+| `-listen-v6` | empty — `[::]` on the `-listen` port |
 | `-dual-stack` | `true` |
 | `-ip-pool-v6` | empty (in-tunnel IPv6 disabled) |
 
@@ -512,7 +513,6 @@ Two different things are called "IPv6" here:
 ```bash
 tiredvpn server \
   -listen :443 \
-  -listen-v6 "[::]:995" \
   -cert server.crt \
   -key server.key \
   -secret <secret> \

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -143,7 +143,8 @@ For production use Let's Encrypt or any CA-signed certificate. See
 The server now:
 
 - Accepts TLS (TCP) on `:443` and QUIC (UDP) on `:443`
-- Also listens on `[::]:995` (`-listen-v6`, IPv6 is on by default)
+- Also listens on `[::]:443` — IPv6 is on by default and follows the `-listen`
+  port unless `-listen-v6` says otherwise
 - Serves a fake website to unauthenticated visitors, over HTTP/1.1 or HTTP/2
   depending on the ALPN the peer negotiated
 - Authenticates clients by HMAC-verified secret

--- a/docs/server.md
+++ b/docs/server.md
@@ -84,9 +84,15 @@ exit. `-upstream-secret` is mandatory when `-upstream` is set.
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `-listen-v6` | `[::]:995` | IPv6 listen address. |
-| `-enable-v6` | `true` | Start the IPv6 listener. Skipped when false or when `-listen-v6` is empty. |
-| `-dual-stack` | `true` | Accepted, but nothing reads it. The IPv6 listener is gated by `-enable-v6` and a non-empty `-listen-v6` alone; IPv4 always listens. |
+| `-listen-v6` | empty | IPv6 listen address. Empty means `[::]` on the `-listen` port. |
+| `-enable-v6` | `true` | Start the IPv6 listener. Skipped when false, and when `-listen-v6` is empty and no address can be derived from `-listen` — the log says which. |
+| `-dual-stack` | `true` | Accepted, but nothing reads it. The IPv6 listener is gated by `-enable-v6` alone; IPv4 always listens. |
+
+An empty `-listen-v6` takes the port from `-listen` and widens the host to
+`[::]`: `-listen :443` gives `[::]:443`, `-listen 1.2.3.4:994` gives `[::]:994`.
+Two cases leave IPv6 off with a reason in the log — `-listen` that already names
+an IPv6 address (say so with `-listen-v6` instead), and a `-listen` with no port
+or an unparsable one.
 
 These control the *transport* the client dials. IPv6 **inside** the tunnel is
 `-ip-pool-v6`.
@@ -458,7 +464,6 @@ tiredvpn server \
 ```bash
 tiredvpn server \
   -listen :443 \
-  -listen-v6 [::]:995 \
   -cert server.crt \
   -key server.key \
   -secret <secret>

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -207,10 +207,9 @@ func Run(cfg *Config) error {
 			log.Info("  endpoint %d: %s v4=%q v6=%q", i, e.Label(i), e.V4, e.V6)
 		}
 	}
-	log.Info("Listening on %s (SOCKS5/HTTP)", cfg.ListenAddr)
-	if cfg.HTTPListenAddr != "" {
-		log.Info("HTTP proxy on %s", cfg.HTTPListenAddr)
-	}
+	// No "Listening on ..." here. This runs before any listener exists, and
+	// four of the modes dispatched below (the benchmarks) never open one at
+	// all; the claim is made where the socket is, in startProxy.
 	log.Info("Adaptive config: reprobe=%v, circuitThreshold=%d, circuitReset=%v, fallback=%v",
 		cfg.ReprobeInterval, cfg.CircuitThreshold, cfg.CircuitResetTime, cfg.EnableFallback)
 
@@ -873,7 +872,11 @@ func runTUNMode(cfg *Config, mgr *strategy.Manager, sigChan chan os.Signal) erro
 		}
 	}
 
-	log.Info("VPN started on %s (IP: %s)", cfg.TunName, cfg.TunIP)
+	// Start returns only after a successful handshake, so by now the exit has
+	// either assigned an address (and connect moved the TUN device onto it) or
+	// echoed back the requested one. Which of the two gets printed is decided
+	// inside logVPNStarted, where a test can hold it to the assigned one.
+	logVPNStarted(cfg, vpnClient)
 	if len(routes) > 0 {
 		log.Info("Routes: %v", routes)
 	}
@@ -949,28 +952,25 @@ func runTUNMode(cfg *Config, mgr *strategy.Manager, sigChan chan os.Signal) erro
 	var tunnelPool *pool.TunnelPool
 	var listener, httpListener net.Listener
 
+	// The pool is tied to the SOCKS address being configured at all, not to the
+	// listen succeeding — the HTTP listener below shares it.
 	if cfg.ListenAddr != "" {
-		// Create connection pool for proxy
 		poolCfg := pool.DefaultConfig()
 		tunnelPool = pool.NewTunnelPool(mgr, cfg.ServerAddr, poolCfg)
+	}
 
-		var err error
-		listener, err = net.Listen("tcp", cfg.ListenAddr)
-		if err != nil {
-			log.Warn("Failed to start SOCKS proxy: %v", err)
-		} else {
-			log.Info("SOCKS5/HTTP proxy listening on %s", cfg.ListenAddr)
-			go acceptConnections(listener, tunnelPool, "socks")
-		}
+	listener, err = startProxy(cfg.ListenAddr, socksProxyLabel)
+	if err != nil {
+		log.Warn("Failed to start SOCKS proxy: %v", err)
+	} else if listener != nil {
+		go acceptConnections(listener, tunnelPool, "socks")
 	}
 
 	if cfg.HTTPListenAddr != "" {
-		var err error
-		httpListener, err = net.Listen("tcp", cfg.HTTPListenAddr)
+		httpListener, err = startProxy(cfg.HTTPListenAddr, httpProxyLabel)
 		if err != nil {
 			log.Warn("Failed to start HTTP proxy: %v", err)
 		} else {
-			log.Info("HTTP proxy listening on %s", cfg.HTTPListenAddr)
 			go acceptConnections(httpListener, tunnelPool, "http")
 		}
 	}
@@ -1020,14 +1020,21 @@ func runProxyMode(cfg *Config, mgr *strategy.Manager, sigChan chan os.Signal) er
 	}()
 
 	// Main listener (auto-detect SOCKS5/HTTP)
-	listener, err := net.Listen("tcp", cfg.ListenAddr)
+	listener, err := startProxy(cfg.ListenAddr, socksProxyLabel)
 	if err != nil {
 		return fmt.Errorf("failed to listen: %w", err)
+	}
+	if listener == nil {
+		// Proxy mode with no proxy port has nothing to do. Refusing beats what
+		// net.Listen does with an empty address, which is to bind a random port
+		// on every interface — an open proxy nobody asked for and nothing in
+		// the log to find it by.
+		return fmt.Errorf("proxy mode needs a listen address: pass -listen, or -tun to run without a local proxy")
 	}
 
 	var httpListener net.Listener
 	if cfg.HTTPListenAddr != "" {
-		httpListener, err = net.Listen("tcp", cfg.HTTPListenAddr)
+		httpListener, err = startProxy(cfg.HTTPListenAddr, httpProxyLabel)
 		if err != nil {
 			listener.Close()
 			return fmt.Errorf("failed to listen HTTP: %w", err)

--- a/internal/client/proxy_listener.go
+++ b/internal/client/proxy_listener.go
@@ -1,0 +1,40 @@
+package client
+
+import (
+	"net"
+
+	"github.com/tiredvpn/tiredvpn/internal/log"
+)
+
+// Labels for the two local proxy sockets, so the "listening" and "disabled"
+// lines for one socket always name it the same way.
+const (
+	socksProxyLabel = "SOCKS5/HTTP proxy"
+	httpProxyLabel  = "HTTP proxy"
+)
+
+// startProxy opens a local proxy listener and logs what actually happened:
+// the address the socket is bound to on success, and the fact that the proxy is
+// off when no address is configured. A failed listen logs nothing here — the
+// callers differ on how loud that is (a warning in TUN mode, fatal in proxy
+// mode) — but in no case is a listening claim made for a socket that is not
+// listening.
+//
+// The bound address comes from the listener rather than the config string, for
+// the same reason the tunnel address does: ":0" and an empty host are resolved
+// by the kernel, and the config is not the fact.
+//
+// Returns (nil, nil) when addr is empty. Callers must handle that case; there
+// is deliberately no listener to fall through with.
+func startProxy(addr, label string) (net.Listener, error) {
+	if addr == "" {
+		log.Info("%s disabled (no listen address configured)", label)
+		return nil, nil
+	}
+	l, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, err
+	}
+	log.Info("%s listening on %s", label, l.Addr())
+	return l, nil
+}

--- a/internal/client/proxy_listener_test.go
+++ b/internal/client/proxy_listener_test.go
@@ -1,0 +1,140 @@
+package client
+
+import (
+	"bytes"
+	"net"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/tiredvpn/tiredvpn/internal/log"
+)
+
+// captureLog redirects the package logger for the duration of one test. The
+// logger is process-global, so these tests must not run in parallel.
+var logMu sync.Mutex
+
+func captureLog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	logMu.Lock()
+	buf := &bytes.Buffer{}
+	log.SetOutput(buf)
+	t.Cleanup(func() {
+		log.SetOutput(os.Stderr)
+		logMu.Unlock()
+	})
+	return buf
+}
+
+// claimsListening reports whether the log asserts that something is listening.
+// Matched loosely on purpose: any future wording of the claim should still be
+// caught by the negative cases below.
+func claimsListening(out string) bool {
+	return strings.Contains(strings.ToLower(out), "listening")
+}
+
+// TestStartProxyDisabledMakesNoListeningClaim: an empty address means the proxy
+// is off on purpose. The log must say so once and must not claim a socket.
+// This is the ruhop case — the local SOCKS port is deliberately left to another
+// process, and the old code still printed "Listening on  (SOCKS5/HTTP)" with an
+// empty address.
+func TestStartProxyDisabledMakesNoListeningClaim(t *testing.T) {
+	buf := captureLog(t)
+
+	l, err := startProxy("", socksProxyLabel)
+	if err != nil {
+		t.Fatalf("startProxy(\"\"): %v", err)
+	}
+	if l != nil {
+		t.Fatalf("startProxy(\"\") returned a listener on %s, want nil", l.Addr())
+	}
+
+	out := buf.String()
+	if claimsListening(out) {
+		t.Errorf("log claims a socket is listening while the proxy is off: %q", out)
+	}
+	if !strings.Contains(out, "disabled") {
+		t.Errorf("log does not say the proxy is disabled: %q", out)
+	}
+	if !strings.Contains(out, socksProxyLabel) {
+		t.Errorf("log does not name which proxy is off: %q", out)
+	}
+}
+
+// TestStartProxyFailedMakesNoListeningClaim: the port is taken, so there is no
+// socket. The old code had already printed the claim at startup, leaving the
+// log asserting both that the proxy listens and that it failed to start.
+func TestStartProxyFailedMakesNoListeningClaim(t *testing.T) {
+	blocker, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("cannot take a port to block: %v", err)
+	}
+	defer blocker.Close()
+	taken := blocker.Addr().String()
+
+	buf := captureLog(t)
+
+	l, err := startProxy(taken, socksProxyLabel)
+	if err == nil {
+		l.Close()
+		t.Fatalf("startProxy(%s) succeeded on a port already held", taken)
+	}
+	if l != nil {
+		t.Errorf("startProxy returned a listener alongside the error")
+	}
+
+	if out := buf.String(); claimsListening(out) {
+		t.Errorf("log claims a socket is listening after the listen failed: %q", out)
+	}
+}
+
+// TestStartProxyListeningReportsBoundAddress: the positive control. Without it
+// the two tests above would pass just as well against a function that never
+// logs anything at all.
+//
+// The address logged is the bound one, not the configured string: ":0" and an
+// empty host are resolved by the kernel, so the config is not the fact.
+func TestStartProxyListeningReportsBoundAddress(t *testing.T) {
+	buf := captureLog(t)
+
+	l, err := startProxy("127.0.0.1:0", socksProxyLabel)
+	if err != nil {
+		t.Fatalf("startProxy: %v", err)
+	}
+	defer l.Close()
+
+	out := buf.String()
+	if !claimsListening(out) {
+		t.Fatalf("log does not report the listening socket: %q", out)
+	}
+	if !strings.Contains(out, l.Addr().String()) {
+		t.Errorf("log does not carry the bound address %s: %q", l.Addr(), out)
+	}
+	if strings.Contains(out, "127.0.0.1:0") {
+		t.Errorf("log carries the configured string instead of the bound port: %q", out)
+	}
+	if strings.Contains(out, "disabled") {
+		t.Errorf("log calls a live proxy disabled: %q", out)
+	}
+}
+
+// TestStartProxyLabelsTheSocket: the two proxies must be distinguishable in the
+// log, otherwise a line about one is read as a line about the other.
+func TestStartProxyLabelsTheSocket(t *testing.T) {
+	buf := captureLog(t)
+
+	l, err := startProxy("127.0.0.1:0", httpProxyLabel)
+	if err != nil {
+		t.Fatalf("startProxy: %v", err)
+	}
+	defer l.Close()
+
+	out := buf.String()
+	if !strings.Contains(out, httpProxyLabel) {
+		t.Errorf("log does not name the HTTP proxy: %q", out)
+	}
+	if strings.Contains(out, socksProxyLabel) {
+		t.Errorf("HTTP proxy logged under the SOCKS label: %q", out)
+	}
+}

--- a/internal/client/vpn_started_log.go
+++ b/internal/client/vpn_started_log.go
@@ -1,0 +1,29 @@
+package client
+
+import (
+	"net"
+
+	"github.com/tiredvpn/tiredvpn/internal/log"
+)
+
+// localIPSource supplies the address the tunnel interface actually carries.
+// *tun.VPNClient implements it; tests supply a fake.
+type localIPSource interface {
+	LocalIP() net.IP
+}
+
+// logVPNStarted announces the live tunnel.
+//
+// The address comes from the tunnel, never from cfg.TunIP. cfg.TunIP is what
+// was *requested* at handshake time; by the time this runs the exit has already
+// assigned an address and the TUN device has been moved onto it, so on any
+// pool-assigning exit the two differ on every start. Reporting the request as
+// if it were the fact once produced a diagnosis of two clients sharing one
+// tunnel address, which had never happened.
+//
+// cfg is passed in whole, rather than just the name, so that this substitution
+// lives inside a function a test can drive: the wrong value is reachable here,
+// and TestLogVPNStartedPrintsAssignedNotRequested fails the moment it is used.
+func logVPNStarted(cfg *Config, tunnel localIPSource) {
+	log.Info("VPN started on %s (IP: %s)", cfg.TunName, tunnel.LocalIP())
+}

--- a/internal/client/vpn_started_log_test.go
+++ b/internal/client/vpn_started_log_test.go
@@ -1,0 +1,90 @@
+package client
+
+import (
+	"net"
+	"strings"
+	"testing"
+)
+
+// fakeTunnel stands in for *tun.VPNClient and records whether it was asked for
+// the address at all, so a version that prints something else without consulting
+// the tunnel is caught even if the string happens to look right.
+type fakeTunnel struct {
+	ip    net.IP
+	asked bool
+}
+
+func (f *fakeTunnel) LocalIP() net.IP {
+	f.asked = true
+	return f.ip
+}
+
+// TestLogVPNStartedPrintsAssignedNotRequested is the regression guard for the
+// defect itself: the line must carry the address the interface ended up with,
+// while the requested one sits right there in cfg, reachable and wrong.
+//
+// The addresses are the ones from the log that caused the trouble: the client
+// asked for 10.8.0.2, the exit assigned 10.8.5.3, and the old line printed the
+// request - which was then read as two clients colliding on one address.
+func TestLogVPNStartedPrintsAssignedNotRequested(t *testing.T) {
+	buf := captureLog(t)
+
+	cfg := &Config{TunName: "tiredvpn-usa2", TunIP: "10.8.0.2"}
+	tunnel := &fakeTunnel{ip: net.IPv4(10, 8, 5, 3)}
+
+	logVPNStarted(cfg, tunnel)
+
+	out := buf.String()
+	if !tunnel.asked {
+		t.Error("the line was produced without asking the tunnel for its address")
+	}
+	if !strings.Contains(out, "10.8.5.3") {
+		t.Errorf("assigned address missing from the line: %q", out)
+	}
+	if strings.Contains(out, "10.8.0.2") {
+		t.Errorf("line carries the requested address instead of the assigned one - this is the defect: %q", out)
+	}
+	if !strings.Contains(out, "tiredvpn-usa2") {
+		t.Errorf("interface name missing from the line: %q", out)
+	}
+}
+
+// TestLogVPNStartedWhenExitEchoedTheRequest: when the exit hands back the
+// address that was asked for, the line is the same either way. The value must
+// still come from the tunnel - otherwise the test above passes for the wrong
+// reason on any exit with a sticky assignment.
+func TestLogVPNStartedWhenExitEchoedTheRequest(t *testing.T) {
+	buf := captureLog(t)
+
+	cfg := &Config{TunName: "tiredvpn0", TunIP: "10.8.0.2"}
+	tunnel := &fakeTunnel{ip: net.IPv4(10, 8, 0, 2)}
+
+	logVPNStarted(cfg, tunnel)
+
+	if !tunnel.asked {
+		t.Error("the line was produced without asking the tunnel for its address")
+	}
+	if out := buf.String(); !strings.Contains(out, "10.8.0.2") {
+		t.Errorf("address missing from the line: %q", out)
+	}
+}
+
+// TestLogVPNStartedNamesTheInterfaceNotTheAddress guards the other half of the
+// format: two %s in one line are easy to transpose, and a transposed line reads
+// plausibly enough to survive review.
+func TestLogVPNStartedNamesTheInterfaceNotTheAddress(t *testing.T) {
+	buf := captureLog(t)
+
+	cfg := &Config{TunName: "tiredvpn-usa2", TunIP: "10.8.0.2"}
+	logVPNStarted(cfg, &fakeTunnel{ip: net.IPv4(10, 8, 5, 3)})
+
+	out := buf.String()
+	nameAt := strings.Index(out, "tiredvpn-usa2")
+	ipAt := strings.Index(out, "10.8.5.3")
+	if nameAt < 0 || ipAt < 0 {
+		t.Fatalf("line is missing the name or the address: %q", out)
+	}
+	if nameAt > ipAt {
+		t.Errorf("address printed where the interface name belongs: %q", out)
+	}
+}

--- a/internal/server/listen_v6.go
+++ b/internal/server/listen_v6.go
@@ -1,0 +1,66 @@
+package server
+
+import (
+	"fmt"
+	"net"
+)
+
+// deriveListenAddrV6 builds the IPv6 listen address from the IPv4 -listen
+// address, for deployments that did not spell -listen-v6 out explicitly.
+//
+// It exists because the previous default was the literal "[::]:995": a server
+// told to listen on any other port still tried to open v6 on 995. Either that
+// port was taken (no v6 entry at all, only a line in the log) or it was free
+// and the process quietly opened a port nobody asked for — extra observable
+// surface on a censorship-resistance box, visible only through `ss -ltn`.
+//
+// A derived address keeps the port and widens the host to the v6 wildcard.
+// Returning an empty string with a non-nil error means "do not start the v6
+// listener, and here is the reason to put in the log"; that is a diagnosable
+// state, not a failure, so the caller logs and carries on with IPv4 only.
+func deriveListenAddrV6(listenAddr string) (string, error) {
+	if listenAddr == "" {
+		return "", fmt.Errorf("-listen is empty, nothing to derive the IPv6 address from")
+	}
+
+	host, port, err := net.SplitHostPort(listenAddr)
+	if err != nil {
+		return "", fmt.Errorf("cannot parse -listen %q: %w", listenAddr, err)
+	}
+	// SplitHostPort accepts ":" and "1.2.3.4:" with an empty port; net.Listen
+	// would read that as "any free port", which is never what an operator
+	// means for the entry socket.
+	if port == "" {
+		return "", fmt.Errorf("-listen %q has no port", listenAddr)
+	}
+
+	// A host that is already an IPv6 literal means the operator addressed the
+	// v6 side themselves in -listen. Deriving a second v6 socket from it would
+	// be second-guessing that; -listen-v6 is the flag for saying otherwise.
+	if ip := net.ParseIP(host); ip != nil && ip.To4() == nil {
+		return "", fmt.Errorf("-listen %q is already an IPv6 address; set -listen-v6 explicitly to add a second IPv6 socket", listenAddr)
+	}
+
+	// Everything else — the empty host of ":443", the v4 wildcard, a concrete
+	// v4 address, a hostname — becomes the v6 wildcard on the same port. For a
+	// concrete v4 address such as 1.2.3.4:443 this is deliberately a widening:
+	// that address has no v6 counterpart to bind, and the alternative (no v6 at
+	// all) is what this whole change is undoing. An operator who needs the v6
+	// socket pinned to one address says so with -listen-v6.
+	return net.JoinHostPort("::", port), nil
+}
+
+// resolveListenAddrV6 returns the address the IPv6 listener should bind, and
+// whether it was derived from -listen rather than given by the operator. An
+// explicit -listen-v6 is passed through untouched, so existing deployments
+// that spell it out keep their exact behavior.
+func resolveListenAddrV6(cfg *Config) (addr string, derived bool, err error) {
+	if cfg.ListenAddrV6 != "" {
+		return cfg.ListenAddrV6, false, nil
+	}
+	addr, err = deriveListenAddrV6(cfg.ListenAddr)
+	if err != nil {
+		return "", false, err
+	}
+	return addr, true, nil
+}

--- a/internal/server/listen_v6_test.go
+++ b/internal/server/listen_v6_test.go
@@ -1,0 +1,146 @@
+package server
+
+import (
+	"net"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// TestDeriveListenAddrV6 pins the address the IPv6 listener binds when the
+// operator did not spell -listen-v6 out. The port must follow -listen; the old
+// hardcoded "[::]:995" default is exactly the defect being fixed.
+func TestDeriveListenAddrV6(t *testing.T) {
+	cases := []struct {
+		name     string
+		listen   string
+		want     string
+		wantErr  string // substring the reason must mention; "" = must succeed
+	}{
+		{name: "port only", listen: ":443", want: "[::]:443"},
+		{name: "v4 wildcard", listen: "0.0.0.0:443", want: "[::]:443"},
+		// A concrete v4 address has no v6 counterpart, so the v6 socket widens
+		// to the wildcard rather than not existing at all.
+		{name: "concrete v4", listen: "1.2.3.4:443", want: "[::]:443"},
+		{name: "hostname", listen: "vpn.example.com:995", want: "[::]:995"},
+		{name: "non-995 port is not 995", listen: ":994", want: "[::]:994"},
+		{name: "v4-mapped v6 counts as v4", listen: "[::ffff:1.2.3.4]:443", want: "[::]:443"},
+
+		// -listen already names the v6 side; adding a second v6 socket would be
+		// second-guessing the operator.
+		{name: "v6 wildcard", listen: "[::]:443", wantErr: "already an IPv6 address"},
+		{name: "v6 literal", listen: "[2001:db8::1]:443", wantErr: "already an IPv6 address"},
+
+		// Malformed input must disable v6 with a reason, never panic or abort.
+		{name: "no port", listen: "1.2.3.4", wantErr: "cannot parse"},
+		{name: "empty port", listen: "1.2.3.4:", wantErr: "no port"},
+		{name: "bare colon", listen: ":", wantErr: "no port"},
+		{name: "empty", listen: "", wantErr: "nothing to derive"},
+		{name: "too many colons", listen: "1:2:3", wantErr: "cannot parse"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := deriveListenAddrV6(tc.listen)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("deriveListenAddrV6(%q) = %q, want error mentioning %q", tc.listen, got, tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("reason = %q, want it to mention %q", err, tc.wantErr)
+				}
+				if got != "" {
+					t.Errorf("address = %q on error, want empty so the caller cannot bind it", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("deriveListenAddrV6(%q): %v", tc.listen, err)
+			}
+			if got != tc.want {
+				t.Errorf("deriveListenAddrV6(%q) = %q, want %q", tc.listen, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestResolveListenAddrV6 covers the flag interaction: an explicit -listen-v6
+// wins untouched (no behavior change for deployments that set it), an empty one
+// is derived, and the caller can tell the two apart for the log line.
+func TestResolveListenAddrV6(t *testing.T) {
+	t.Run("explicit wins", func(t *testing.T) {
+		cfg := &Config{ListenAddr: ":443", ListenAddrV6: "[::1]:9995"}
+		addr, derived, err := resolveListenAddrV6(cfg)
+		if err != nil {
+			t.Fatalf("resolveListenAddrV6: %v", err)
+		}
+		if addr != "[::1]:9995" {
+			t.Errorf("addr = %q, want the explicit [::1]:9995", addr)
+		}
+		if derived {
+			t.Error("derived = true for an explicitly configured address")
+		}
+	})
+
+	t.Run("explicit wins even over an unparsable -listen", func(t *testing.T) {
+		cfg := &Config{ListenAddr: "garbage", ListenAddrV6: "[::]:9995"}
+		addr, derived, err := resolveListenAddrV6(cfg)
+		if err != nil || addr != "[::]:9995" || derived {
+			t.Errorf("got (%q, %v, %v), want (\"[::]:9995\", false, nil)", addr, derived, err)
+		}
+	})
+
+	t.Run("empty is derived", func(t *testing.T) {
+		cfg := &Config{ListenAddr: "0.0.0.0:994"}
+		addr, derived, err := resolveListenAddrV6(cfg)
+		if err != nil {
+			t.Fatalf("resolveListenAddrV6: %v", err)
+		}
+		if addr != "[::]:994" {
+			t.Errorf("addr = %q, want [::]:994 following -listen", addr)
+		}
+		if !derived {
+			t.Error("derived = false, want true so the log can say where the port came from")
+		}
+	})
+
+	t.Run("empty with unparsable -listen disables v6", func(t *testing.T) {
+		cfg := &Config{ListenAddr: "garbage"}
+		addr, derived, err := resolveListenAddrV6(cfg)
+		if err == nil {
+			t.Fatalf("got %q, want an error so the caller skips the listener", addr)
+		}
+		if addr != "" || derived {
+			t.Errorf("got (%q, %v) on error, want (\"\", false)", addr, derived)
+		}
+	})
+}
+
+// TestDerivedAddrIsBindable proves the derived string is something the IPv6
+// listener can actually bind, and that it lands on the port -listen named. The
+// port is taken from a throwaway listener so the test needs no root and no
+// fixed port. Positive control for the table above: without it, every case
+// there could agree on a string that net.Listen rejects.
+func TestDerivedAddrIsBindable(t *testing.T) {
+	probe, err := net.Listen("tcp6", "[::1]:0")
+	if err != nil {
+		t.Skipf("no usable IPv6 loopback here: %v", err)
+	}
+	port := probe.Addr().(*net.TCPAddr).Port
+	probe.Close()
+
+	addrV6, err := deriveListenAddrV6(net.JoinHostPort("127.0.0.1", strconv.Itoa(port)))
+	if err != nil {
+		t.Fatalf("deriveListenAddrV6: %v", err)
+	}
+
+	l, err := net.Listen("tcp6", addrV6)
+	if err != nil {
+		t.Fatalf("listening on derived %q: %v", addrV6, err)
+	}
+	defer l.Close()
+
+	if got := l.Addr().(*net.TCPAddr).Port; got != port {
+		t.Errorf("bound port %d, want %d from -listen", got, port)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -351,9 +351,11 @@ type Config struct {
 	MaxConcurrentConns int
 
 	// IPv6 Support
-	ListenAddrV6 string // "[::]:995"
-	EnableIPv6   bool   // default: true
-	DualStack    bool   // default: true
+	// ListenAddrV6 is the IPv6 listen address. Empty means "derive it from
+	// ListenAddr" — same port, host [::] — see resolveListenAddrV6.
+	ListenAddrV6 string
+	EnableIPv6   bool // default: true
+	DualStack    bool // default: true
 
 	// EnableICMP enables the ICMP tunnel server (requires CAP_NET_RAW).
 	// If the process lacks the capability, the listener is silently skipped.
@@ -537,13 +539,25 @@ func Run(cfg *Config) error {
 
 	go handleShutdownSignal(sigChan, srvCtx, quicServer, listener)
 
-	if cfg.EnableIPv6 && cfg.ListenAddrV6 != "" {
-		log.Info("Starting dual-stack mode: IPv4 and IPv6")
-		go func() {
-			if err := startIPv6Listener(cfg.ListenAddrV6, srvCtx); err != nil {
-				log.Error("IPv6 listener failed: %v", err)
-			}
-		}()
+	if cfg.EnableIPv6 {
+		// Derived here rather than at flag-parse time so every way of building
+		// a Config ends up under the same rule.
+		addrV6, derived, err := resolveListenAddrV6(cfg)
+		switch {
+		case err != nil:
+			log.Warn("IPv6 listener disabled: %v", err)
+		case derived:
+			log.Info("Starting dual-stack mode: IPv4 and IPv6 on %s (derived from -listen %s; pass -listen-v6 to override)", addrV6, cfg.ListenAddr)
+		default:
+			log.Info("Starting dual-stack mode: IPv4 and IPv6 on %s", addrV6)
+		}
+		if err == nil {
+			go func() {
+				if err := startIPv6Listener(addrV6, srvCtx); err != nil {
+					log.Error("IPv6 listener failed: %v", err)
+				}
+			}()
+		}
 	}
 
 	if cfg.EnableICMP {

--- a/internal/tun/vpn.go
+++ b/internal/tun/vpn.go
@@ -1233,6 +1233,27 @@ func (v *VPNClient) GetServerCapabilities() ServerCapabilities {
 	return v.serverCaps
 }
 
+// LocalIP returns the tunnel address the interface actually carries: the one
+// the exit assigned during the handshake, or the requested one when the exit
+// echoed it back unchanged. Callers that log the address must use this rather
+// than the configured VPNConfig.LocalIP — after Start returns, connect has
+// already replaced the requested address with the assigned one and updated the
+// TUN device, so the configured value is stale.
+//
+// Taken under v.mu, the same lock connect holds while it mutates localIP.
+// The result is a copy: net.IP is a slice, and handing out the live one would
+// let a caller mutate the client's own state.
+func (v *VPNClient) LocalIP() net.IP {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if v.localIP == nil {
+		return nil
+	}
+	out := make(net.IP, len(v.localIP))
+	copy(out, v.localIP)
+	return out
+}
+
 // sendKeepalive periodically sends keepalive packets to prevent timeout
 func (v *VPNClient) sendKeepalive() {
 	defer func() {

--- a/internal/tun/vpn_localip_test.go
+++ b/internal/tun/vpn_localip_test.go
@@ -1,0 +1,77 @@
+package tun
+
+import (
+	"net"
+	"testing"
+)
+
+// TestLocalIPReportsAssignedNotRequested drives the real assignment path: the
+// client asks for 10.8.0.2, the exit hands back 10.8.5.3, and LocalIP must
+// report the assigned address. This is the fact the "VPN started on ... (IP:
+// %s)" line needs; printing the configured address there once produced a report
+// of two clients sharing one address that never happened.
+//
+// TUNDevice is a zero value on purpose: UpdateLocalIP fails fast on
+// netlink.LinkByName("") without touching the host, and the caller tolerates
+// that failure — so the test exercises the localIP bookkeeping without root.
+func TestLocalIPReportsAssignedNotRequested(t *testing.T) {
+	requested := net.IPv4(10, 8, 0, 2)
+	assigned := net.IPv4(10, 8, 5, 3)
+
+	// [status:1][serverIP:4][assignedClientIP:4][flags:1]
+	resp := []byte{0x00, 10, 8, 0, 1, 10, 8, 5, 3, 0x00}
+	conn := &scriptedConn{chunks: [][]byte{resp}}
+
+	v := &VPNClient{tun: &TUNDevice{mtu: 1280}, localIP: requested}
+	if err := v.performHandshake(conn); err != nil {
+		t.Fatalf("performHandshake: %v", err)
+	}
+
+	got := v.LocalIP()
+	if !got.Equal(assigned) {
+		t.Errorf("LocalIP() = %s, want the assigned %s", got, assigned)
+	}
+	if got.Equal(requested) {
+		t.Errorf("LocalIP() = %s, the requested address — this is the defect", got)
+	}
+}
+
+// TestLocalIPKeepsRequestedWhenEchoed covers the other outcome: an exit that
+// hands back the address that was asked for. LocalIP must still be the truth,
+// which here happens to equal the request.
+func TestLocalIPKeepsRequestedWhenEchoed(t *testing.T) {
+	requested := net.IPv4(10, 8, 0, 2)
+	resp := []byte{0x00, 10, 8, 0, 1, 10, 8, 0, 2, 0x00}
+	conn := &scriptedConn{chunks: [][]byte{resp}}
+
+	v := &VPNClient{tun: &TUNDevice{mtu: 1280}, localIP: requested}
+	if err := v.performHandshake(conn); err != nil {
+		t.Fatalf("performHandshake: %v", err)
+	}
+	if got := v.LocalIP(); !got.Equal(requested) {
+		t.Errorf("LocalIP() = %s, want %s", got, requested)
+	}
+}
+
+// TestLocalIPReturnsCopy: net.IP is a slice, so handing out the live one would
+// let a caller rewrite the client's idea of its own address.
+func TestLocalIPReturnsCopy(t *testing.T) {
+	v := &VPNClient{localIP: net.IPv4(10, 8, 5, 3)}
+
+	got := v.LocalIP()
+	for i := range got {
+		got[i] = 0xff
+	}
+
+	if after := v.LocalIP(); !after.Equal(net.IPv4(10, 8, 5, 3)) {
+		t.Errorf("mutating the returned IP changed client state: %s", after)
+	}
+}
+
+// TestLocalIPNilBeforeAssignment: a client that never handshook has no address,
+// and must say so rather than panic.
+func TestLocalIPNilBeforeAssignment(t *testing.T) {
+	if got := (&VPNClient{}).LocalIP(); got != nil {
+		t.Errorf("LocalIP() = %s on a fresh client, want nil", got)
+	}
+}


### PR DESCRIPTION
Two unrelated defects, both found while reconciling the live fleet after 1.6.0. One commit each.

## 1. `-listen-v6` was hardcoded to `[::]:995`

`-enable-v6` defaults to true and `-listen-v6` defaulted to the literal `[::]:995`, so a server told to listen on any other port still tried to open v6 on 995. Two outcomes, and the second is the worse one:

- **port taken** — no IPv6 entry at all, just a line in the log. This is the live state on the Dubai box: three units (`-listen :994`, `:996`, `:997`) were all failing to bind `[::]:995`, held by the fourth. Three relays with no IPv6 ingress, and nothing but a log line to say so.
- **port free** — the process quietly opens a port nobody asked for. On a censorship-resistance box that is extra observable surface, discoverable only by running `ss -ltn`.

The default is now empty and the address is derived from `-listen`: same port, v6 wildcard host. An explicit `-listen-v6` passes through untouched.

Edge cases, each with a test:
- `:443`, `0.0.0.0:443` → `[::]:443`
- `1.2.3.4:443` → `[::]:443`. A concrete v4 address has no v6 counterpart to bind; widening beats the alternative of no v6 at all, and `-listen-v6` is there for operators who need it pinned.
- `[::]:443` / `[2001:db8::1]:443` → **no second listener**. The main socket is already v6; deriving another guarantees a bind conflict with itself. Real case: a USA unit runs exactly like that.
- empty or unparseable `-listen`, or no port → v6 stays off with a stated reason in the log, not a crash.

**Behaviour change for deployments relying on the default**: a server on a non-995 port used to attempt v6 on 995 and now listens on its own port. Documentation updated alongside the flag.

## 2. Three log lines asserted things that were not true

- `VPN started on %s (IP: %s)` printed `cfg.TunIP` — the address *requested* at handshake. By then the exit has assigned a different one and the TUN device has already moved. On a pool-assigning exit those differ on every start. This line is what produced a diagnosis of two clients sharing one tunnel address, which had never happened; the interfaces held `10.8.5.3` and `10.8.100.2` all along.
- `Listening on %s (SOCKS5/HTTP)` printed unconditionally at startup, long before `net.Listen`. With `-listen ""` it announced `Listening on  (SOCKS5/HTTP)` with an empty address — the ruhop case, where port 1080 belongs to a separate `ss-redir` and the proxy is off on purpose. When `net.Listen` failed the log carried both the claim and the warning.
- The `HTTPListenAddr` line had the same shape and got the same treatment.

The claim now sits next to the socket, and disabled means one line saying so.

## Verification

Every test was shown to broken code, one site at a time: hardcoding the derived port, removing the v6-literal guard, letting an empty port through, restoring `cfg.TunIP` in the log, and making the proxy announce unconditionally. Each reddened the tests that cover it.

One gap was caught this way and closed: the first version tested the `LocalIP()` getter rather than the log line's use of it, so restoring `cfg.TunIP` passed clean. Formatting moved into `logVPNStarted`, and `TestLogVPNStartedPrintsAssignedNotRequested` now fails the moment the requested address comes back.

Gate: `go build`, `go vet`, `go test ./... -race -short`, `golangci-lint run` — all clean.