### PR TITLE
fix(server): derive the IPv6 address from a wildcard -listen too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`-listen [::]:<port>` no longer switches the IPv6 listener off.** 1.7.0
+  started deriving the v6 address from `-listen`, but refused to derive one
+  when `-listen` already named an IPv6 host, on the belief that a second
+  socket on that port would collide with the main listener. It does not. The
+  main listener runs on `tcp4`, which turns a wildcard host into `0.0.0.0`,
+  and Go sets `IPV6_V6ONLY` on every `tcp6` socket, so the two coexist on one
+  port - measured directly, and now pinned by a test that opens both. The
+  refusal therefore denied IPv6 to exactly the operator who had asked for both
+  families by writing `[::]`. A concrete literal such as `[2001:db8::1]:443`
+  is still refused, for a different and real reason: `tcp4` cannot bind it at
+  all, so the process exits before the IPv6 listener is ever reached, and the
+  message now says so.
+
 ## [1.7.0] - 2026-08-27
 
 ### Fixed

--- a/docs/server.md
+++ b/docs/server.md
@@ -90,9 +90,14 @@ exit. `-upstream-secret` is mandatory when `-upstream` is set.
 
 An empty `-listen-v6` takes the port from `-listen` and widens the host to
 `[::]`: `-listen :443` gives `[::]:443`, `-listen 1.2.3.4:994` gives `[::]:994`.
-Two cases leave IPv6 off with a reason in the log — `-listen` that already names
-an IPv6 address (say so with `-listen-v6` instead), and a `-listen` with no port
-or an unparsable one.
+`-listen [::]:997` gives `[::]:997` — the IPv4 listener reads a wildcard host as
+`0.0.0.0`, and the IPv6 socket is `V6ONLY`, so both sit on the port.
+
+Two cases leave IPv6 off with a reason in the log: a `-listen` with no port or
+an unparsable one, and a `-listen` naming a *concrete* IPv6 address such as
+`[2001:db8::1]:443`. The second one stops the server outright, before the IPv6
+listener is reached — the IPv4 listener cannot bind an IPv6 address. Give both
+families explicitly (`-listen` plus `-listen-v6`) instead.
 
 These control the *transport* the client dials. IPv6 **inside** the tunnel is
 `-ip-pool-v6`.

--- a/internal/server/listen_v6.go
+++ b/internal/server/listen_v6.go
@@ -34,11 +34,23 @@ func deriveListenAddrV6(listenAddr string) (string, error) {
 		return "", fmt.Errorf("-listen %q has no port", listenAddr)
 	}
 
-	// A host that is already an IPv6 literal means the operator addressed the
-	// v6 side themselves in -listen. Deriving a second v6 socket from it would
-	// be second-guessing that; -listen-v6 is the flag for saying otherwise.
-	if ip := net.ParseIP(host); ip != nil && ip.To4() == nil {
-		return "", fmt.Errorf("-listen %q is already an IPv6 address; set -listen-v6 explicitly to add a second IPv6 socket", listenAddr)
+	// A concrete IPv6 literal is a dead end, but not because of this function:
+	// the main listener runs net.Listen("tcp4", ...), and tcp4 rejects an IPv6
+	// address outright ("no suitable address found"), so the process never gets
+	// this far. Report the reason rather than derive an address for a server
+	// that will not start.
+	//
+	// The v6 wildcard is the opposite case and used to be lumped in with it, on
+	// the assumption that deriving [::]:port would collide with the main socket.
+	// Measured, and it does not: tcp4 with a wildcard host binds 0.0.0.0, and Go
+	// sets IPV6_V6ONLY on every tcp6 socket, so the two coexist on one port.
+	// Verified both halves directly — net.Listen("tcp4", "[::]:P") reports
+	// 0.0.0.0:P, and a tcp6 listener on the same port opens alongside it without
+	// error. Refusing to derive here would leave an operator who wrote -listen
+	// [::]:997 — that is, who asked for both families — with no IPv6 entry at
+	// all, which is the very failure this whole change exists to remove.
+	if ip := net.ParseIP(host); ip != nil && ip.To4() == nil && !ip.IsUnspecified() {
+		return "", fmt.Errorf("-listen %q is an IPv6 address, which the IPv4 listener cannot bind; set -listen and -listen-v6 explicitly", listenAddr)
 	}
 
 	// Everything else — the empty host of ":443", the v4 wildcard, a concrete

--- a/internal/server/listen_v6_test.go
+++ b/internal/server/listen_v6_test.go
@@ -12,10 +12,10 @@ import (
 // hardcoded "[::]:995" default is exactly the defect being fixed.
 func TestDeriveListenAddrV6(t *testing.T) {
 	cases := []struct {
-		name     string
-		listen   string
-		want     string
-		wantErr  string // substring the reason must mention; "" = must succeed
+		name    string
+		listen  string
+		want    string
+		wantErr string // substring the reason must mention; "" = must succeed
 	}{
 		{name: "port only", listen: ":443", want: "[::]:443"},
 		{name: "v4 wildcard", listen: "0.0.0.0:443", want: "[::]:443"},
@@ -26,10 +26,16 @@ func TestDeriveListenAddrV6(t *testing.T) {
 		{name: "non-995 port is not 995", listen: ":994", want: "[::]:994"},
 		{name: "v4-mapped v6 counts as v4", listen: "[::ffff:1.2.3.4]:443", want: "[::]:443"},
 
-		// -listen already names the v6 side; adding a second v6 socket would be
-		// second-guessing the operator.
-		{name: "v6 wildcard", listen: "[::]:443", wantErr: "already an IPv6 address"},
-		{name: "v6 literal", listen: "[2001:db8::1]:443", wantErr: "already an IPv6 address"},
+		// The v6 wildcard asks for both families: tcp4 binds 0.0.0.0 from it and
+		// the derived tcp6 socket opens alongside on the same port (see
+		// TestWildcardListenersCoexist). Refusing here would leave that operator
+		// with no IPv6 entry at all.
+		{name: "v6 wildcard", listen: "[::]:443", want: "[::]:443"},
+		{name: "v6 wildcard, non-995 port", listen: "[::]:997", want: "[::]:997"},
+
+		// A concrete v6 literal is refused because the IPv4 listener cannot bind
+		// it at all — the process dies before the v6 listener is reached.
+		{name: "v6 literal", listen: "[2001:db8::1]:443", wantErr: "IPv4 listener cannot bind"},
 
 		// Malformed input must disable v6 with a reason, never panic or abort.
 		{name: "no port", listen: "1.2.3.4", wantErr: "cannot parse"},
@@ -142,5 +148,50 @@ func TestDerivedAddrIsBindable(t *testing.T) {
 
 	if got := l.Addr().(*net.TCPAddr).Port; got != port {
 		t.Errorf("bound port %d, want %d from -listen", got, port)
+	}
+}
+
+// TestWildcardListenersCoexist is the positive control under the decision to
+// derive [::]:port from -listen [::]:port. The claim being tested is that the
+// two sockets do not fight over the port: the main listener uses tcp4, which
+// turns a wildcard host into 0.0.0.0, and Go sets IPV6_V6ONLY on every tcp6
+// socket, so the derived listener binds the v6 wildcard beside it.
+//
+// It runs against the real network stack rather than asserting the claim in a
+// comment, because the opposite belief — that this pair collides — is what put
+// the refusal into deriveListenAddrV6 in the first place, and it survived
+// review precisely because nobody made it fail.
+func TestWildcardListenersCoexist(t *testing.T) {
+	main4, err := net.Listen("tcp4", "[::]:0")
+	if err != nil {
+		t.Fatalf(`net.Listen("tcp4", "[::]:0"): %v`, err)
+	}
+	defer main4.Close()
+
+	addr4, ok := main4.Addr().(*net.TCPAddr)
+	if !ok {
+		t.Fatalf("main listener address is %T, want *net.TCPAddr", main4.Addr())
+	}
+	if !addr4.IP.Equal(net.IPv4zero) {
+		t.Fatalf("tcp4 on a v6 wildcard bound %s, want 0.0.0.0 — the premise of the derivation no longer holds", addr4.IP)
+	}
+
+	derived, err := deriveListenAddrV6(net.JoinHostPort("::", strconv.Itoa(addr4.Port)))
+	if err != nil {
+		t.Fatalf("deriveListenAddrV6 refused the v6 wildcard: %v", err)
+	}
+
+	v6, err := net.Listen("tcp6", derived)
+	if err != nil {
+		t.Fatalf("tcp6 listener on %s alongside tcp4 on port %d: %v", derived, addr4.Port, err)
+	}
+	defer v6.Close()
+
+	addr6, ok := v6.Addr().(*net.TCPAddr)
+	if !ok {
+		t.Fatalf("v6 listener address is %T, want *net.TCPAddr", v6.Addr())
+	}
+	if addr6.Port != addr4.Port {
+		t.Errorf("v6 listener took port %d, want %d — both sockets must sit on the -listen port", addr6.Port, addr4.Port)
 	}
 }


### PR DESCRIPTION
Follow-up to #68, which shipped in 1.7.0 with one case decided on an assumption instead of a measurement.

## What was wrong

1.7.0 derives the IPv6 listen address from `-listen` when `-listen-v6` is empty, but refused to derive one if `-listen` already named an IPv6 host. The stated reason was that a second socket on that port would collide with the main listener.

It does not collide. The main listener runs `net.Listen("tcp4", ...)`, and tcp4 reads a wildcard host as `0.0.0.0`; Go sets `IPV6_V6ONLY` on every tcp6 socket. The two sit on one port without complaint.

So the refusal took IPv6 away from precisely the operator who had asked for both families by writing `[::]` — the opposite of the defect #68 set out to fix. A unit running `-listen [::]:997` would have got no IPv6 entry at all.

## Measured, not argued

```
net.Listen("tcp4", "[::]:19981")  ->  0.0.0.0:19981   (err == nil)
net.Listen("tcp6", "[::]:19981")  ->  [::]:19981      (err == nil, alongside)
net.Listen("tcp4", "[2001:db8::1]:19982")  ->  no suitable address found
```

`TestWildcardListenersCoexist` now opens both sockets against the real stack, so the assumption cannot return untested. It also asserts that tcp4 really binds `0.0.0.0` — if that ever stops being true, the derivation's premise is gone and the test says so rather than the code quietly misbehaving.

## What still refuses, and why

A concrete literal such as `[2001:db8::1]:443`. The reason is real this time: tcp4 cannot bind an IPv6 address, so the process exits before the IPv6 listener is reached. The error message says that instead of suggesting the operator add a flag that would not help.

## Fleet check

No node regressed. Every unit with `-listen [::]` sets `-listen-v6` explicitly, and an explicit value bypasses derivation entirely — checked across AMS, both USA boxes, Dubai and ruhop before writing the fix.

Broken-code check: restoring the old condition reddens both wildcard table cases and `TestWildcardListenersCoexist`; letting the concrete literal through reddens the literal case. Gate clean — build, vet, `-race -short`, lint 0 issues. Flag documentation updated alongside.