### PR TITLE
feat: a server pool may give every server its own secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,19 @@ Versions follow [Semantic Versioning](https://semver.org/).
   no default is configured anywhere: that configuration has no key for half its
   servers.
 
+### Fixed
+
+- **Seqovl's packet-level overlap no longer marks its fake segments with the
+  wrong key, silently.** Level A (Linux, `-seqovl-packet`, off by default) is one
+  NFQUEUE hook for the whole process carrying one marker, derived once when the
+  injector starts. With a pool whose endpoints have different secrets it stayed
+  on the first endpoint's key, so the marker meant nothing to any other server
+  and the fake segments were only discarded by luck of the safe geometry. The
+  marker now comes from the endpoint that starts the injector, and a later
+  endpoint with a different key gets a warning saying level A cannot follow it
+  and that connection rides the level-B decoy alone - which is per connection
+  and does follow the key.
+
 ## [1.7.1] - 2026-08-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **A server pool may now give every server its own `secret`.** Until now a
+  `[[servers]]` list whose entries disagreed on `secret` was a startup error,
+  and the reason was an implementation detail rather than the protocol: the key
+  was copied into each strategy when the strategy was built, once, so it could
+  not follow an endpoint switch. The key is now resolved per candidate and
+  travels with the dial, along with everything derived from it - the REALITY
+  donor pool and the client identifier the server looks a client up by, both of
+  which would otherwise have arrived at the new server derived from the old
+  server's key. Pooling servers that belong to different accounts, or that were
+  provisioned separately, no longer requires making them share one credential.
+  `-secret` / `TIREDVPN_SECRET` becomes the default for entries that name none
+  of their own instead of competing with them, so the two can now be combined.
+  A single server with `-secret` and no list behaves exactly as before. What
+  stays an error is a list where some entries carry a secret, some do not, and
+  no default is configured anywhere: that configuration has no key for half its
+  servers.
+
 ## [1.7.1] - 2026-08-27
 
 ### Fixed

--- a/configs/client.example.toml
+++ b/configs/client.example.toml
@@ -29,6 +29,18 @@ port = 443
 # address = "203.0.113.20"
 # port = 443
 # weight = 50
+#
+# Each entry may carry its own `secret`: the key is resolved per endpoint and
+# travels with the dial, so switching server switches the key with it. -secret /
+# TIREDVPN_SECRET is the default for entries that name none. Setting it on some
+# entries and not others, with no default configured anywhere, is a startup
+# error - that config has no key for half its servers.
+#
+# [[servers]]
+# name = "usa"
+# address = "203.0.113.30"
+# port = 443
+# secret = "the-key-this-server-knows-me-by"
 
 # --- Which server gets dialled, and when it is given up on ---
 # [selection]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -116,7 +116,9 @@ candidates.
 ```
 
 Falling back from IPv6 to IPv4 within one server is tried before moving to
-another server: same secret, same bypass route, same latency profile. Candidate
+another server: same key, same bypass route, same latency profile. Moving to
+another server may change the key - each endpoint can carry its own `secret`,
+which is resolved per candidate and travels with the dial. Candidate
 order comes from `[selection]` — `priority` (as written), `latency` (measured
 EWMA, ranking endpoints rather than families so a slow path cannot override
 `prefer_v6`), or `weighted`, which is sticky because reselecting per dial would

--- a/docs/client.md
+++ b/docs/client.md
@@ -491,12 +491,17 @@ number in a config file is a unit waiting to be guessed wrong. A
 
 Notes worth reading once:
 
-- **One secret for all servers.** The secret is fixed when a strategy is
-  constructed, so a per-server `secret` cannot take effect on a switch. Entries
-  that disagree - or disagree with `-secret` - are a startup error, not a
-  silent fallback to the wrong key. A single `secret` shared by every entry is
-  fine and is used as the client's secret. Setting it on some entries but not
-  others is also an error.
+- **`secret` is per server.** Each entry may carry its own; the key travels
+  with the dial, so switching server switches the key with it, along with
+  everything derived from it (the REALITY donor pool, the client identifier the
+  server looks you up by). Entries that disagree are normal, not an error.
+  `-secret` / `TIREDVPN_SECRET` is the default for entries that name none of
+  their own - the two no longer compete. A list where some entries carry a
+  secret, some do not, and no default is configured anywhere IS a startup
+  error: that config has no key for half its servers, and the likeliest cause
+  is a missed line. If every entry agrees on one `secret` and nothing else
+  named a default, that value becomes the client's, which is what lets the
+  config file be the only place a secret appears.
 - **`sni` is recorded but not applied yet**: the cover host is still
   process-wide (`-cover`). The client says so in the log rather than pretending.
 - **`policy` other than `priority`, and `health_check = "active"`, are not

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -266,12 +266,12 @@ func listStrategies(cfg *Config) error {
 	return nil
 }
 
-// resolveSecret returns the effective secret: from cfg, env, or insecure default.
+// resolveSecret returns the effective default secret: from cfg, env, or the
+// insecure placeholder. It is the key for every endpoint that does not carry one
+// of its own; endpoints that do are authenticated with theirs (see
+// reconcileSecrets and internal/strategy/secret.go).
 func resolveSecret(cfg *Config) string {
-	s := cfg.Secret
-	if s == "" {
-		s = os.Getenv("TIREDVPN_SECRET")
-	}
+	s := defaultSecret(cfg)
 	if s == "" {
 		log.Warn("No secret provided - using default (INSECURE!)")
 		s = "default-secret-change-me"

--- a/internal/client/endpoints.go
+++ b/internal/client/endpoints.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/tiredvpn/tiredvpn/internal/endpoint"
@@ -93,13 +94,26 @@ func ResolveEndpoints(cfg *Config) ([]endpoint.Endpoint, error) {
 	return eps, nil
 }
 
-// reconcileSecrets enforces the one-secret rule.
+// reconcileSecrets validates the secrets across the server list and settles what
+// the client's default secret is.
 //
-// A strategy bakes the secret in when it is constructed, so a per-endpoint
-// secret cannot take effect on a switch. Rather than accept the field and
-// quietly authenticate with the wrong key, a mismatch is an error. A single
-// secret shared by every entry is fine and is adopted as the client's secret
-// when no -secret was given, so the field is not decoration either.
+// Different secrets on different servers are legal: the secret in force is a
+// property of the endpoint being dialled and travels with the dial (see
+// internal/strategy/secret.go). -secret / TIREDVPN_SECRET is the default for
+// entries that name none of their own, which is why the two no longer conflict.
+//
+// What stays an error is a list where some entries carry a secret, some do not,
+// and there is no default for the ones that do not: that config has no answer
+// for half its servers, and the likeliest cause is a missed line rather than an
+// intent. With a default present the same shape is a deliberate "these two
+// servers are special", so it is accepted.
+//
+// The one write-back: when nothing else named a default, the first entry's
+// secret becomes it. That is what lets a config file be the only place a secret
+// appears, and it also keeps resolveSecret's "no secret - using the insecure
+// default" warning off a list where every entry does have one. No dial can reach
+// the adopted value, because a default is only consulted for an endpoint without
+// a secret and by then there are none.
 func reconcileSecrets(cfg *Config, specs []ServerSpec) error {
 	var withSecret, without []string
 	common := ""
@@ -112,28 +126,33 @@ func reconcileSecrets(cfg *Config, specs []ServerSpec) error {
 		withSecret = append(withSecret, name)
 		if common == "" {
 			common = s.Secret
-			continue
-		}
-		if s.Secret != common {
-			return fmt.Errorf("servers %s and %s configure different secrets: "+
-				"one secret for all servers in this version (the secret is fixed when a strategy is built)",
-				withSecret[0], name)
 		}
 	}
 	if common == "" {
 		return nil
 	}
-	if len(without) > 0 {
-		return fmt.Errorf("server %s sets a secret but %s does not: "+
-			"set it on every entry or on none (a per-server secret is not supported in this version)",
-			withSecret[0], without[0])
+
+	if defaultSecret(cfg) != "" {
+		return nil
 	}
-	if cfg.Secret != "" && cfg.Secret != common {
-		return fmt.Errorf("the configured server secret differs from -secret / TIREDVPN_SECRET: " +
-			"remove one of the two rather than guessing which server the other belongs to")
+	if len(without) > 0 {
+		return fmt.Errorf("server %s sets a secret but %s does not, and no default is configured: "+
+			"give every entry a secret, or set -secret / TIREDVPN_SECRET for the ones that have none",
+			withSecret[0], without[0])
 	}
 	cfg.Secret = common
 	return nil
+}
+
+// defaultSecret is the secret for endpoints that name none: the flag, then the
+// environment. Deliberately without resolveSecret's insecure placeholder - this
+// answers "did the operator configure a default", and the placeholder is what
+// happens when the answer is no.
+func defaultSecret(cfg *Config) string {
+	if cfg.Secret != "" {
+		return cfg.Secret
+	}
+	return os.Getenv("TIREDVPN_SECRET")
 }
 
 func specName(i int, name string) string {

--- a/internal/client/endpoints_test.go
+++ b/internal/client/endpoints_test.go
@@ -108,32 +108,62 @@ func TestResolveEndpoints_EntryWithoutAddress(t *testing.T) {
 	}
 }
 
-// TestResolveEndpoints_Secrets pins the rule from the plan: the secret is
-// baked into a strategy when it is constructed, so a per-server secret cannot
-// take effect on a switch. Disagreement is an error, never a silent choice.
+// TestResolveEndpoints_Secrets pins the rules a server list's secrets follow.
+//
+// Different secrets on different servers are legal now: the key travels with the
+// dial rather than being baked into a strategy. What is left to check is the
+// shape of the list - where the default comes from, and which shapes have no
+// answer for half their servers.
 func TestResolveEndpoints_Secrets(t *testing.T) {
-	t.Run("differing secrets are rejected", func(t *testing.T) {
+	t.Run("differing secrets are kept per endpoint", func(t *testing.T) {
+		t.Setenv("TIREDVPN_SECRET", "")
 		cfg := &Config{Servers: []ServerSpec{
 			{Name: "ams", Addr: "203.0.113.10:443", Secret: "one"},
 			{Name: "fra", Addr: "203.0.113.20:443", Secret: "two"},
 		}}
-		_, err := ResolveEndpoints(cfg)
-		if err == nil || !strings.Contains(err.Error(), "different secrets") {
-			t.Fatalf("err = %v, want a rejection naming the mismatch", err)
+		eps, err := ResolveEndpoints(cfg)
+		if err != nil {
+			t.Fatalf("ResolveEndpoints: %v", err)
+		}
+		if eps[0].Secret != "one" || eps[1].Secret != "two" {
+			t.Fatalf("secrets = %q/%q, want one/two", eps[0].Secret, eps[1].Secret)
 		}
 	})
 
-	t.Run("secret on some entries only is rejected", func(t *testing.T) {
+	t.Run("secret on some entries only, with no default, is rejected", func(t *testing.T) {
+		t.Setenv("TIREDVPN_SECRET", "")
 		cfg := &Config{Servers: []ServerSpec{
 			{Name: "ams", Addr: "203.0.113.10:443", Secret: "one"},
 			{Name: "fra", Addr: "203.0.113.20:443"},
 		}}
 		if _, err := ResolveEndpoints(cfg); err == nil {
-			t.Fatal("a half-configured secret must not fall back to the global one silently")
+			t.Fatal("a half-configured secret must not fall back to the insecure placeholder silently")
+		}
+	})
+
+	t.Run("secret on some entries only is fine with a default", func(t *testing.T) {
+		t.Setenv("TIREDVPN_SECRET", "")
+		cfg := &Config{
+			Secret: "from-flag",
+			Servers: []ServerSpec{
+				{Name: "ams", Addr: "203.0.113.10:443", Secret: "override"},
+				{Name: "fra", Addr: "203.0.113.20:443"},
+			},
+		}
+		eps, err := ResolveEndpoints(cfg)
+		if err != nil {
+			t.Fatalf("ResolveEndpoints: %v", err)
+		}
+		if eps[0].Secret != "override" || eps[1].Secret != "" {
+			t.Fatalf("secrets = %q/%q, want override and the default", eps[0].Secret, eps[1].Secret)
+		}
+		if cfg.Secret != "from-flag" {
+			t.Fatalf("Secret = %q, want the flag left alone as the default", cfg.Secret)
 		}
 	})
 
 	t.Run("one shared secret is adopted", func(t *testing.T) {
+		t.Setenv("TIREDVPN_SECRET", "")
 		cfg := &Config{Servers: []ServerSpec{
 			{Name: "ams", Addr: "203.0.113.10:443", Secret: "shared"},
 			{Name: "fra", Addr: "203.0.113.20:443", Secret: "shared"},
@@ -146,13 +176,38 @@ func TestResolveEndpoints_Secrets(t *testing.T) {
 		}
 	})
 
-	t.Run("config secret conflicting with -secret is rejected", func(t *testing.T) {
+	t.Run("-secret does not compete with a per-server secret", func(t *testing.T) {
+		t.Setenv("TIREDVPN_SECRET", "")
 		cfg := &Config{
 			Secret:  "from-flag",
 			Servers: []ServerSpec{{Name: "ams", Addr: "203.0.113.10:443", Secret: "from-file"}},
 		}
-		if _, err := ResolveEndpoints(cfg); err == nil {
-			t.Fatal("two different secrets must not be resolved by guessing")
+		eps, err := ResolveEndpoints(cfg)
+		if err != nil {
+			t.Fatalf("ResolveEndpoints: %v", err)
+		}
+		if eps[0].Secret != "from-file" {
+			t.Fatalf("endpoint secret = %q, want the per-server value to win its own dial", eps[0].Secret)
+		}
+		if cfg.Secret != "from-flag" {
+			t.Fatalf("Secret = %q, want the flag kept as the default", cfg.Secret)
+		}
+	})
+
+	t.Run("every entry with its own secret needs no flag", func(t *testing.T) {
+		t.Setenv("TIREDVPN_SECRET", "")
+		cfg := &Config{Servers: []ServerSpec{
+			{Name: "ams", Addr: "203.0.113.10:443", Secret: "one"},
+			{Name: "fra", Addr: "203.0.113.20:443", Secret: "two"},
+		}}
+		if _, err := ResolveEndpoints(cfg); err != nil {
+			t.Fatalf("ResolveEndpoints: %v", err)
+		}
+		// The adopted default is never dialled with - every endpoint has its own
+		// - but it must not be empty, or resolveSecret substitutes the insecure
+		// placeholder and warns about a secret the operator did configure.
+		if cfg.Secret == "" {
+			t.Fatal("no default adopted: resolveSecret would fall back to the insecure placeholder")
 		}
 	})
 }

--- a/internal/config/toml/client.go
+++ b/internal/config/toml/client.go
@@ -46,8 +46,9 @@ type ClientServer struct {
 
 	// Secret and SNI are per-endpoint overrides. Both are carried through to
 	// the endpoint description; see internal/client.ResolveEndpoints for what
-	// the runtime does with them today (a differing Secret is an error, not a
-	// silent fallback to the global one).
+	// the runtime does with them today. Secret is honoured: it is the key this
+	// endpoint is dialled with, and entries may disagree. SNI is still recorded
+	// and not applied.
 	Secret string `toml:"secret,omitempty"`
 	SNI    string `toml:"sni,omitempty"`
 }

--- a/internal/strategy/antiprobe.go
+++ b/internal/strategy/antiprobe.go
@@ -89,6 +89,7 @@ func (s *AntiProbeStrategy) Probe(ctx context.Context, target string) error {
 func (s *AntiProbeStrategy) Connect(ctx context.Context, target string) (net.Conn, error) {
 	// Get server address (IPv6/IPv4 with automatic fallback)
 	serverAddr := s.manager.GetServerAddr(ctx)
+	secret := dialSecret(ctx, s.knockSecret)
 	log.Debug("AntiProbe: Using server address: %s", serverAddr)
 
 	// Phase 1: Connect with TLS first (server requires TLS)
@@ -152,7 +153,7 @@ func (s *AntiProbeStrategy) Connect(ctx context.Context, target string) (net.Con
 	}
 
 	// Phase 3: Perform timing-based authentication over TLS
-	if err := s.timingKnock(tlsConn); err != nil {
+	if err := s.timingKnock(tlsConn, secret); err != nil {
 		tlsConn.Close()
 		return nil, err
 	}
@@ -167,9 +168,9 @@ func (s *AntiProbeStrategy) Connect(ctx context.Context, target string) (net.Con
 }
 
 // timingKnock performs timing-based knock sequence
-func (s *AntiProbeStrategy) timingKnock(conn net.Conn) error {
+func (s *AntiProbeStrategy) timingKnock(conn net.Conn, secret []byte) error {
 	// Generate timing sequence from secret
-	sequence := s.generateKnockSequence()
+	sequence := generateKnockSequence(secret)
 
 	// Send packets with specific timing
 	for i, delay := range sequence.Delays {
@@ -180,7 +181,7 @@ func (s *AntiProbeStrategy) timingKnock(conn net.Conn) error {
 		packet[0] = byte(i) // Sequence number
 
 		// Fill with deterministic data based on secret
-		s.fillPacketData(packet, i)
+		fillPacketData(packet, i, secret)
 
 		if _, err := conn.Write(packet); err != nil {
 			return err
@@ -203,8 +204,8 @@ func (s *AntiProbeStrategy) timingKnock(conn net.Conn) error {
 }
 
 // generateKnockSequence creates timing sequence from secret
-func (s *AntiProbeStrategy) generateKnockSequence() *KnockSequence {
-	h := hmac.New(sha256.New, s.knockSecret)
+func generateKnockSequence(secret []byte) *KnockSequence {
+	h := hmac.New(sha256.New, secret)
 	h.Write([]byte("knock-sequence"))
 	hash := h.Sum(nil)
 
@@ -224,8 +225,8 @@ func (s *AntiProbeStrategy) generateKnockSequence() *KnockSequence {
 }
 
 // fillPacketData fills packet with deterministic data
-func (s *AntiProbeStrategy) fillPacketData(packet []byte, seqNum int) {
-	h := hmac.New(sha256.New, s.knockSecret)
+func fillPacketData(packet []byte, seqNum int, secret []byte) {
+	h := hmac.New(sha256.New, secret)
 	h.Write([]byte{byte(seqNum)})
 	hash := h.Sum(nil)
 

--- a/internal/strategy/antiprobe_test.go
+++ b/internal/strategy/antiprobe_test.go
@@ -12,7 +12,7 @@ func TestKnockSequenceGeneration(t *testing.T) {
 	secret := []byte("test-secret-key")
 	strat := NewAntiProbeStrategy(NewManager(), secret)
 
-	seq := strat.generateKnockSequence()
+	seq := generateKnockSequence(strat.knockSecret)
 
 	// Should have 5 delays and 5 sizes
 	if len(seq.Delays) != 5 {
@@ -43,10 +43,10 @@ func TestKnockSequenceDeterministic(t *testing.T) {
 	secret := []byte("deterministic-secret")
 
 	strat1 := NewAntiProbeStrategy(NewManager(), secret)
-	seq1 := strat1.generateKnockSequence()
+	seq1 := generateKnockSequence(strat1.knockSecret)
 
 	strat2 := NewAntiProbeStrategy(NewManager(), secret)
-	seq2 := strat2.generateKnockSequence()
+	seq2 := generateKnockSequence(strat2.knockSecret)
 
 	// Should produce identical sequences
 	if len(seq1.Delays) != len(seq2.Delays) {
@@ -69,10 +69,10 @@ func TestKnockSequenceDifferentSecrets(t *testing.T) {
 	secret2 := []byte("secret-two")
 
 	strat1 := NewAntiProbeStrategy(NewManager(), secret1)
-	seq1 := strat1.generateKnockSequence()
+	seq1 := generateKnockSequence(strat1.knockSecret)
 
 	strat2 := NewAntiProbeStrategy(NewManager(), secret2)
-	seq2 := strat2.generateKnockSequence()
+	seq2 := generateKnockSequence(strat2.knockSecret)
 
 	// Should produce different sequences
 	identical := true
@@ -130,11 +130,11 @@ func TestPacketDataFilling(t *testing.T) {
 
 	// Generate packet data for sequence 0
 	packet1 := make([]byte, 50)
-	strat.fillPacketData(packet1, 0)
+	fillPacketData(packet1, 0, strat.knockSecret)
 
 	// Generate same packet again
 	packet2 := make([]byte, 50)
-	strat.fillPacketData(packet2, 0)
+	fillPacketData(packet2, 0, strat.knockSecret)
 
 	// Should be identical (deterministic)
 	for i := range packet1 {
@@ -146,7 +146,7 @@ func TestPacketDataFilling(t *testing.T) {
 
 	// Different sequence should produce different data
 	packet3 := make([]byte, 50)
-	strat.fillPacketData(packet3, 1)
+	fillPacketData(packet3, 1, strat.knockSecret)
 
 	identical := true
 	for i := range packet1 {
@@ -168,7 +168,7 @@ func TestKnockSequenceVariability(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		secret := []byte{byte(i), byte(i * 2), byte(i * 3)}
 		strat := NewAntiProbeStrategy(NewManager(), secret)
-		sequences[i] = strat.generateKnockSequence()
+		sequences[i] = generateKnockSequence(strat.knockSecret)
 	}
 
 	// Check that we have variability in delays
@@ -201,7 +201,7 @@ func TestKnockSequenceVariability(t *testing.T) {
 func TestKnockSequenceTiming(t *testing.T) {
 	secret := []byte("timing-test")
 	strat := NewAntiProbeStrategy(NewManager(), secret)
-	seq := strat.generateKnockSequence()
+	seq := generateKnockSequence(strat.knockSecret)
 
 	// Calculate total time for knock sequence
 	totalTime := time.Duration(0)
@@ -222,7 +222,7 @@ func TestKnockSequenceTiming(t *testing.T) {
 func TestKnockPacketSizes(t *testing.T) {
 	secret := []byte("size-test")
 	strat := NewAntiProbeStrategy(NewManager(), secret)
-	seq := strat.generateKnockSequence()
+	seq := generateKnockSequence(strat.knockSecret)
 
 	// Calculate total bytes sent
 	totalBytes := 0
@@ -254,7 +254,7 @@ func TestHMACBasedGeneration(t *testing.T) {
 
 	// Verify hash is used for generation
 	strat := NewAntiProbeStrategy(NewManager(), secret)
-	seq := strat.generateKnockSequence()
+	seq := generateKnockSequence(strat.knockSecret)
 
 	// First delay should be derived from first byte of hash
 	expectedDelay := time.Duration(50+int(expectedHash[0])%150) * time.Millisecond
@@ -303,7 +303,7 @@ func TestKnockSequenceHashDistribution(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		secret := []byte{byte(i), byte(i >> 8), byte(i >> 16)}
 		strat := NewAntiProbeStrategy(NewManager(), secret)
-		seq := strat.generateKnockSequence()
+		seq := generateKnockSequence(strat.knockSecret)
 
 		for _, delay := range seq.Delays {
 			ms := int(delay.Milliseconds())

--- a/internal/strategy/geneva_strategy.go
+++ b/internal/strategy/geneva_strategy.go
@@ -139,6 +139,7 @@ func (g *GenevaStrategy) Connect(ctx context.Context, target string) (net.Conn, 
 
 	// Step 1: Get server address (IPv6/IPv4 with automatic fallback)
 	serverAddr := g.manager.GetServerAddr(ctx)
+	secret := dialSecret(ctx, g.secret)
 	log.Debug("Geneva: Using server address: %s", serverAddr)
 
 	// Step 2: Establish TCP connection to server (context-aware, respects Android timeouts)
@@ -171,7 +172,7 @@ func (g *GenevaStrategy) Connect(ctx context.Context, target string) (net.Conn, 
 
 	// Step 5: Perform WebSocket upgrade (same format as WebSocket Salamander) with auth token
 	wsKey := generateWebSocketKey()
-	authToken := generateAuthToken(g.secret)
+	authToken := generateAuthToken(secret)
 	upgradeReq := fmt.Sprintf(
 		"GET %s HTTP/1.1\r\n"+
 			"Host: %s\r\n"+
@@ -226,7 +227,7 @@ func (g *GenevaStrategy) Connect(ctx context.Context, target string) (net.Conn, 
 	log.Info("Geneva: WebSocket upgrade successful")
 
 	// Step 6: Wrap with SalamanderConn (handles padding)
-	padder := padding.NewSalamanderPadder(g.secret, padding.Balanced)
+	padder := padding.NewSalamanderPadder(secret, padding.Balanced)
 	salamanderConn := NewSalamanderConn(tlsConn, padder, true) // true = client side
 
 	log.Info("Geneva (%s): Connection established with %s manipulation", g.country, genevaConn.GetManipulation())

--- a/internal/strategy/http_polling.go
+++ b/internal/strategy/http_polling.go
@@ -101,16 +101,17 @@ func (s *HTTPPollingStrategy) Probe(ctx context.Context, target string) error {
 func (s *HTTPPollingStrategy) Connect(ctx context.Context, target string) (net.Conn, error) {
 	// Get server address (IPv6/IPv6 with automatic fallback)
 	serverAddr := s.manager.GetServerAddr(ctx)
+	secret := dialSecret(ctx, s.secret)
 	log.Debug("HTTP Polling: Connecting to %s via %s", target, serverAddr)
 
 	// Generate session ID
-	sessionID := generateSessionID(s.secret)
+	sessionID := generateSessionID(secret)
 
 	// Create polling connection with parallel workers
 	pollConn := &HTTPPollingConn{
 		manager:         s.manager,
 		serverAddr:      serverAddr,
-		secret:          s.secret,
+		secret:          secret,
 		host:            s.host,
 		path:            s.path,
 		sessionID:       sessionID,

--- a/internal/strategy/icmp_tunnel.go
+++ b/internal/strategy/icmp_tunnel.go
@@ -232,7 +232,7 @@ func (s *ICMPTunnelStrategy) Connect(ctx context.Context, target string) (net.Co
 
 	// Derive per-direction keys so client-to-server and server-to-client packets
 	// use independent keystreams, preventing bidirectional nonce reuse.
-	masterKey := DeriveICMPKey(s.secret)
+	masterKey := DeriveICMPKey(dialSecret(ctx, s.secret))
 	sendCipher, err := chacha20poly1305.NewX(DeriveICMPDirectionalKey(masterKey, sessionID, "c2s"))
 	if err != nil {
 		icmpConn.Close()

--- a/internal/strategy/imap_camouflage.go
+++ b/internal/strategy/imap_camouflage.go
@@ -100,6 +100,7 @@ func (s *IMAPCamouflageStrategy) Probe(ctx context.Context, target string) error
 // Connect dials the server over plain TCP and performs the fake IMAP handshake.
 func (s *IMAPCamouflageStrategy) Connect(ctx context.Context, target string) (net.Conn, error) {
 	serverAddr := s.manager.GetServerAddr(ctx)
+	secret := dialSecret(ctx, s.secret)
 	log.Debug("IMAP Camouflage: connecting to %s (raw TCP, fake IMAP handshake)", serverAddr)
 
 	dialer := &net.Dialer{}
@@ -108,7 +109,7 @@ func (s *IMAPCamouflageStrategy) Connect(ctx context.Context, target string) (ne
 		return nil, err
 	}
 
-	br, err := performIMAPClientHandshake(conn, s.secret)
+	br, err := performIMAPClientHandshake(conn, secret)
 	if err != nil {
 		conn.Close()
 		return nil, fmt.Errorf("imap camouflage handshake: %w", err)

--- a/internal/strategy/morph.go
+++ b/internal/strategy/morph.go
@@ -309,6 +309,8 @@ func (s *TrafficMorphStrategy) Connect(ctx context.Context, target string) (net.
 	var baseConn net.Conn
 	var err error
 
+	secret := dialSecret(ctx, s.secret)
+
 	if s.baseStrat != nil {
 		baseConn, err = s.baseStrat.Connect(ctx, target)
 	} else {
@@ -358,7 +360,7 @@ func (s *TrafficMorphStrategy) Connect(ctx context.Context, target string) (net.
 		// over a socket whose TLS receive buffer is empty and whose record
 		// sequence counter matches the next byte on the wire.
 		profileName := []byte(s.profile.Name)
-		authToken := generateAuthToken(s.secret)
+		authToken := generateAuthToken(secret)
 		// Layout: MRPH(4) + nameLen(1) + name(N) + auth(32) + shaperID(1).
 		// The trailing shaperID byte is the wire-protocol v2 addition; servers
 		// that predate it ignore the extra byte, and a server that expects it
@@ -406,7 +408,7 @@ func (s *TrafficMorphStrategy) Connect(ctx context.Context, target string) (net.
 	// For the baseStrat path the handshake goes through the underlying strategy
 	// transport via NewMorphedConnWithShaper as before.
 	if s.baseStrat != nil {
-		return newMorphedConnWithShaperID(baseConn, s.profile, s.secret, s.customShaper, s.shaperID), nil
+		return newMorphedConnWithShaperID(baseConn, s.profile, secret, s.customShaper, s.shaperID), nil
 	}
 	sh := s.customShaper
 	if sh == nil {

--- a/internal/strategy/per_endpoint_secret_test.go
+++ b/internal/strategy/per_endpoint_secret_test.go
@@ -1,0 +1,383 @@
+package strategy
+
+import (
+	"context"
+	"crypto/ecdh"
+	"crypto/rand"
+	"errors"
+	"io"
+	"net"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/tiredvpn/tiredvpn/internal/endpoint"
+	"github.com/tiredvpn/tiredvpn/internal/evasion"
+	customtls "github.com/tiredvpn/tiredvpn/internal/tls"
+)
+
+// deadAddr returns an address on loopback that nothing is listening on: bind,
+// note the port, close. Connecting to it gets a refusal straight away, which is
+// what makes "the first endpoint is down" cheap and deterministic here.
+func deadAddr(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+	if err := ln.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	return addr
+}
+
+// serveB1 puts srv behind a listener and returns its address. Every accepted
+// connection is served; the goroutine ends when the listener closes.
+func serveB1(t *testing.T, srv *b1TestServer) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func() { _ = srv.serve(t, conn) }()
+		}
+	}()
+	t.Cleanup(func() { _ = ln.Close(); <-done })
+	return ln.Addr().String()
+}
+
+// v4Only is the family policy for the loopback pools below: these tests dial
+// 127.0.0.1 and nothing else, and a v6 leg would only add a refused connection
+// per candidate.
+func v4Only() *endpoint.FamilyPolicy {
+	p := endpoint.V4Only
+	return &p
+}
+
+// TestPerEndpointSecretAuthenticatesSecondServer is the acceptance test for the
+// whole change, and it is deliberately end to end rather than a check on a
+// helper.
+//
+// Two endpoints, two DIFFERENT secrets. The first is dead, the second is a real
+// B1 server that rejects anyone whose session_id does not carry ShortIDFor(its
+// own secret) and whose binding proof is not computed under it. So the tunnel
+// only comes up if the client noticed the switch and authenticated with the
+// second endpoint's key - the previous build could not, and refused to start at
+// all rather than try.
+func TestPerEndpointSecretAuthenticatesSecondServer(t *testing.T) {
+	// One static key for both endpoints: the server's X25519 identity is a
+	// separate axis from the client secret, and this test is about the secret.
+	staticPriv, err := ecdh.X25519().GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	live := &b1TestServer{
+		staticPriv: staticPriv,
+		secret:     []byte("secret-of-the-second-server"),
+		srvTime:    time.Now().Truncate(time.Second),
+	}
+	liveAddr := serveB1(t, live)
+	firstAddr := deadAddr(t)
+
+	m := NewManager()
+	m.setDefaultSecret([]byte("process-wide-default-nobody-accepts"))
+	if err := m.SetEndpointsTuned([]endpoint.Endpoint{
+		{Name: "first", V4: firstAddr, Order: 0, Secret: "secret-of-the-first-server"},
+		{Name: "second", V4: liveAddr, Order: 1, Secret: string(live.secret)},
+	}, endpoint.Tuning{Family: v4Only()}); err != nil {
+		t.Fatalf("SetEndpointsTuned: %v", err)
+	}
+
+	// The strategy is constructed with the FIRST endpoint's secret, which is how
+	// it is built in production: one construction, whatever the pool does later.
+	r := NewREALITYStrategy(m, []byte("secret-of-the-first-server"))
+	r.SetB1(staticPriv.PublicKey().Bytes())
+	if !r.b1Enabled {
+		t.Fatal("B1 did not enable")
+	}
+	m.Register(r)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Second)
+	defer cancel()
+
+	conn, _, err := m.Connect(ctx, firstAddr)
+	if err != nil {
+		t.Fatalf("Connect across the pool: %v", err)
+	}
+	defer conn.Close()
+
+	// The server echoes, so a round trip proves the tunnel is up rather than
+	// merely that a TCP connection was made.
+	want := []byte("per-endpoint secret round trip")
+	if _, err := conn.Write(want); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got := make([]byte, len(want))
+	if err := conn.SetReadDeadline(time.Now().Add(10 * time.Second)); err != nil {
+		t.Fatalf("SetReadDeadline: %v", err)
+	}
+	if _, err := io.ReadFull(conn, got); err != nil {
+		t.Fatalf("read echo: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("echo = %q, want %q", got, want)
+	}
+
+	// And the switch actually happened, rather than the first endpoint quietly
+	// answering.
+	if addr := m.GetServerAddr(ctx); addr != liveAddr {
+		t.Fatalf("pinned address = %s, want the second endpoint %s", addr, liveAddr)
+	}
+}
+
+// TestPerEndpointSecretRejectedWhenWrong is the positive control for the test
+// above: the same setup, but the second endpoint is configured with a secret its
+// server does not know. The dial must fail.
+//
+// Without this, "the tunnel came up" would be consistent with a server that
+// accepts anything, and the test above would prove nothing about which key was
+// used.
+func TestPerEndpointSecretRejectedWhenWrong(t *testing.T) {
+	staticPriv, err := ecdh.X25519().GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	live := &b1TestServer{
+		staticPriv: staticPriv,
+		secret:     []byte("secret-of-the-second-server"),
+		srvTime:    time.Now().Truncate(time.Second),
+	}
+	liveAddr := serveB1(t, live)
+
+	m := NewManager()
+	m.setDefaultSecret([]byte("process-wide-default-nobody-accepts"))
+	if err := m.SetEndpointsTuned([]endpoint.Endpoint{
+		{Name: "second", V4: liveAddr, Order: 0, Secret: "not-the-servers-secret"},
+	}, endpoint.Tuning{Family: v4Only()}); err != nil {
+		t.Fatalf("SetEndpointsTuned: %v", err)
+	}
+
+	r := NewREALITYStrategy(m, live.secret) // right key, wrong place to put it
+	r.SetB1(staticPriv.PublicKey().Bytes())
+	m.Register(r)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Second)
+	defer cancel()
+
+	conn, _, err := m.Connect(ctx, liveAddr)
+	if err == nil {
+		conn.Close()
+		t.Fatal("connected with the wrong per-endpoint secret: the endpoint's secret is not reaching the handshake")
+	}
+}
+
+// TestDialSecretFallsBackToConstruction pins the single-server case: nothing on
+// the context, so every strategy sees exactly the secret it was built with. This
+// is the shape every production unit runs today (-secret, one -server), and it
+// must not have moved.
+func TestDialSecretFallsBackToConstruction(t *testing.T) {
+	built := []byte("built-in")
+	if got := dialSecret(t.Context(), built); string(got) != "built-in" {
+		t.Fatalf("dialSecret = %q, want the construction secret", got)
+	}
+	ctx := withDialSecret(t.Context(), []byte("from-the-endpoint"))
+	if got := dialSecret(ctx, built); string(got) != "from-the-endpoint" {
+		t.Fatalf("dialSecret = %q, want the endpoint secret", got)
+	}
+	// An empty endpoint secret must not blank out the fallback: that is how an
+	// endpoint with no secret of its own inherits the process-wide default. Two
+	// separate guards stand between an empty value and a strategy - one refusing
+	// to record it, one refusing to return it - and each is checked on its own,
+	// because either alone would make this pass.
+	base := t.Context()
+	if withDialSecret(base, nil) != base {
+		t.Fatal("withDialSecret recorded an empty secret, which would blank out a value an outer caller set")
+	}
+	empty := context.WithValue(base, dialSecretKey{}, []byte(nil))
+	if got := dialSecret(empty, built); string(got) != "built-in" {
+		t.Fatalf("dialSecret = %q, want an empty recorded secret to fall through to the fallback", got)
+	}
+}
+
+// TestManagerSecretFollowsPinnedEndpoint checks the other half of the wiring:
+// which secret the manager hands out when the caller did not name one. It must
+// be the pinned endpoint's, and it must move when the pin moves.
+func TestManagerSecretFollowsPinnedEndpoint(t *testing.T) {
+	m := NewManager()
+	m.setDefaultSecret([]byte("default"))
+	eps := []endpoint.Endpoint{
+		{Name: "a", V4: "203.0.113.10:443", Order: 0, Secret: "secret-a"},
+		{Name: "b", V4: "203.0.113.20:443", Order: 1, Secret: "secret-b"},
+		{Name: "c", V4: "203.0.113.30:443", Order: 2}, // no secret of its own
+	}
+	if err := m.SetEndpointsTuned(eps, endpoint.Tuning{Family: v4Only()}); err != nil {
+		t.Fatalf("SetEndpointsTuned: %v", err)
+	}
+	sel := m.selector()
+
+	if got := m.CurrentSecret(); string(got) != "secret-a" {
+		t.Fatalf("CurrentSecret = %q, want secret-a", got)
+	}
+	for i, want := range []string{"secret-a", "secret-b", "default"} {
+		cand := sel.Candidates()[i]
+		sel.Pin(cand)
+		if got := m.CurrentSecret(); string(got) != want {
+			t.Fatalf("after pinning %s: CurrentSecret = %q, want %q", cand, got, want)
+		}
+		if got := m.secretForCandidate(cand); string(got) != want {
+			t.Fatalf("secretForCandidate(%s) = %q, want %q", cand, got, want)
+		}
+	}
+
+	// ensureDialSecret must not overwrite a secret the caller already named -
+	// dialEndpoints names one per candidate, and that is the authoritative one.
+	pinned := m.ensureDialSecret(t.Context())
+	if got := dialSecret(pinned, nil); string(got) != "default" {
+		t.Fatalf("ensureDialSecret on a bare context gave %q, want the pinned endpoint's", got)
+	}
+	named := m.ensureDialSecret(withDialSecret(t.Context(), []byte("named-by-caller")))
+	if got := dialSecret(named, nil); string(got) != "named-by-caller" {
+		t.Fatalf("ensureDialSecret overwrote the caller's secret with %q", got)
+	}
+}
+
+// TestDonorPoolFollowsEndpointSecret covers the derived value that is easiest to
+// get wrong, because it is computed once at construction and then reused.
+//
+// The REALITY donor pool is HKDF'd from the secret (derivePool): each user hides
+// behind their own ordering of cover domains. A client that switched endpoint
+// but kept the first endpoint's pool would present one user's donor sequence
+// while authenticating as another - exactly the linkage derivePool exists to
+// prevent.
+func TestDonorPoolFollowsEndpointSecret(t *testing.T) {
+	developer := make([]string, 0, 8)
+	for _, e := range evasion.WhitelistedSNIs {
+		if e.Category == "developer" {
+			developer = append(developer, e.SNI)
+		}
+	}
+	if len(developer) < 2 {
+		t.Skipf("donor pool has %d entries, nothing to order", len(developer))
+	}
+
+	r := NewREALITYStrategy(nil, []byte("secret-a"))
+
+	poolA, rotA := r.donorsFor([]byte("secret-a"))
+	if !slices.Equal(poolA, derivePool(developer, []byte("secret-a"), len(developer))) {
+		t.Fatalf("pool for the construction secret = %v, want the derived one", poolA)
+	}
+	if rotA != r.sniRotator {
+		t.Fatal("construction secret got a fresh rotator instead of the strategy's own")
+	}
+
+	poolB, rotB := r.donorsFor([]byte("secret-b"))
+	if !slices.Equal(poolB, derivePool(developer, []byte("secret-b"), len(developer))) {
+		t.Fatalf("pool for the second secret = %v, want the pool derived from THAT secret", poolB)
+	}
+	if slices.Equal(poolA, poolB) {
+		t.Fatal("both secrets produced the same donor ordering: the pool is not following the secret")
+	}
+	if rotB == rotA {
+		t.Fatal("the second secret reuses the first one's rotator, so it walks the first one's pool")
+	}
+
+	// Cached, not re-derived: a second ask must hand back the same rotator, or
+	// the cooldown that rotator carries restarts on every dial.
+	if _, again := r.donorsFor([]byte("secret-b")); again != rotB {
+		t.Fatal("donorsFor re-derived the pool instead of caching it")
+	}
+
+	// And the destination actually chosen comes from the second pool.
+	dest, err := r.selectDestination([]byte("secret-b"))
+	if err != nil {
+		t.Fatalf("selectDestination: %v", err)
+	}
+	host, _, err := net.SplitHostPort(dest)
+	if err != nil {
+		host = dest
+	}
+	if !slices.Contains(poolB, host) {
+		t.Fatalf("destination %q is not in the second secret's pool %v", host, poolB)
+	}
+}
+
+// TestShortIDFollowsDialSecret pins the client identifier the server looks up.
+// ShortIDFor is what the B1 session_id carries; deriving it from a stale secret
+// is what produces "client not found" on a server that is working perfectly.
+func TestShortIDFollowsDialSecret(t *testing.T) {
+	a := customtls.ShortIDFor([]byte("secret-a"))
+	b := customtls.ShortIDFor([]byte("secret-b"))
+	if a == b {
+		t.Fatal("two secrets share a short id; this test cannot tell them apart")
+	}
+
+	staticPriv, err := ecdh.X25519().GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	srv := &b1TestServer{
+		staticPriv: staticPriv,
+		secret:     []byte("secret-b"),
+		srvTime:    time.Now().Truncate(time.Second),
+	}
+
+	// Built with secret-a, dialled under secret-b. The stand-in server checks
+	// ShortIDFor(secret-b) on the session_id before it will even hand back a
+	// certificate, so reaching the echo means the identifier was recomputed.
+	r := NewREALITYStrategy(nil, []byte("secret-a"))
+	r.SetB1(staticPriv.PublicKey().Bytes())
+
+	addr := serveB1(t, srv)
+	tcpConn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	deadline := time.Now().Add(10 * time.Second)
+	if err := tcpConn.SetDeadline(deadline); err != nil {
+		t.Fatalf("SetDeadline: %v", err)
+	}
+	conn, err := r.connectB1(t.Context(), tcpConn, "github.com:443", deadline, []byte("secret-b"))
+	if err != nil {
+		tcpConn.Close()
+		t.Fatalf("connectB1 under the dial secret: %v", err)
+	}
+	defer conn.Close()
+
+	if _, err := conn.Write([]byte("ping")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got := make([]byte, 4)
+	if _, err := io.ReadFull(conn, got); err != nil {
+		t.Fatalf("read echo: %v", err)
+	}
+
+	// Positive control: the construction secret is now the wrong one, and the
+	// same call with it must be refused.
+	tcpConn2, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	if err := tcpConn2.SetDeadline(time.Now().Add(10 * time.Second)); err != nil {
+		t.Fatalf("SetDeadline: %v", err)
+	}
+	bad, err := r.connectB1(t.Context(), tcpConn2, "github.com:443", time.Now().Add(10*time.Second), r.secret)
+	tcpConn2.Close()
+	if err == nil {
+		bad.Close()
+		t.Fatal("the stale secret was accepted; the server is not checking what this test assumes")
+	}
+	if errors.Is(err, errB1NoAuthKey) {
+		t.Fatalf("failed for the wrong reason: %v", err)
+	}
+}

--- a/internal/strategy/per_endpoint_secret_test.go
+++ b/internal/strategy/per_endpoint_secret_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net"
 	"slices"
+	"sync"
 	"testing"
 	"time"
 
@@ -379,5 +380,152 @@ func TestShortIDFollowsDialSecret(t *testing.T) {
 	}
 	if errors.Is(err, errB1NoAuthKey) {
 		t.Fatalf("failed for the wrong reason: %v", err)
+	}
+}
+
+// developerDonors is the global cover pool derivePool draws from.
+func developerDonors() []string {
+	out := make([]string, 0, 8)
+	for _, e := range evasion.WhitelistedSNIs {
+		if e.Category == "developer" {
+			out = append(out, e.SNI)
+		}
+	}
+	return out
+}
+
+// sniRecorder is a listener that reads the ClientHello off every connection it
+// accepts and remembers the cover domain it named, in arrival order. Each
+// connection is closed straight after, so the client's dial fails - which is
+// fine, the ClientHello is the whole subject here.
+type sniRecorder struct {
+	addr string
+	mu   sync.Mutex
+	seen []string
+}
+
+func newSNIRecorder(t *testing.T) *sniRecorder {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	rec := &sniRecorder{addr: ln.Addr().String()}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			_ = conn.SetDeadline(time.Now().Add(10 * time.Second))
+			hello, _, err := peekClientHello(conn)
+			conn.Close()
+			switch {
+			case err != nil:
+				rec.record("read failed: " + err.Error())
+			default:
+				start, length, ok := walkSNIHostname(hello)
+				if !ok {
+					rec.record("no SNI in the ClientHello")
+					continue
+				}
+				rec.record(string(hello[start : start+length]))
+			}
+		}
+	}()
+	t.Cleanup(func() { _ = ln.Close(); <-done })
+	return rec
+}
+
+func (r *sniRecorder) record(s string) {
+	r.mu.Lock()
+	r.seen = append(r.seen, s)
+	r.mu.Unlock()
+}
+
+func (r *sniRecorder) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.seen)
+}
+
+func (r *sniRecorder) snapshot() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return slices.Clone(r.seen)
+}
+
+// TestCoverDomainsOnTheWireFollowTheDialSecret is the call-site test for the
+// donor pool, and it deliberately reads the domains off a socket rather than
+// asking the strategy which pool it would use.
+//
+// The distinction is not academic. A test that calls donorsFor directly stays
+// green when the CALLER hands it the wrong secret - and the caller is exactly
+// where this can go wrong, twice over: connect chooses the destination, and
+// selectDestination resolves the pool. Either one reverting to the strategy's
+// construction-time secret would put one user's donor sequence on the wire while
+// authenticating as another, which is the linkage derivePool exists to break.
+//
+// The cooldown rotator walks its pool in order, so the sequence of cover domains
+// across successive dials IS the derived pool. That makes the assertion exact
+// rather than statistical.
+func TestCoverDomainsOnTheWireFollowTheDialSecret(t *testing.T) {
+	const (
+		builtIn = "the-secret-the-strategy-was-built-with"
+		dialing = "the-secret-of-the-endpoint-being-dialled"
+	)
+	donors := developerDonors()
+	if len(donors) < 2 {
+		t.Skipf("cover pool has %d entries, nothing to order", len(donors))
+	}
+	wantBuiltIn := derivePool(donors, []byte(builtIn), len(donors))
+	wantDialing := derivePool(donors, []byte(dialing), len(donors))
+	if slices.Equal(wantBuiltIn, wantDialing) {
+		t.Fatal("the two secrets derive the same ordering; this test could not tell them apart")
+	}
+
+	rec := newSNIRecorder(t)
+
+	m := NewManager()
+	m.setDefaultSecret([]byte(builtIn))
+	if err := m.SetEndpointsTuned([]endpoint.Endpoint{
+		{Name: "peer", V4: rec.addr, Order: 0, Secret: dialing},
+	}, endpoint.Tuning{Family: v4Only()}); err != nil {
+		t.Fatalf("SetEndpointsTuned: %v", err)
+	}
+
+	r := NewREALITYStrategy(m, []byte(builtIn))
+	// The real gate spaces handshakes to one donor by a quarter of a second;
+	// these dials go to loopback and there is nothing to space out.
+	r.gate = newHandshakeGateWith(2, 0, 0)
+	m.Register(r)
+
+	// One Connect makes more than one dial (the manager retries), so this loops
+	// on the count of ClientHellos seen rather than on a dial count.
+	for attempt := 0; rec.count() < len(wantDialing) && attempt < 4*len(wantDialing); attempt++ {
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+		conn, _, err := m.Connect(ctx, rec.addr)
+		cancel()
+		if err == nil {
+			conn.Close()
+			t.Fatal("the recording listener answered a handshake it cannot complete")
+		}
+	}
+
+	got := rec.snapshot()
+	if len(got) < len(wantDialing) {
+		t.Fatalf("only %d ClientHellos reached the listener, want %d", len(got), len(wantDialing))
+	}
+	got = got[:len(wantDialing)]
+	if !slices.Equal(got, wantDialing) {
+		if slices.Equal(got, wantBuiltIn) {
+			t.Fatalf("the cover domains on the wire are the CONSTRUCTION secret's pool (%v): "+
+				"the dial secret is not reaching the donor selection", got)
+		}
+		t.Fatalf("cover domains = %v, want the dial secret's pool %v", got, wantDialing)
 	}
 }

--- a/internal/strategy/quic.go
+++ b/internal/strategy/quic.go
@@ -167,6 +167,7 @@ func (s *QUICStrategy) buildProbePacket() []byte {
 func (s *QUICStrategy) Connect(ctx context.Context, target string) (net.Conn, error) {
 	// Get server address (IPv6/IPv4 with automatic fallback)
 	addr := s.manager.GetServerAddr(ctx)
+	secret := dialSecret(ctx, s.secret)
 
 	// Use Salamander port if enabled
 	if s.useSalamander {
@@ -234,7 +235,7 @@ func (s *QUICStrategy) Connect(ctx context.Context, target string) (net.Conn, er
 		}
 
 		// Wrap with Salamander
-		padder := padding.NewSalamanderPadder(s.secret, padding.Balanced)
+		padder := padding.NewSalamanderPadder(secret, padding.Balanced)
 		salamanderConn := padding.NewSalamanderPacketConn(udpConn, padder)
 
 		// Parse server address (use generic "udp" to support both IPv4/IPv6)
@@ -351,7 +352,7 @@ func (s *QUICStrategy) Connect(ctx context.Context, target string) (net.Conn, er
 	quicConn := &QUICConn{
 		Conn:   conn,
 		stream: stream,
-		secret: s.secret,
+		secret: secret,
 	}
 
 	if err := quicConn.Handshake(); err != nil {

--- a/internal/strategy/reality.go
+++ b/internal/strategy/reality.go
@@ -27,7 +27,11 @@ import (
 // REALITYStrategy implements the REALITY protocol (Xray-like)
 // Server impersonates legitimate websites (yandex.ru, microsoft.com) without their private keys
 type REALITYStrategy struct {
-	manager    *Manager // IPv6/IPv4 transport layer support
+	manager *Manager // IPv6/IPv4 transport layer support
+
+	// secret is the fallback key: what the strategy was constructed with, used
+	// when the dial's context names none (single-server clients, tests). The key
+	// actually in force comes from dialSecret(ctx, r.secret) - see secret.go.
 	secret     []byte
 	sniRotator *evasion.SNIRotator
 
@@ -35,6 +39,15 @@ type REALITYStrategy struct {
 	destPool    []string // the derived donor pool, in rotator order
 	recentDests map[string]time.Time
 	destMu      sync.RWMutex
+
+	// donors caches the donor pool derived for a secret other than r.secret,
+	// keyed by that secret. The pool is a function of the key (see derivePool),
+	// so a client walking endpoints with different keys must not carry one
+	// endpoint's donor set onto another - that set is exactly the thing
+	// derivePool exists to keep per-user. Deriving costs an HKDF plus a sort, so
+	// it is done once per secret rather than once per dial.
+	donors   map[string]*donorSet
+	donorsMu sync.Mutex
 
 	// requireDataV2 refuses to fall back to the v1 data layer when the server
 	// does not confirm v2. Off by default because during the rollout (exits →
@@ -126,9 +139,52 @@ func NewREALITYStrategy(manager *Manager, secret []byte) *REALITYStrategy {
 		sniRotator:  sniRotator,
 		destPool:    subPool,
 		recentDests: make(map[string]time.Time),
+		donors:      make(map[string]*donorSet),
 		fingerprint: customtls.DefaultFingerprintName,
 		gate:        newHandshakeGate(),
 	}
+}
+
+// donorSet is the cover-domain pool derived from one secret, together with the
+// rotator that walks it. One per secret: the rotator carries the position in the
+// cycle, and sharing that across two different pools would defeat the cooldown.
+type donorSet struct {
+	pool    []string
+	rotator *evasion.SNIRotator
+}
+
+// donorsFor returns the donor pool and rotator belonging to secret.
+//
+// The set built at construction answers for the constructor's own secret and
+// for a dial that named none, which is every single-server client. Any other
+// secret gets its own set, derived on first use and kept.
+func (r *REALITYStrategy) donorsFor(secret []byte) ([]string, *evasion.SNIRotator) {
+	if len(secret) == 0 || string(secret) == string(r.secret) {
+		return r.destPool, r.sniRotator
+	}
+
+	r.donorsMu.Lock()
+	defer r.donorsMu.Unlock()
+	if d, ok := r.donors[string(secret)]; ok {
+		return d.pool, d.rotator
+	}
+
+	developerPool := make([]string, 0, 8)
+	for _, entry := range evasion.WhitelistedSNIs {
+		if entry.Category == "developer" {
+			developerPool = append(developerPool, entry.SNI)
+		}
+	}
+	pool := derivePool(developerPool, secret, len(developerPool))
+	if len(pool) == 0 {
+		pool = getRussianSNIsStatic()
+	}
+	d := &donorSet{pool: pool, rotator: evasion.NewSNIRotatorWithPool(pool, evasion.StrategyCooldown)}
+	if r.donors == nil {
+		r.donors = make(map[string]*donorSet)
+	}
+	r.donors[string(secret)] = d
+	return d.pool, d.rotator
 }
 
 // SetB1 enables the B1 transport with the server's static X25519 public key.
@@ -321,7 +377,14 @@ func (r *REALITYStrategy) connect(ctx context.Context, target string, wrapFirstF
 	serverAddr := r.manager.GetServerAddr(ctx)
 	log.Debug("REALITY: Connecting to %s via %s", target, serverAddr)
 
-	dest, err := r.selectDestination()
+	// Resolved once, here, and passed down by hand. Everything below that touches
+	// the key - the donor pool, the ClientHello extension, the ServerHello check,
+	// the data layer, the B1 session_id - has to agree on it, and re-reading the
+	// context in each of them would let a mid-handshake endpoint switch split the
+	// handshake across two keys.
+	secret := dialSecret(ctx, r.secret)
+
+	dest, err := r.selectDestination(secret)
 	if err != nil {
 		return nil, fmt.Errorf("reality: destination selection failed: %w", err)
 	}
@@ -426,7 +489,7 @@ func (r *REALITYStrategy) connect(ctx context.Context, target string, wrapFirstF
 	// the first flight, and the first flight is now a genuine ClientHello whose
 	// bytes are authenticated by session_id.
 	if r.b1Enabled && wrapFirstFlight == nil {
-		conn, err := r.connectB1(ctx, tcpConn, dest, deadline)
+		conn, err := r.connectB1(ctx, tcpConn, dest, deadline, secret)
 		if err != nil {
 			tcpConn.Close()
 			return nil, err
@@ -435,7 +498,7 @@ func (r *REALITYStrategy) connect(ctx context.Context, target string, wrapFirstF
 		return conn, nil
 	}
 
-	clientHello, err := r.buildClientHello(dest, clientPrivKey, clientSalt)
+	clientHello, err := r.buildClientHello(dest, clientPrivKey, clientSalt, secret)
 	if err != nil {
 		tcpConn.Close()
 		return nil, fmt.Errorf("reality: clienthello build failed: %w", err)
@@ -512,7 +575,7 @@ func (r *REALITYStrategy) connect(ctx context.Context, target string, wrapFirstF
 		return nil, errHelloRetryRequest
 	}
 
-	serverExt, err := r.validateServerHello(serverHello, clientPubKey)
+	serverExt, err := r.validateServerHello(serverHello, clientPubKey, secret)
 	if err != nil {
 		tcpConn.Close()
 		return nil, fmt.Errorf("reality: validation failed: %w", err)
@@ -527,7 +590,7 @@ func (r *REALITYStrategy) connect(ctx context.Context, target string, wrapFirstF
 	// Wrap TCP in an encrypted TLS-record framing layer so TSPU sees a normal
 	// TLS Application Data stream instead of raw smux bytes. Without this, TSPU
 	// throttles the connection after ~600 bytes.
-	dataConn, err := r.wrapDataLayer(tcpConn, serverExt, clientPrivKey, clientPubKey, clientSalt)
+	dataConn, err := r.wrapDataLayer(tcpConn, serverExt, clientPrivKey, clientPubKey, clientSalt, secret)
 	if err != nil {
 		tcpConn.Close()
 		return nil, fmt.Errorf("reality: data conn init: %w", err)
@@ -560,7 +623,11 @@ func (r *REALITYStrategy) connect(ctx context.Context, target string, wrapFirstF
 }
 
 // selectDestination chooses a legitimate destination from the SNI whitelist
-func (r *REALITYStrategy) selectDestination() (string, error) {
+// derived for secret. Two endpoints with different secrets therefore hide behind
+// different donor domains, which is the point of derivePool.
+func (r *REALITYStrategy) selectDestination(secret []byte) (string, error) {
+	pool, rotator := r.donorsFor(secret)
+
 	r.destMu.Lock()
 	defer r.destMu.Unlock()
 
@@ -578,7 +645,7 @@ func (r *REALITYStrategy) selectDestination() (string, error) {
 	// Try up to 10 times to find a non-recent destination
 	for attempt := 0; attempt < 10; attempt++ {
 		// Use SNI rotator over the derived subpool
-		sni := r.sniRotator.Next()
+		sni := rotator.Next()
 
 		// Check cooldown (30 seconds)
 		if lastUse, used := r.recentDests[sni]; used {
@@ -605,15 +672,14 @@ func (r *REALITYStrategy) selectDestination() (string, error) {
 	// a four-domain donor pool and a fresh handshake per CONNECT arrives fast —
 	// every dial past the first few piled onto yandex.ru. That is precisely the
 	// burst pattern the per-SNI freeze looks for, manufactured by us.
-	sni := r.leastRecentlyUsedDestLocked()
+	sni := r.leastRecentlyUsedDestLocked(pool)
 	r.recentDests[sni] = time.Now()
 	return net.JoinHostPort(sni, "443"), nil
 }
 
 // leastRecentlyUsedDestLocked returns the donor SNI whose last use is furthest
 // in the past. Callers must hold destMu.
-func (r *REALITYStrategy) leastRecentlyUsedDestLocked() string {
-	pool := r.destPool
+func (r *REALITYStrategy) leastRecentlyUsedDestLocked(pool []string) string {
 	if len(pool) == 0 {
 		pool = getRussianSNIsStatic()
 	}
@@ -743,7 +809,7 @@ func (r *REALITYStrategy) getIranianSNIs() []string {
 //
 // clientPrivKey and clientSalt are this connection's ephemeral material; both
 // end up inside the 256-byte padding block, whose size on the wire is unchanged.
-func (r *REALITYStrategy) buildClientHello(dest string, clientPrivKey, clientSalt [32]byte) ([]byte, error) {
+func (r *REALITYStrategy) buildClientHello(dest string, clientPrivKey, clientSalt [32]byte, secret []byte) ([]byte, error) {
 	log.Info("REALITY-BUILD: Starting buildClientHello for %s", dest)
 
 	// Extract hostname from dest
@@ -772,7 +838,7 @@ func (r *REALITYStrategy) buildClientHello(dest string, clientPrivKey, clientSal
 		fp.Name, len(clientHello), int(clientHello[3])<<8|int(clientHello[4]))
 
 	// Create REALITY extension (with the v2 data-layer signal appended)
-	realityExt, err := customtls.NewClientREALITYExtensionDataV2(r.secret, clientPrivKey, clientSalt)
+	realityExt, err := customtls.NewClientREALITYExtensionDataV2(secret, clientPrivKey, clientSalt)
 	if err != nil {
 		log.Error("REALITY-BUILD: extension creation failed: %v", err)
 		return nil, fmt.Errorf("reality extension creation failed: %w", err)
@@ -839,7 +905,7 @@ func (r *REALITYStrategy) readServerHello(conn net.Conn, timeout time.Duration) 
 
 // validateServerHello validates the server's response and returns the extension
 // it found. Looks for REALITY data in padding extension (0x0015).
-func (r *REALITYStrategy) validateServerHello(serverHello []byte, clientPubKey [32]byte) (*customtls.REALITYExtension, error) {
+func (r *REALITYStrategy) validateServerHello(serverHello []byte, clientPubKey [32]byte, secret []byte) (*customtls.REALITYExtension, error) {
 	// Search for REALITY in padding extension (0x0015)
 	var serverExt *customtls.REALITYExtension
 
@@ -862,7 +928,7 @@ func (r *REALITYStrategy) validateServerHello(serverHello []byte, clientPubKey [
 			// Extract REALITY extension from start of padding (no magic check).
 			paddingData := serverHello[extDataStart : extDataStart+extLen]
 			ext, err := customtls.ExtractREALITYFromPadding(paddingData)
-			if err == nil && customtls.VerifyServerAuth(r.secret, clientPubKey[:], ext.AuthToken) {
+			if err == nil && customtls.VerifyServerAuth(secret, clientPubKey[:], ext.AuthToken) {
 				serverExt = ext
 				break
 			}
@@ -888,14 +954,14 @@ func (r *REALITYStrategy) validateServerHello(serverHello []byte, clientPubKey [
 //
 // Even the fallback is safe from the v1 keystream reuse this change is about:
 // the key there is derived from clientPubKey, which is now fresh per connection.
-func (r *REALITYStrategy) wrapDataLayer(tcpConn net.Conn, serverExt *customtls.REALITYExtension, clientPrivKey, clientPubKey, clientSalt [32]byte) (net.Conn, error) {
-	serverSalt, ok := customtls.ParseServerDataV2(r.secret, clientPubKey, serverExt.PubKey, clientSalt, serverExt.Extra)
+func (r *REALITYStrategy) wrapDataLayer(tcpConn net.Conn, serverExt *customtls.REALITYExtension, clientPrivKey, clientPubKey, clientSalt [32]byte, secret []byte) (net.Conn, error) {
+	serverSalt, ok := customtls.ParseServerDataV2(secret, clientPubKey, serverExt.PubKey, clientSalt, serverExt.Extra)
 	if !ok {
 		if r.requireDataV2 {
 			return nil, errors.New("server did not confirm data layer v2")
 		}
 		log.Info("REALITY: server on legacy data layer v1, falling back")
-		return NewRealityDataConn(tcpConn, r.secret, clientPubKey[:], true)
+		return NewRealityDataConn(tcpConn, secret, clientPubKey[:], true)
 	}
 
 	ecdh, err := RealityV2ECDH(clientPrivKey, serverExt.PubKey)
@@ -905,7 +971,7 @@ func (r *REALITYStrategy) wrapDataLayer(tcpConn net.Conn, serverExt *customtls.R
 
 	log.Debug("REALITY: data layer v2 negotiated")
 	return NewRealityDataConnV2(tcpConn, RealityV2Params{
-		SharedSecret: r.secret,
+		SharedSecret: secret,
 		ECDH:         ecdh,
 		ClientPub:    clientPubKey,
 		ServerPub:    serverExt.PubKey,

--- a/internal/strategy/reality_b1_client.go
+++ b/internal/strategy/reality_b1_client.go
@@ -55,7 +55,7 @@ var errB1NoAuthKey = errors.New("reality b1: certificate check ran before the au
 //     to be derived before the handshake starts.
 //   - The binding record is the first application data, so it goes after the
 //     handshake and before smux.
-func (r *REALITYStrategy) connectB1(ctx context.Context, tcpConn net.Conn, dest string, deadline time.Time) (net.Conn, error) {
+func (r *REALITYStrategy) connectB1(ctx context.Context, tcpConn net.Conn, dest string, deadline time.Time, secret []byte) (net.Conn, error) {
 	host, _, err := net.SplitHostPort(dest)
 	if err != nil {
 		host = dest
@@ -95,7 +95,7 @@ func (r *REALITYStrategy) connectB1(ctx context.Context, tcpConn net.Conn, dest 
 		return nil, fmt.Errorf("reality b1: build client: %w", err)
 	}
 
-	authKey, err = r.sealSessionID(uconn)
+	authKey, err = r.sealSessionID(uconn, secret)
 	if err != nil {
 		return nil, err
 	}
@@ -127,7 +127,7 @@ func (r *REALITYStrategy) connectB1(ctx context.Context, tcpConn net.Conn, dest 
 	// proof_c and the dispatch byte travel together inside one encrypted record.
 	// The dispatch byte used to go out on its own, unencrypted, in its own TCP
 	// segment — signature #1 from the improvement plan.
-	if err := customtls.WriteClientBinding(uconn, r.secret, ekm, protocol.TypeMux); err != nil {
+	if err := customtls.WriteClientBinding(uconn, secret, ekm, protocol.TypeMux); err != nil {
 		return nil, fmt.Errorf("reality b1: client binding: %w", err)
 	}
 
@@ -183,7 +183,7 @@ func (r *REALITYStrategy) connectB1(ctx context.Context, tcpConn net.Conn, dest 
 // against. It does — GREASE ECH caches its payload under a sync.Once, which is
 // what makes this safe for the Firefox profile — and the length check below is
 // the cheap runtime guard against that ceasing to be true.
-func (r *REALITYStrategy) sealSessionID(uconn *utls.UConn) ([]byte, error) {
+func (r *REALITYStrategy) sealSessionID(uconn *utls.UConn, secret []byte) ([]byte, error) {
 	if err := uconn.BuildHandshakeState(); err != nil {
 		return nil, fmt.Errorf("reality b1: build handshake state: %w", err)
 	}
@@ -210,7 +210,7 @@ func (r *REALITYStrategy) sealSessionID(uconn *utls.UConn) ([]byte, error) {
 		// and nothing to coordinate with the server's rollout.
 		Flags:   customtls.AuthFlagExporterBinding | customtls.AuthFlagReshapeCapable,
 		Time:    uint32(r.clockOffset.Now().Unix()),
-		ShortID: customtls.ShortIDFor(r.secret),
+		ShortID: customtls.ShortIDFor(secret),
 	}
 
 	sid, err := customtls.SealSessionID(eph, r.serverStaticPub, aad, hello.Random, payload)

--- a/internal/strategy/reality_b1_client_test.go
+++ b/internal/strategy/reality_b1_client_test.go
@@ -255,7 +255,7 @@ func dialB1(t *testing.T, r *REALITYStrategy, srv *b1TestServer) (net.Conn, erro
 	deadline := time.Now().Add(10 * time.Second)
 	_ = tcpConn.SetDeadline(deadline)
 
-	conn, err := r.connectB1(t.Context(), tcpConn, "github.com:443", deadline)
+	conn, err := r.connectB1(t.Context(), tcpConn, "github.com:443", deadline, r.secret)
 	if err != nil {
 		tcpConn.Close()
 		<-srvDone
@@ -409,7 +409,7 @@ func TestB1ClientSendsNothingInTheClear(t *testing.T) {
 	deadline := time.Now().Add(10 * time.Second)
 	_ = tcpConn.SetDeadline(deadline)
 
-	conn, err := b1Client(t, srv).connectB1(t.Context(), rec, "github.com:443", deadline)
+	conn, err := b1Client(t, srv).connectB1(t.Context(), rec, "github.com:443", deadline, srv.secret)
 	if err != nil {
 		t.Fatalf("connectB1: %v", err)
 	}
@@ -497,7 +497,7 @@ func TestB1ClientStillSendsRenegotiationInfo(t *testing.T) {
 			r := b1Client(t, srv)
 			r.SetFingerprint(profile)
 
-			conn, err := r.connectB1(t.Context(), rec, "github.com:443", deadline)
+			conn, err := r.connectB1(t.Context(), rec, "github.com:443", deadline, r.secret)
 			if err != nil {
 				t.Fatalf("connectB1 with %s: %v", profile, err)
 			}
@@ -578,7 +578,7 @@ func BenchmarkB1ClientThroughput(b *testing.B) {
 
 	r := NewREALITYStrategy(nil, srv.secret)
 	r.SetB1(srv.publicKey())
-	conn, err := r.connectB1(b.Context(), tcpConn, "github.com:443", deadline)
+	conn, err := r.connectB1(b.Context(), tcpConn, "github.com:443", deadline, r.secret)
 	if err != nil {
 		b.Fatalf("connectB1: %v", err)
 	}

--- a/internal/strategy/reality_b1_wire_test.go
+++ b/internal/strategy/reality_b1_wire_test.go
@@ -58,7 +58,7 @@ func dialB1Recorded(t *testing.T, profile string, srv *b1TestServer, tune func(*
 	r := b1Client(t, srv)
 	r.SetFingerprint(profile)
 
-	conn, err := r.connectB1(t.Context(), rec, "github.com:443", deadline)
+	conn, err := r.connectB1(t.Context(), rec, "github.com:443", deadline, r.secret)
 	if err != nil {
 		t.Fatalf("connectB1 with %s: %v", profile, err)
 	}
@@ -354,7 +354,7 @@ func TestB1ServerMustNotSelectP256(t *testing.T) {
 
 	r := b1Client(t, srv)
 	r.SetFingerprint("firefox")
-	_, err = r.connectB1(t.Context(), tcpConn, "github.com:443", deadline)
+	_, err = r.connectB1(t.Context(), tcpConn, "github.com:443", deadline, r.secret)
 	tcpConn.Close()
 	<-srvDone
 

--- a/internal/strategy/reality_clienthello_test.go
+++ b/internal/strategy/reality_clienthello_test.go
@@ -44,7 +44,7 @@ func TestBuildClientHelloCarriesAuthAndDataV2(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			hello, err := r.buildClientHello("github.com:443", clientPriv, salt)
+			hello, err := r.buildClientHello("github.com:443", clientPriv, salt, r.secret)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -98,7 +98,7 @@ func TestBuildClientHelloRotatesKeyMaterial(t *testing.T) {
 		if _, err := rand.Read(salt[:]); err != nil {
 			t.Fatal(err)
 		}
-		hello, err := r.buildClientHello("github.com:443", priv, salt)
+		hello, err := r.buildClientHello("github.com:443", priv, salt, r.secret)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/strategy/reality_conn_v2_test.go
+++ b/internal/strategy/reality_conn_v2_test.go
@@ -390,7 +390,7 @@ func TestWrapDataLayerVersionChoice(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		conn, err := r.wrapDataLayer(writeOnlyConn{Writer: io.Discard}, ext, priv, pub, salt)
+		conn, err := r.wrapDataLayer(writeOnlyConn{Writer: io.Discard}, ext, priv, pub, salt, r.secret)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -405,7 +405,7 @@ func TestWrapDataLayerVersionChoice(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		conn, err := r.wrapDataLayer(writeOnlyConn{Writer: io.Discard}, ext, priv, pub, salt)
+		conn, err := r.wrapDataLayer(writeOnlyConn{Writer: io.Discard}, ext, priv, pub, salt, r.secret)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -421,7 +421,7 @@ func TestWrapDataLayerVersionChoice(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if _, err := r.wrapDataLayer(writeOnlyConn{Writer: io.Discard}, ext, priv, pub, salt); err == nil {
+		if _, err := r.wrapDataLayer(writeOnlyConn{Writer: io.Discard}, ext, priv, pub, salt, r.secret); err == nil {
 			t.Fatal("fell back to v1 despite requireDataV2")
 		}
 	})

--- a/internal/strategy/reality_dest_test.go
+++ b/internal/strategy/reality_dest_test.go
@@ -24,7 +24,7 @@ func TestSelectDestinationSpreadsUnderLoad(t *testing.T) {
 	const dials = 40
 	counts := make(map[string]int, len(pool))
 	for range dials {
-		dest, err := r.selectDestination()
+		dest, err := r.selectDestination(r.secret)
 		if err != nil {
 			t.Fatalf("selectDestination: %v", err)
 		}
@@ -59,7 +59,7 @@ func TestLeastRecentlyUsedDestPrefersUnusedThenOldest(t *testing.T) {
 
 	// Nothing used yet: the first entry is as good as any, but it must come
 	// from the pool.
-	if got := r.leastRecentlyUsedDestLocked(); got != "a.example" {
+	if got := r.leastRecentlyUsedDestLocked(r.destPool); got != "a.example" {
 		t.Fatalf("empty history returned %q", got)
 	}
 
@@ -67,12 +67,12 @@ func TestLeastRecentlyUsedDestPrefersUnusedThenOldest(t *testing.T) {
 	r.recentDests["a.example"] = now
 	r.recentDests["b.example"] = now.Add(-time.Minute)
 	// c.example never used — must win over both.
-	if got := r.leastRecentlyUsedDestLocked(); got != "c.example" {
+	if got := r.leastRecentlyUsedDestLocked(r.destPool); got != "c.example" {
 		t.Fatalf("unused donor not preferred, got %q", got)
 	}
 
 	r.recentDests["c.example"] = now.Add(-time.Second)
-	if got := r.leastRecentlyUsedDestLocked(); got != "b.example" {
+	if got := r.leastRecentlyUsedDestLocked(r.destPool); got != "b.example" {
 		t.Fatalf("oldest donor not chosen, got %q", got)
 	}
 }

--- a/internal/strategy/secret.go
+++ b/internal/strategy/secret.go
@@ -1,0 +1,113 @@
+package strategy
+
+import (
+	"context"
+
+	"github.com/tiredvpn/tiredvpn/internal/endpoint"
+)
+
+// Which key the client authenticates with is a property of the endpoint being
+// dialled, not of the process. A strategy is built once at start-up and outlives
+// any number of endpoint switches, so a secret copied into it at construction
+// can only ever be right for whichever endpoint happened to be first.
+//
+// The secret in force therefore travels with the dial, on the context that
+// already reaches every strategy's Connect and Probe. Two concurrent dials to
+// two different endpoints then stay honest without a barrier: each reads the
+// value its own caller put on its own context, and nothing shared is mutated.
+// A conn that needs the secret after Connect returns (http_polling's poll loop,
+// seqovl's decoy on first write) captures it at construction, which is the same
+// snapshot rule one level down - per connection rather than per process.
+//
+// Nothing on the wire changes. The bytes of every handshake are what they were;
+// only the key fed into them can now differ per endpoint.
+
+type dialSecretKey struct{}
+
+// withDialSecret returns ctx carrying secret as the key for this dial. An empty
+// secret is not recorded, so a caller with nothing to say cannot blank out a
+// value a wrapping caller already set.
+func withDialSecret(ctx context.Context, secret []byte) context.Context {
+	if len(secret) == 0 {
+		return ctx
+	}
+	return context.WithValue(ctx, dialSecretKey{}, secret)
+}
+
+// dialSecret returns the secret this dial must authenticate with, falling back
+// to the one the strategy was constructed with.
+//
+// The fallback is the whole single-server story: one -secret, no [[servers]]
+// list, nothing on the context - and every strategy behaves exactly as it did
+// before per-endpoint secrets existed. It is also what the unit tests and the
+// benchmarks rely on, since they construct strategies directly and dial with a
+// bare context.Background().
+func dialSecret(ctx context.Context, fallback []byte) []byte {
+	if ctx != nil {
+		if s, ok := ctx.Value(dialSecretKey{}).([]byte); ok && len(s) > 0 {
+			return s
+		}
+	}
+	return fallback
+}
+
+// ensureDialSecret fills in the pinned endpoint's secret when the caller has not
+// named one.
+//
+// dialEndpoints names it per candidate, which is the precise answer. Every other
+// way into the strategy scan - reconnect after a network change, budget
+// recycling, port-hop make-before-break, the periodic reprobe - dials whatever
+// is pinned right now, so the pinned endpoint's secret is the right answer for
+// them, and this is the one place that has to say so.
+func (m *Manager) ensureDialSecret(ctx context.Context) context.Context {
+	if ctx != nil {
+		if s, ok := ctx.Value(dialSecretKey{}).([]byte); ok && len(s) > 0 {
+			return ctx
+		}
+	}
+	return withDialSecret(ctx, m.CurrentSecret())
+}
+
+// CurrentSecret returns the secret of the endpoint pinned right now, or the
+// process-wide default when no endpoint carries one of its own.
+func (m *Manager) CurrentSecret() []byte {
+	sel := m.selector()
+	if sel == nil {
+		return m.defaultSecret()
+	}
+	cand, ok := sel.Current()
+	if !ok {
+		return m.defaultSecret()
+	}
+	return m.secretForCandidate(cand)
+}
+
+// secretForCandidate returns the secret configured on cand's endpoint, or the
+// default when that endpoint has none.
+func (m *Manager) secretForCandidate(cand endpoint.Candidate) []byte {
+	sel := m.selector()
+	if sel == nil {
+		return m.defaultSecret()
+	}
+	ep, ok := sel.Endpoint(cand)
+	if !ok || ep.Secret == "" {
+		return m.defaultSecret()
+	}
+	return []byte(ep.Secret)
+}
+
+// defaultSecret returns the process-wide secret (-secret / TIREDVPN_SECRET, or
+// the single value a config file gave every server).
+func (m *Manager) defaultSecret() []byte {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.secret
+}
+
+// setDefaultSecret records the process-wide secret. Called once, from
+// NewDefaultManager, before any dial can start.
+func (m *Manager) setDefaultSecret(secret []byte) {
+	m.mu.Lock()
+	m.secret = secret
+	m.mu.Unlock()
+}

--- a/internal/strategy/secret_callsite_test.go
+++ b/internal/strategy/secret_callsite_test.go
@@ -1,0 +1,157 @@
+package strategy
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A strategy keeps the secret it was built with only as a fallback, for the
+// single-server case and for tests. Every dial resolves the key in force once,
+// at the top of Connect, and passes it down by hand.
+//
+// The failure this guards against is not a missing feature but a reverted call
+// site: `donorsFor(secret)` written as `donorsFor(r.secret)`, or
+// `NewHTTP2StegoConn(conn, secret, ...)` as `NewHTTP2StegoConn(conn, s.secret,
+// ...)`. Each compiles, each looks right in review, and each puts one
+// endpoint's key into a handshake aimed at another. A behavioural test catches
+// this only where there is a server to reject the wrong key; most of these
+// strategies have no such test, and building one for every transport (raw ICMP,
+// QUIC, five different TLS dialects) is not a thing this repository has.
+//
+// So this is a coverage floor rather than a substitute: it says the
+// construction-time field is read in exactly the places it is allowed to be
+// read, which is the whole of this mistake's shape. What it does NOT catch is a
+// call site handed some third wrong value - for that, see the wire-level tests
+// in per_endpoint_secret_test.go and secret_wire_test.go.
+//
+// allowedConstructionSecretReads names the functions that may read the field,
+// with the reason each needs to.
+var allowedConstructionSecretReads = map[string]string{
+	// The fallback argument itself: dialSecret(ctx, r.secret).
+	"": "",
+	// donorsFor compares the asked-for secret against the construction one to
+	// decide whether the set derived at construction is the right answer.
+	"donorsFor": "compares against the construction secret by design",
+}
+
+// secretFieldNames are the construction-time secret fields on strategy types.
+var secretFieldNames = map[string]bool{"secret": true, "knockSecret": true}
+
+func TestConstructionSecretIsOnlyEverAFallback(t *testing.T) {
+	files, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+
+	fset := token.NewFileSet()
+	var offenders []string
+	checked := 0
+
+	for _, name := range files {
+		if strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		src, err := os.ReadFile(name)
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		file, err := parser.ParseFile(fset, name, src, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Recv == nil || fn.Body == nil {
+				continue
+			}
+			recvName, recvType := receiverOf(fn)
+			if recvName == "" || !strings.HasSuffix(recvType, "Strategy") {
+				continue
+			}
+			checked++
+			if _, allowed := allowedConstructionSecretReads[fn.Name.Name]; allowed {
+				continue
+			}
+			for _, pos := range constructionSecretReads(fn.Body, recvName) {
+				offenders = append(offenders,
+					fset.Position(pos).String()+" in "+recvType+"."+fn.Name.Name)
+			}
+		}
+	}
+
+	if checked == 0 {
+		t.Fatal("no strategy methods were examined; the scan is not looking at anything")
+	}
+	if len(offenders) > 0 {
+		t.Fatalf("a strategy method reads its construction-time secret outside dialSecret's fallback:\n  %s\n"+
+			"the key in force comes from dialSecret(ctx, <field>), resolved once at the top of Connect; "+
+			"reading the field again dials one endpoint with another endpoint's key",
+			strings.Join(offenders, "\n  "))
+	}
+}
+
+// receiverOf returns the receiver's variable name and bare type name, or empty
+// strings for a receiver this scan cannot reason about (unnamed, or not a
+// pointer/value to a plain identifier).
+func receiverOf(fn *ast.FuncDecl) (name, typ string) {
+	if len(fn.Recv.List) != 1 || len(fn.Recv.List[0].Names) != 1 {
+		return "", ""
+	}
+	name = fn.Recv.List[0].Names[0].Name
+	expr := fn.Recv.List[0].Type
+	if star, ok := expr.(*ast.StarExpr); ok {
+		expr = star.X
+	}
+	id, ok := expr.(*ast.Ident)
+	if !ok {
+		return "", ""
+	}
+	return name, id.Name
+}
+
+// constructionSecretReads returns the positions where body reads
+// recv.secret / recv.knockSecret somewhere other than as dialSecret's fallback
+// argument.
+func constructionSecretReads(body *ast.BlockStmt, recv string) []token.Pos {
+	// Positions of the reads that ARE the fallback argument, so they can be
+	// subtracted from the total rather than matched structurally twice.
+	allowed := map[token.Pos]bool{}
+	ast.Inspect(body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		id, ok := call.Fun.(*ast.Ident)
+		if !ok || id.Name != "dialSecret" || len(call.Args) != 2 {
+			return true
+		}
+		if sel, ok := call.Args[1].(*ast.SelectorExpr); ok {
+			allowed[sel.Pos()] = true
+		}
+		return true
+	})
+
+	var found []token.Pos
+	ast.Inspect(body, func(n ast.Node) bool {
+		sel, ok := n.(*ast.SelectorExpr)
+		if !ok || !secretFieldNames[sel.Sel.Name] {
+			return true
+		}
+		id, ok := sel.X.(*ast.Ident)
+		if !ok || id.Name != recv {
+			return true
+		}
+		if allowed[sel.Pos()] {
+			return true
+		}
+		found = append(found, sel.Pos())
+		return true
+	})
+	return found
+}

--- a/internal/strategy/secret_wire_test.go
+++ b/internal/strategy/secret_wire_test.go
@@ -1,0 +1,430 @@
+package strategy
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	stdtls "crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/hex"
+	"io"
+	"math/big"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tiredvpn/tiredvpn/internal/endpoint"
+	"github.com/tiredvpn/tiredvpn/internal/protocol"
+)
+
+// These read the credential a strategy actually put on the socket, then ask
+// which secret produced it. That is the question a test on the derivation
+// function cannot answer: the derivation is right either way, and what goes
+// wrong is the CALL SITE handing it the secret the strategy was constructed
+// with instead of the one this dial is for.
+//
+// Each of these fails on exactly that swap, and each carries its own positive
+// control - the same bytes checked against the construction secret must NOT
+// verify, or the test would pass against a strategy that ignores the secret
+// altogether.
+//
+// Two secrets, and which is which matters: builtSecret is what the strategy is
+// constructed with, dialSecret is the endpoint's. They must never be equal.
+const (
+	wireBuiltSecret = "the-secret-this-strategy-was-constructed-with"
+	wireDialSecret  = "the-secret-of-the-endpoint-being-dialled"
+)
+
+// managerAt builds a manager whose single endpoint is addr with the dial
+// secret, so Connect resolves that key exactly the way production does.
+func managerAt(t *testing.T, addr string) *Manager {
+	t.Helper()
+	m := NewManager()
+	m.setDefaultSecret([]byte(wireBuiltSecret))
+	if err := m.SetEndpointsTuned([]endpoint.Endpoint{
+		{Name: "peer", V4: addr, Order: 0, Secret: wireDialSecret},
+	}, endpoint.Tuning{Family: v4Only()}); err != nil {
+		t.Fatalf("SetEndpointsTuned: %v", err)
+	}
+	return m
+}
+
+// acceptOne runs serve on the first connection and hands back whatever it
+// returned. The strategy's dial is expected to fail - these servers only get as
+// far as the credential - so the caller ignores the dial error.
+func acceptOne(t *testing.T, serve func(net.Conn) (any, error)) (addr string, result <-chan any) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	out := make(chan any, 1)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		first := true
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				close(out)
+				return
+			}
+			if !first {
+				// The manager retries a failed strategy, and these servers play
+				// their part exactly once. Refusing the retries immediately keeps
+				// the test off the dial timeout.
+				conn.Close()
+				continue
+			}
+			first = false
+			_ = conn.SetDeadline(time.Now().Add(15 * time.Second))
+			got, err := serve(conn)
+			conn.Close()
+			if err != nil {
+				t.Errorf("server side: %v", err)
+				close(out)
+				return
+			}
+			out <- got
+		}
+	}()
+	t.Cleanup(func() { _ = ln.Close(); <-done })
+	return ln.Addr().String(), out
+}
+
+func awaitCredential(t *testing.T, ch <-chan any) any {
+	t.Helper()
+	select {
+	case got, ok := <-ch:
+		if !ok {
+			t.Fatal("the server never reached the client's credential")
+		}
+		return got
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for the client's credential")
+		return nil
+	}
+}
+
+// TestSSHCamouflageAuthenticatesWithTheDialSecret reads the token the fake SSH
+// KEX_ECDH_INIT carries and checks it belongs to the endpoint's secret.
+func TestSSHCamouflageAuthenticatesWithTheDialSecret(t *testing.T) {
+	addr, tokens := acceptOne(t, func(conn net.Conn) (any, error) {
+		br := bufio.NewReader(conn)
+		if _, err := br.ReadString('\n'); err != nil { // client banner
+			return nil, err
+		}
+		if _, err := conn.Write([]byte(SSHBanner)); err != nil {
+			return nil, err
+		}
+		if _, err := ReadSSHPacket(br); err != nil { // client KEXINIT
+			return nil, err
+		}
+		if err := WriteSSHPacket(conn, BuildSSHKexInit()); err != nil {
+			return nil, err
+		}
+		payload, err := ReadSSHPacket(br) // ECDH init carrying the token
+		if err != nil {
+			return nil, err
+		}
+		return ParseSSHKexPubKey(payload, sshMsgKexECDHInit)
+	})
+
+	m := managerAt(t, addr)
+	s := NewSSHCamouflageStrategy(m, []byte(wireBuiltSecret))
+	m.Register(s)
+	dialAndIgnore(t, m, addr)
+
+	token := awaitCredential(t, tokens).([]byte)
+	if !VerifySSHAuthToken(token, []byte(wireDialSecret)) {
+		t.Fatal("the SSH token does not verify under the endpoint's secret")
+	}
+	if VerifySSHAuthToken(token, []byte(wireBuiltSecret)) {
+		t.Fatal("the SSH token verifies under the construction secret too; this test cannot tell them apart")
+	}
+}
+
+// imapLogin is what the fake IMAP server pulls out of the LOGIN line.
+type imapLogin struct {
+	user  string
+	token []byte
+}
+
+// TestIMAPCamouflageAuthenticatesWithTheDialSecret covers both credentials the
+// IMAP camouflage derives: the token in the password field and the username,
+// which is the first four bytes of the secret in hex.
+func TestIMAPCamouflageAuthenticatesWithTheDialSecret(t *testing.T) {
+	addr, logins := acceptOne(t, func(conn net.Conn) (any, error) {
+		br := bufio.NewReader(conn)
+		for {
+			line, err := br.ReadString('\n')
+			if err != nil {
+				return nil, err
+			}
+			switch {
+			case strings.HasPrefix(line, "A001 CAPABILITY"):
+				if _, err := conn.Write([]byte("* CAPABILITY IMAP4rev1\r\nA001 OK done\r\n")); err != nil {
+					return nil, err
+				}
+			case strings.HasPrefix(line, "A002 LOGIN "):
+				fields := strings.Fields(strings.TrimSpace(line))
+				if len(fields) != 4 {
+					return nil, io.ErrUnexpectedEOF
+				}
+				tok, err := base64.StdEncoding.DecodeString(fields[3])
+				if err != nil {
+					return nil, err
+				}
+				return imapLogin{user: fields[2], token: tok}, nil
+			}
+		}
+	})
+
+	m := managerAt(t, addr)
+	s := NewIMAPCamouflageStrategy(m, []byte(wireBuiltSecret))
+	m.Register(s)
+	dialAndIgnore(t, m, addr)
+
+	got := awaitCredential(t, logins).(imapLogin)
+	if !VerifyIMAPAuthToken(got.token, []byte(wireDialSecret)) {
+		t.Fatal("the IMAP token does not verify under the endpoint's secret")
+	}
+	if VerifyIMAPAuthToken(got.token, []byte(wireBuiltSecret)) {
+		t.Fatal("the IMAP token verifies under the construction secret too")
+	}
+	if want := imapUsername([]byte(wireDialSecret)); got.user != want {
+		t.Fatalf("LOGIN user = %q, want %q (derived from the endpoint's secret)", got.user, want)
+	}
+}
+
+// TestWebSocketPaddedAuthenticatesWithTheDialSecret reads X-Auth-Token off the
+// upgrade request, which the strategy sends inside TLS.
+func TestWebSocketPaddedAuthenticatesWithTheDialSecret(t *testing.T) {
+	addr, tokens := acceptOne(t, func(raw net.Conn) (any, error) {
+		conn, err := serverTLS(t, raw)
+		if err != nil {
+			return nil, err
+		}
+		if _, err := protocol.ReadDispatch(conn); err != nil {
+			return nil, err
+		}
+		br := bufio.NewReader(conn)
+		for {
+			line, err := br.ReadString('\n')
+			if err != nil {
+				return nil, err
+			}
+			if v, ok := strings.CutPrefix(line, "X-Auth-Token: "); ok {
+				return hex.DecodeString(strings.TrimSpace(v))
+			}
+			if strings.TrimSpace(line) == "" {
+				return nil, io.ErrUnexpectedEOF
+			}
+		}
+	})
+
+	m := managerAt(t, addr)
+	s := NewWebSocketPaddedStrategy(m, []byte(wireBuiltSecret))
+	m.Register(s)
+	dialAndIgnore(t, m, addr)
+
+	assertAuthTokenSecret(t, awaitCredential(t, tokens).([]byte), "WebSocket upgrade")
+}
+
+// TestTrafficMorphAuthenticatesWithTheDialSecret reads the 32-byte token out of
+// the MRPH handshake.
+func TestTrafficMorphAuthenticatesWithTheDialSecret(t *testing.T) {
+	addr, tokens := acceptOne(t, func(raw net.Conn) (any, error) {
+		conn, err := serverTLS(t, raw)
+		if err != nil {
+			return nil, err
+		}
+		if _, err := protocol.ReadDispatch(conn); err != nil {
+			return nil, err
+		}
+		// MRPH(4) + nameLen(1) + name(N) + auth(32) + shaperID(1)
+		head := make([]byte, 5)
+		if _, err := io.ReadFull(conn, head); err != nil {
+			return nil, err
+		}
+		if !bytes.Equal(head[:4], []byte("MRPH")) {
+			return nil, io.ErrUnexpectedEOF
+		}
+		rest := make([]byte, int(head[4])+32+1)
+		if _, err := io.ReadFull(conn, rest); err != nil {
+			return nil, err
+		}
+		return rest[int(head[4]) : int(head[4])+32], nil
+	})
+
+	m := managerAt(t, addr)
+	s := NewTrafficMorphStrategy(m, YandexVideoProfile, nil, []byte(wireBuiltSecret))
+	m.Register(s)
+	dialAndIgnore(t, m, addr)
+
+	assertAuthTokenSecret(t, awaitCredential(t, tokens).([]byte), "MRPH handshake")
+}
+
+// assertAuthTokenSecret checks a generateAuthToken value against both secrets.
+//
+// The token is bucketed to the minute, so a run that straddles a boundary would
+// otherwise flake; neighbouring buckets are accepted, which is what the server
+// does too.
+func assertAuthTokenSecret(t *testing.T, token []byte, what string) {
+	t.Helper()
+	if !authTokenMatches(token, []byte(wireDialSecret)) {
+		t.Fatalf("the %s token does not verify under the endpoint's secret", what)
+	}
+	if authTokenMatches(token, []byte(wireBuiltSecret)) {
+		t.Fatalf("the %s token verifies under the construction secret too", what)
+	}
+}
+
+func authTokenMatches(token, secret []byte) bool {
+	for _, skew := range []time.Duration{0, -time.Minute, time.Minute} {
+		if bytes.Equal(token, authTokenAt(secret, time.Now().Add(skew))) {
+			return true
+		}
+	}
+	return false
+}
+
+// authTokenAt mirrors generateAuthToken at a chosen time. Spelled out rather
+// than calling generateAuthToken, which can only answer for the current minute
+// and would otherwise make this test compare a function against itself.
+func authTokenAt(secret []byte, at time.Time) []byte {
+	bucket := make([]byte, 8)
+	binary.BigEndian.PutUint64(bucket, uint64(at.Unix()/60))
+	h := hmac.New(sha256.New, secret)
+	h.Write(bucket)
+	h.Write([]byte("http2-stego-auth"))
+	return h.Sum(nil)[:32]
+}
+
+// dialAndIgnore runs one Connect against the recording server. It is expected to
+// fail: these servers stop at the credential and never complete a handshake.
+func dialAndIgnore(t *testing.T, m *Manager, addr string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	defer cancel()
+	conn, _, err := m.Connect(ctx, addr)
+	if err == nil {
+		conn.Close()
+		t.Fatal("the recording server completed a handshake it does not implement")
+	}
+}
+
+// serverTLS wraps raw in a TLS server with a throwaway self-signed certificate.
+// Every strategy here dials with InsecureSkipVerify, so the certificate only has
+// to exist.
+func serverTLS(t *testing.T, raw net.Conn) (net.Conn, error) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "recorder"},
+		DNSNames:     []string{"recorder"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, key.Public(), key)
+	if err != nil {
+		return nil, err
+	}
+	conn := stdtls.Server(raw, &stdtls.Config{
+		Certificates: []stdtls.Certificate{{Certificate: [][]byte{der}, PrivateKey: key}},
+		NextProtos:   []string{"h2", "http/1.1"},
+	})
+	if err := conn.Handshake(); err != nil {
+		return nil, err
+	}
+	return conn, nil
+}
+
+// TestSeqovlDecoyMarkerUsesTheDialSecret reads the decoy record seqovl puts in
+// front of the ClientHello and recomputes its marker.
+//
+// The marker is HMAC(secret, salt||nonce) over a nonce chosen per connection, so
+// it cannot be compared against a fixed value - the nonce comes off the wire and
+// the marker is recomputed under each secret in turn. That is also what the
+// server does.
+func TestSeqovlDecoyMarkerUsesTheDialSecret(t *testing.T) {
+	addr, records := acceptOne(t, func(conn net.Conn) (any, error) {
+		head := make([]byte, 5)
+		if _, err := io.ReadFull(conn, head); err != nil {
+			return nil, err
+		}
+		if head[0] != 0x16 {
+			return nil, io.ErrUnexpectedEOF
+		}
+		body := make([]byte, int(head[3])<<8|int(head[4]))
+		if _, err := io.ReadFull(conn, body); err != nil {
+			return nil, err
+		}
+		return body, nil
+	})
+
+	m := managerAt(t, addr)
+	s := NewSeqovlStrategy(m, []byte(wireBuiltSecret), false)
+	m.Register(s)
+	dialAndIgnore(t, m, addr)
+
+	body := awaitCredential(t, records).([]byte)
+	if len(body) < seqovlNonceLen+seqovlMarkerLen {
+		t.Fatalf("decoy payload is %d bytes, too short to hold a nonce and a marker", len(body))
+	}
+	nonce := body[:seqovlNonceLen]
+	marker := body[seqovlNonceLen : seqovlNonceLen+seqovlMarkerLen]
+
+	if !bytes.Equal(marker, seqovlMarker([]byte(wireDialSecret), nonce)) {
+		t.Fatal("the decoy marker was not computed under the endpoint's secret")
+	}
+	if bytes.Equal(marker, seqovlMarker([]byte(wireBuiltSecret), nonce)) {
+		t.Fatal("the decoy marker also matches the construction secret; this test cannot tell them apart")
+	}
+}
+
+// TestGenevaAuthenticatesWithTheDialSecret is the same shape as the WebSocket
+// one - Geneva reuses that upgrade format - but it goes through a different
+// strategy, and the call site is a different line.
+func TestGenevaAuthenticatesWithTheDialSecret(t *testing.T) {
+	addr, tokens := acceptOne(t, func(raw net.Conn) (any, error) {
+		conn, err := serverTLS(t, raw)
+		if err != nil {
+			return nil, err
+		}
+		br := bufio.NewReader(conn)
+		for {
+			line, err := br.ReadString('\n')
+			if err != nil {
+				return nil, err
+			}
+			if v, ok := strings.CutPrefix(line, "X-Auth-Token: "); ok {
+				return hex.DecodeString(strings.TrimSpace(v))
+			}
+		}
+	})
+
+	m := managerAt(t, addr)
+	g := NewGenevaStrategy(m, []byte(wireBuiltSecret), "russia")
+	m.Register(g)
+	dialAndIgnore(t, m, addr)
+
+	assertAuthTokenSecret(t, awaitCredential(t, tokens).([]byte), "Geneva upgrade")
+}

--- a/internal/strategy/seqovl.go
+++ b/internal/strategy/seqovl.go
@@ -131,6 +131,18 @@ type SeqovlStrategy struct {
 	injectorOnce sync.Once
 	injectorStop context.CancelFunc
 	packetActive atomic.Bool
+
+	// injectorSecret is the key the level-A marker was derived from, and
+	// mismatchOnce keeps the warning about it to one line.
+	//
+	// Level A is one NFQUEUE hook for the whole process, carrying one marker,
+	// while the key is per endpoint. So the injector is pinned to whichever
+	// endpoint started it and cannot follow a switch; a pool whose endpoints
+	// have different secrets gets level A on one of them and level B - which is
+	// per connection and does follow the key - on all of them. Saying so out
+	// loud beats a silently ineffective marker.
+	injectorSecret []byte
+	mismatchOnce   sync.Once
 }
 
 // NewSeqovlStrategy creates a seqovl strategy over its own REALITY handshake.
@@ -192,14 +204,14 @@ func (s *SeqovlStrategy) Connect(ctx context.Context, target string) (net.Conn, 
 	// CAP_NET_ADMIN and an operator-provisioned OUTPUT NFQUEUE rule. On Android /
 	// unprivileged hosts tryStartPacketOverlap is a no-op and we ride level B
 	// alone. Either way the app-framing decoy below always runs.
-	if s.packetEnabled {
-		s.tryStartPacketOverlap()
-	}
-	log.Debug("Seqovl: connecting to %s (decoy prefix + REALITY, packet=%v)", target, s.packetActive.Load())
 	// The decoy record is written on the conn's first write, which happens after
 	// Connect returns, so the key is captured here rather than looked up there.
 	// The REALITY handshake underneath resolves the same context to the same key.
 	secret := dialSecret(ctx, s.secret)
+	if s.packetEnabled {
+		s.tryStartPacketOverlap(secret)
+	}
+	log.Debug("Seqovl: connecting to %s (decoy prefix + REALITY, packet=%v)", target, s.packetActive.Load())
 	return s.reality.connect(ctx, target, func(c net.Conn) net.Conn {
 		return newSeqovlConn(c, secret)
 	})

--- a/internal/strategy/seqovl.go
+++ b/internal/strategy/seqovl.go
@@ -196,8 +196,12 @@ func (s *SeqovlStrategy) Connect(ctx context.Context, target string) (net.Conn, 
 		s.tryStartPacketOverlap()
 	}
 	log.Debug("Seqovl: connecting to %s (decoy prefix + REALITY, packet=%v)", target, s.packetActive.Load())
+	// The decoy record is written on the conn's first write, which happens after
+	// Connect returns, so the key is captured here rather than looked up there.
+	// The REALITY handshake underneath resolves the same context to the same key.
+	secret := dialSecret(ctx, s.secret)
 	return s.reality.connect(ctx, target, func(c net.Conn) net.Conn {
-		return newSeqovlConn(c, s.secret)
+		return newSeqovlConn(c, secret)
 	})
 }
 

--- a/internal/strategy/seqovl_packet_linux.go
+++ b/internal/strategy/seqovl_packet_linux.go
@@ -3,6 +3,7 @@
 package strategy
 
 import (
+	"bytes"
 	"context"
 
 	"github.com/tiredvpn/tiredvpn/internal/capabilities"
@@ -27,7 +28,13 @@ const seqovlQueueNum = 1
 // The default OverlapPrimitive uses the safe geometry (fake segment sits below
 // the server's rcv_nxt), so even without the server-side NFQUEUE drop the
 // cooperating server's kernel discards the fake and the real stream stays clean.
-func (s *SeqovlStrategy) tryStartPacketOverlap() bool {
+//
+// secret is the key of the endpoint being dialled, and it marks the fake
+// segments. One NFQUEUE hook carries one marker for the whole process, so the
+// injector is pinned to the endpoint that started it - see SeqovlStrategy for
+// why that is a limitation rather than a bug, and why a later endpoint with a
+// different key gets a warning instead of a second injector.
+func (s *SeqovlStrategy) tryStartPacketOverlap(secret []byte) bool {
 	if !s.packetEnabled {
 		return false
 	}
@@ -38,7 +45,7 @@ func (s *SeqovlStrategy) tryStartPacketOverlap() bool {
 	}
 
 	s.injectorOnce.Do(func() {
-		marker := seqovlPacketMarker(s.secret)
+		marker := seqovlPacketMarker(secret)
 		prim := geneva.NewOverlapPrimitive(marker)
 		strat := geneva.NewOverlapStrategy(prim)
 
@@ -51,9 +58,16 @@ func (s *SeqovlStrategy) tryStartPacketOverlap() bool {
 		}
 		s.injector = inj
 		s.injectorStop = cancel
+		s.injectorSecret = append([]byte(nil), secret...)
 		s.packetActive.Store(true)
 		log.Info("Seqovl: packet-level overlap active on NFQUEUE %d (server must provision the OUTPUT rule)", seqovlQueueNum)
 	})
 
+	if s.packetActive.Load() && !bytes.Equal(s.injectorSecret, secret) {
+		s.mismatchOnce.Do(func() {
+			log.Warn("Seqovl: packet-level overlap is marked with the key of the endpoint that started it " +
+				"and cannot follow a switch; this endpoint rides the level-B decoy alone")
+		})
+	}
 	return s.packetActive.Load()
 }

--- a/internal/strategy/seqovl_packet_other.go
+++ b/internal/strategy/seqovl_packet_other.go
@@ -5,6 +5,6 @@ package strategy
 // tryStartPacketOverlap is a no-op off Linux: packet-level seqovl needs NFQUEUE
 // and a raw socket, neither of which exists on Android / macOS / Windows. The
 // connection rides the level-B app-framing decoy alone.
-func (s *SeqovlStrategy) tryStartPacketOverlap() bool {
+func (s *SeqovlStrategy) tryStartPacketOverlap(_ []byte) bool {
 	return false
 }

--- a/internal/strategy/ssh_camouflage.go
+++ b/internal/strategy/ssh_camouflage.go
@@ -81,6 +81,7 @@ func (s *SSHCamouflageStrategy) Probe(ctx context.Context, target string) error 
 // Connect dials the server over plain TCP and performs the fake SSH handshake.
 func (s *SSHCamouflageStrategy) Connect(ctx context.Context, target string) (net.Conn, error) {
 	serverAddr := s.manager.GetServerAddr(ctx)
+	secret := dialSecret(ctx, s.secret)
 	log.Debug("SSH Camouflage: connecting to %s (raw TCP, fake SSH handshake)", serverAddr)
 
 	dialer := &net.Dialer{}
@@ -89,7 +90,7 @@ func (s *SSHCamouflageStrategy) Connect(ctx context.Context, target string) (net
 		return nil, err
 	}
 
-	if err := performSSHClientHandshake(conn, s.secret); err != nil {
+	if err := performSSHClientHandshake(conn, secret); err != nil {
 		conn.Close()
 		return nil, fmt.Errorf("ssh camouflage handshake: %w", err)
 	}

--- a/internal/strategy/stego.go
+++ b/internal/strategy/stego.go
@@ -153,6 +153,7 @@ func (s *HTTP2StegoStrategy) Probe(ctx context.Context, target string) error {
 func (s *HTTP2StegoStrategy) Connect(ctx context.Context, target string) (net.Conn, error) {
 	// Get server address (IPv6/IPv4 with automatic fallback)
 	serverAddr := s.manager.GetServerAddr(ctx)
+	secret := dialSecret(ctx, s.secret)
 	log.Debug("HTTP/2 Stego: Using server address: %s", serverAddr)
 
 	// Establish TLS connection with standard ALPN.
@@ -231,7 +232,7 @@ func (s *HTTP2StegoStrategy) Connect(ctx context.Context, target string) (net.Co
 	}
 
 	// Create steganographic connection with padding mode
-	stegoConn := NewHTTP2StegoConn(finalConn, s.secret, true, s.paddingMode)
+	stegoConn := NewHTTP2StegoConn(finalConn, secret, true, s.paddingMode)
 
 	// Perform initial handshake, bounded by the caller's context so a
 	// non-responding server can't hold this strategy past the strategy

--- a/internal/strategy/strategy.go
+++ b/internal/strategy/strategy.go
@@ -182,6 +182,12 @@ type Manager struct {
 	// selector itself is safe for concurrent use.
 	endpoints *endpoint.Selector
 
+	// secret is the process-wide shared secret: -secret / TIREDVPN_SECRET, or
+	// the one value a config file gave every server. It is the fallback for
+	// endpoints that do not carry a secret of their own - see secret.go for how
+	// the secret in force reaches a strategy. Guarded by m.mu.
+	secret []byte
+
 	// Shared TLS client session cache for resumption across reconnects.
 	// The adaptive manager reconnects frequently (fallback, reprobe); without a
 	// shared cache every stdlib-TLS strategy does a full handshake each time,
@@ -462,6 +468,9 @@ func (m *Manager) ProbeAll(ctx context.Context, target string) []Result {
 		target = addr
 		log.Debug("Probing with effective server address: %s", target)
 	}
+	// Same endpoint, same key: a probe that authenticates does it against the
+	// pinned endpoint, which is the one whose address was just resolved above.
+	ctx = m.ensureDialSecret(ctx)
 
 	m.mu.RLock()
 	// Filter out disabled strategies (priority <= 0)
@@ -782,8 +791,16 @@ func (m *Manager) dialEndpoints(ctx context.Context, target string) (net.Conn, S
 		// family - which is exactly what the old one-shot IPv6 check did.
 		cand, _ = sel.ProbeCurrent(ctx)
 
+		// Name the secret for THIS candidate, on this dial's own context. The
+		// pinned candidate can move underneath us - a concurrent Connect, the
+		// pre-flight gate, a health report - so reading the pin again down in a
+		// strategy would let a handshake authenticate to one server with another
+		// server's key. Here the address and the key are decided together and
+		// travel together.
+		dialCtx := withDialSecret(ctx, m.secretForCandidate(cand))
+
 		start := time.Now()
-		conn, strategy, err := m.ConnectExcluding(ctx, m.withHoppedPort(cand.Addr), nil)
+		conn, strategy, err := m.ConnectExcluding(dialCtx, m.withHoppedPort(cand.Addr), nil)
 		if err == nil {
 			sel.Report(cand, true, time.Since(start))
 			return conn, strategy, nil
@@ -901,6 +918,11 @@ func (m *Manager) ConnectExcluding(ctx context.Context, target string, excludeID
 
 // connectWithRTT is the internal connect method with optional RTT masking
 func (m *Manager) connectWithRTT(ctx context.Context, target string, excludeIDs []string, useRTTMasking bool) (net.Conn, Strategy, error) {
+	// Every path that reaches a strategy's Connect goes through here, so this is
+	// where a dial that nobody labelled picks up the pinned endpoint's secret.
+	// dialEndpoints labels its own, per candidate, and that label wins.
+	ctx = m.ensureDialSecret(ctx)
+
 	m.mu.RLock()
 	// Check if we have a recent successful strategy to try first (for fast reconnect)
 	lastSuccessful := m.lastSuccessfulStrategy
@@ -1345,6 +1367,11 @@ func NewDefaultManager(cfg DefaultManagerConfig) *Manager {
 
 	// Set before registering: strategies copy this at construction.
 	m.SetBurstReshape(cfg.BurstReshape)
+
+	// Set before the selector exists: it is the fallback every endpoint without
+	// a secret of its own resolves to, and CurrentSecret must never return nil
+	// once a dial can start.
+	m.setDefaultSecret(cfg.Secret)
 
 	initManagerTransport(m, cfg)
 	initManagerPortHopping(m, cfg)
@@ -2275,6 +2302,9 @@ func (m *Manager) ConnectForReconnect(ctx context.Context, target string) (net.C
 			log.Debug("Reconnect: using effective server address: %s", target)
 		}
 	}
+	// This path calls Connect on the strategies itself rather than going through
+	// connectWithRTT, so it has to name the key for the address it just resolved.
+	ctx = m.ensureDialSecret(ctx)
 
 	m.mu.RLock()
 	lastStrategy := m.lastSuccessfulStrategy
@@ -2467,8 +2497,9 @@ func (m *Manager) performMakeBeforeBreak(newPort int) {
 
 	log.Debug("Port hop: establishing new connection to %s (make before break)", newTarget)
 
-	// Try to connect using the last successful strategy
-	conn, err := lastStrategy.Connect(ctx, newTarget)
+	// Try to connect using the last successful strategy. Same endpoint, only a
+	// different port, so the pinned endpoint's key is the right one.
+	conn, err := lastStrategy.Connect(m.ensureDialSecret(ctx), newTarget)
 	if err != nil {
 		log.Warn("Port hop: new connection failed (%v), forcing hard reconnect", err)
 		m.CloseMuxSession()
@@ -2561,7 +2592,9 @@ func (m *Manager) performBudgetRecycling() {
 
 	log.Debug("Budget recycling: pre-warming new carrier to %s", target)
 
-	conn, err := lastStrategy.Connect(ctx, target)
+	// The replacement carrier goes to the same endpoint the old one did, so it
+	// authenticates with that endpoint's key.
+	conn, err := lastStrategy.Connect(m.ensureDialSecret(ctx), target)
 	if err != nil {
 		log.Warn("Budget recycling: new connection failed (%v), keeping current carrier", err)
 		return

--- a/internal/strategy/strategy_test.go
+++ b/internal/strategy/strategy_test.go
@@ -251,7 +251,7 @@ func TestAntiProbeKnockSequence(t *testing.T) {
 	secret := []byte("test-secret")
 	strat := NewAntiProbeStrategy(NewManager(), secret)
 
-	seq := strat.generateKnockSequence()
+	seq := generateKnockSequence(strat.knockSecret)
 
 	if len(seq.Delays) != 5 {
 		t.Errorf("Expected 5 delays, got %d", len(seq.Delays))

--- a/internal/strategy/websocket_padded.go
+++ b/internal/strategy/websocket_padded.go
@@ -92,6 +92,7 @@ func (s *WebSocketPaddedStrategy) Probe(ctx context.Context, target string) erro
 func (s *WebSocketPaddedStrategy) Connect(ctx context.Context, target string) (net.Conn, error) {
 	// Get server address (IPv6/IPv4 with automatic fallback)
 	serverAddr := s.manager.GetServerAddr(ctx)
+	secret := dialSecret(ctx, s.secret)
 	log.Debug("WebSocket Padded: Connecting to %s via %s", target, serverAddr)
 
 	// 1. Establish TLS connection to server (context-aware)
@@ -133,7 +134,7 @@ func (s *WebSocketPaddedStrategy) Connect(ctx context.Context, target string) (n
 
 	// 2. Send WebSocket upgrade request with auth token
 	wsKey := generateWebSocketKey()
-	authToken := generateAuthToken(s.secret)
+	authToken := generateAuthToken(secret)
 	upgradeReq := fmt.Sprintf(
 		"GET %s HTTP/1.1\r\n"+
 			"Host: %s\r\n"+
@@ -188,7 +189,7 @@ func (s *WebSocketPaddedStrategy) Connect(ctx context.Context, target string) (n
 	paddingLevel := padding.Balanced
 
 	// 5. Wrap with SalamanderConn
-	padder := padding.NewSalamanderPadder(s.secret, paddingLevel)
+	padder := padding.NewSalamanderPadder(secret, paddingLevel)
 	salamanderConn := NewSalamanderConn(baseConn, padder, true) // true = client side
 
 	log.Info("WebSocket Padded: Connection established to %s", target)


### PR DESCRIPTION
Until now a pool with differing secrets was refused outright at startup (`reconcileSecrets`), on the grounds that a strategy bakes the secret in at construction and cannot change it on a switch. That was a property of the implementation, not of the protocol — the server has supported per-client secrets for a while. Now the client does too.

## How

The secret in force travels **with the dial**, on the context that already reaches every strategy's `Connect` and `Probe`, rather than being copied into sixteen strategies at construction.

That choice matters for a reason beyond tidiness: two concurrent dials to two different endpoints stay honest with no barrier at all, because each reads the value its own caller placed on its own context and nothing shared is mutated. Rebuilding the strategies on every switch would have been the obvious alternative and would have thrown away exactly what the manager exists to accumulate — circuit breakers, storm detector, per-strategy success history.

Single-server behaviour is untouched: no value on the context means the constructed secret is used, which is the path `-secret` / `TIREDVPN_SECRET`, the unit tests and the benchmarks all take.

**Nothing on the wire changes.** The bytes of every handshake are what they were; only the key fed into them can now differ per endpoint.

## The part that was easy to get wrong

Values *derived* from the secret, not the secret itself. The REALITY donor pool is HKDF'd from it (`derivePool`) so that each user walks their own ordering of cover domains. A client that switched endpoints while keeping the first pool would present one user's donor sequence while authenticating as another — precisely the linkage that derivation exists to break, visible to an observer and invisible to a passing test suite. The pool is now cached per secret.

Reviewing for this turned up a real defect in a place hand-inspection had missed: seqovl's packet-level injector derived its NFQUEUE marker from the construction secret, so with a mixed-key pool the fake segments carried the first key forever and every other server's rule simply never matched. The failure mode was "level A quietly does nothing". One hook carries one marker, so this cannot be per-endpoint without a second queue; the marker now belongs to the endpoint that started the injector and a later endpoint with a different key gets one warning. Level B is per connection and was always fine.

## Verification

Tests were shown to broken code one site at a time: `dialSecret` ignoring the context, `secretForCandidate` collapsing to the process secret, and the donor-pool call site passing the construction secret instead of the dial's.

The last one initially passed clean — the existing test covered `donorsFor` itself, which stays correct under a swapped argument, rather than what the call site hands it. That is now covered by a test that reads the cover domains **off the wire**, so the assertion is about the path rather than the function.

Gate: build, vet, `go test ./... -race -short`, `golangci-lint run` — all clean.

## Config

`reconcileSecrets` keeps the checks that still mean something (a pool where some entries carry a secret and others do not is almost certainly a typo) and drops the one that no longer does. `-secret` now reads as the default for entries that name none. Example config and docs updated.