### PR TITLE
fix: stop a phone from re-dialling one dead server forever

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **A phone with six servers configured no longer keeps dialling the first
+  one.** Reported on a Pixel 9 that lost Wi-Fi and moved to MTS: three and a
+  half minutes of logs, sixty connection attempts, all to one address, none to
+  the other five in the pool. The address was blackholed - the TCP handshake
+  completed and nothing ever came back - so every transport in the scan died on
+  its connect timeout, and the endpoint layer never got to record a verdict,
+  because the Android service abandons a connect after about twenty-six seconds
+  and rebuilds the client. Two things kept it going in circles. Candidate health
+  lived in the selector the discarded client owned, so the replacement started
+  from the top of the pool with a clean slate and the failure threshold - which
+  counts failed cycles of one selector - could never be reached. And one cycle
+  cost far more than the service was willing to wait: twenty-one strategies at
+  ten seconds each, then the whole list again with RTT masking, including after
+  the service had already given up and the context was cancelled.
+
+  Selectors are now scoped to the process and keyed by their configuration, so a
+  rebuilt client inherits what its predecessor measured. A scan that gets no
+  answer at all from an address - timeouts only, no refusal, no reset, no
+  rejected handshake - is abandoned after two transports on Android rather than
+  running the list out, and that verdict parks the candidate at once instead of
+  waiting for a second cycle that may never finish. An address that answers
+  still gets the whole scan, which is the case the scan exists for: a transport
+  the DPI recognises and cuts is a fact about the transport, not the server. The
+  masked second pass no longer runs against an address that answered nothing, or
+  after the caller has walked away.
+
 ## [1.8.0] - 2026-08-27
 
 ### Changed

--- a/internal/client/endpoints.go
+++ b/internal/client/endpoints.go
@@ -209,6 +209,10 @@ func selectorConfig(cfg *Config, eps []endpoint.Endpoint) (endpoint.Config, erro
 		Cooldown:         cfg.Selection.Cooldown,
 		MaxCooldown:      cfg.Selection.MaxCooldown,
 		MinDwell:         cfg.Selection.MinDwell,
+		// The Android service rebuilds the whole client on every failed
+		// connect; without this the selector it hands the new client has never
+		// seen a failure and starts again from the first server in the pool.
+		Shared: true,
 	}, nil
 }
 

--- a/internal/endpoint/policy.go
+++ b/internal/endpoint/policy.go
@@ -89,6 +89,9 @@ func (t Tuning) config(eps []Endpoint, family FamilyPolicy) Config {
 		FailureThreshold: t.FailureThreshold,
 		Cooldown:         t.Cooldown,
 		MinDwell:         t.MinDwell,
+		// Every caller of this path is a real client being built or rebuilt,
+		// which is exactly the case candidate health has to survive.
+		Shared: true,
 	}
 }
 

--- a/internal/endpoint/selector.go
+++ b/internal/endpoint/selector.go
@@ -67,6 +67,11 @@ type Config struct {
 
 	ProbeTimeout time.Duration
 
+	// Shared makes NewSelector return the process-scoped selector for this
+	// configuration instead of a private one, so candidate health survives a
+	// client being torn down and rebuilt. See shared.go for why that matters.
+	Shared bool
+
 	Dial DialFunc
 	Now  func() time.Time
 	Rand func() float64
@@ -152,10 +157,18 @@ type Selector struct {
 	pinnedAt  time.Time
 }
 
-// NewSelector builds a selector from cfg.
+// NewSelector builds a selector from cfg, or returns the process-scoped one
+// when cfg.Shared is set.
 func NewSelector(cfg Config) (*Selector, error) {
 	cfg.applyDefaults()
+	if cfg.Shared {
+		return sharedSelectorFor(cfg)
+	}
+	return newSelector(cfg)
+}
 
+// newSelector always builds a fresh selector. cfg must already carry defaults.
+func newSelector(cfg Config) (*Selector, error) {
 	eps := make([]Endpoint, len(cfg.Endpoints))
 	copy(eps, cfg.Endpoints)
 	cands := buildCandidates(eps, cfg.Family, endpointOrder(eps, cfg.Selection, cfg.Rand))
@@ -500,6 +513,33 @@ func (s *Selector) ReportProbe(c Candidate, ok bool, latency time.Duration) {
 		return
 	}
 	s.recordFailureLocked(idx, now)
+}
+
+// ReportSilent records the strongest failure verdict a connect cycle can
+// produce: the address accepted the connection and then answered nothing, on
+// every transport in turn.
+//
+// It parks the candidate immediately, without waiting for FailureThreshold.
+// The threshold is there so one bad minute does not cost a good server, and it
+// is right for an ordinary failure - a refusal, a reset, a handshake that got
+// an answer it did not like. Silence across every transport is not a bad
+// minute: it is what a blackholed address looks like, and the second cycle
+// would confirm what the first one established at the price of another full
+// scan. On a phone, where the service restarts the client after every failed
+// cycle, that second scan may never finish.
+func (s *Selector) ReportSilent(c Candidate) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	idx, found := s.byAddr[c.Addr]
+	if !found {
+		return
+	}
+	now := s.cfg.Now()
+	h := &s.health[idx]
+	h.consecutiveFailures++
+	h.lastFailure = now
+	h.backoff = s.nextBackoff(h.backoff)
+	h.cooldownUntil = now.Add(s.jitter(h.backoff))
 }
 
 // recordFailureLocked bumps the streak and parks the candidate once it crosses

--- a/internal/endpoint/shared.go
+++ b/internal/endpoint/shared.go
@@ -1,0 +1,98 @@
+package endpoint
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// A client is not a process.
+//
+// On Android the VPN service throws the Go client away whenever a connect
+// fails and builds a new one inside the same process. Every verdict the
+// selector had reached died with it, so the replacement started from the top of
+// the pool and rediscovered the same dead server - which is how a pool of six
+// servers produced sixty dials to one address and none to the other five. The
+// failure threshold could never be crossed either: it counts failed cycles of
+// ONE selector, and no selector lived long enough to see two.
+//
+// Selectors built with Config.Shared come from a process-scoped table keyed by
+// their configuration, so a rebuilt client inherits the health its predecessor
+// measured. On desktop, where the client outlives every reconnect, the table
+// hands back the same instance that would have been built anyway.
+const sharedSelectorTTL = 10 * time.Minute
+
+type sharedEntry struct {
+	sel  *Selector
+	used time.Time
+}
+
+var (
+	sharedMu  sync.Mutex
+	sharedSel = map[string]*sharedEntry{}
+)
+
+// sharedSelectorFor returns the process-scoped selector for cfg, building it on
+// first use. cfg must already have been through applyDefaults, so that two
+// configs that resolve to the same policy share one entry.
+func sharedSelectorFor(cfg Config) (*Selector, error) {
+	key := sharedKey(cfg)
+
+	// Wall clock on purpose. This measures how long the process has been idle,
+	// which is not what cfg.Now measures - a test that injects a clock and
+	// advances it by hours must not have its cached selector evicted.
+	now := time.Now()
+
+	sharedMu.Lock()
+	defer sharedMu.Unlock()
+
+	if e, ok := sharedSel[key]; ok && now.Sub(e.used) < sharedSelectorTTL {
+		e.used = now
+		return e.sel, nil
+	}
+
+	sel, err := newSelector(cfg)
+	if err != nil {
+		return nil, err
+	}
+	// An entry older than the TTL describes a network the device may have left
+	// hours ago; drop those instead of letting the table grow with every
+	// configuration the process has ever seen.
+	for k, e := range sharedSel {
+		if now.Sub(e.used) >= sharedSelectorTTL {
+			delete(sharedSel, k)
+		}
+	}
+	sharedSel[key] = &sharedEntry{sel: sel, used: now}
+	return sel, nil
+}
+
+// sharedKey fingerprints everything about a Config that changes what the
+// selector decides. A field left out here would let two different policies
+// share one set of verdicts, so the fingerprint is covered by a test that
+// perturbs each field in turn.
+//
+// The func fields (Dial, Now, Rand) are deliberately absent: they are not
+// comparable, and a caller that injects them is describing HOW to measure, not
+// WHAT to measure.
+func sharedKey(cfg Config) string {
+	h := sha256.New()
+	fmt.Fprintf(h, "family=%d;selection=%d;threshold=%d;cooldown=%d;maxcooldown=%d;dwell=%d;jitter=%v;probe=%d;",
+		cfg.Family, cfg.Selection, cfg.FailureThreshold,
+		cfg.Cooldown, cfg.MaxCooldown, cfg.MinDwell, cfg.JitterFrac, cfg.ProbeTimeout)
+	for _, e := range cfg.Endpoints {
+		fmt.Fprintf(h, "ep(%q,%q,%q,%d,%d,%q,%q);", e.Name, e.V4, e.V6, e.Weight, e.Order, e.Secret, e.SNI)
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// ResetSharedSelectors empties the process-scoped table. Tests use it to keep
+// one case from inheriting another's verdicts; production never calls it,
+// because the point of the table is that it survives.
+func ResetSharedSelectors() {
+	sharedMu.Lock()
+	defer sharedMu.Unlock()
+	clear(sharedSel)
+}

--- a/internal/endpoint/shared_test.go
+++ b/internal/endpoint/shared_test.go
@@ -1,0 +1,153 @@
+package endpoint
+
+import (
+	"testing"
+	"time"
+)
+
+func sharedTestEndpoints() []Endpoint {
+	return []Endpoint{
+		{Name: "a", V4: "198.51.100.1:443", V6: "[2001:db8::1]:443", Order: 0, Weight: 1, Secret: "s1", SNI: "a.example"},
+		{Name: "b", V4: "198.51.100.2:443", Order: 1, Weight: 2},
+	}
+}
+
+// TestSharedSelectorIsReusedForTheSameConfig is the property the Android
+// lifecycle depends on: a client rebuilt from the same configuration must get
+// the selector its predecessor was using, not a blank one.
+func TestSharedSelectorIsReusedForTheSameConfig(t *testing.T) {
+	ResetSharedSelectors()
+	t.Cleanup(ResetSharedSelectors)
+
+	cfg := Config{Endpoints: sharedTestEndpoints(), Shared: true}
+
+	first, err := NewSelector(cfg)
+	if err != nil {
+		t.Fatalf("NewSelector: %v", err)
+	}
+	second, err := NewSelector(cfg)
+	if err != nil {
+		t.Fatalf("NewSelector: %v", err)
+	}
+	if first != second {
+		t.Fatal("a rebuilt client got a fresh selector, losing every verdict the previous one reached")
+	}
+
+	// Without the opt-in nothing is shared, which is what every existing
+	// caller and every test that injects its own clock relies on.
+	private, err := NewSelector(Config{Endpoints: sharedTestEndpoints()})
+	if err != nil {
+		t.Fatalf("NewSelector: %v", err)
+	}
+	if private == first {
+		t.Fatal("a selector built without Shared came out of the shared table")
+	}
+}
+
+// TestSharedSelectorVerdictsSurviveRebuild checks the thing the sharing is for,
+// not merely that the pointer matches: a failure recorded by one client is
+// still in force for the next.
+func TestSharedSelectorVerdictsSurviveRebuild(t *testing.T) {
+	ResetSharedSelectors()
+	t.Cleanup(ResetSharedSelectors)
+
+	cfg := Config{Endpoints: sharedTestEndpoints(), Family: V4Only, Shared: true}
+
+	first, err := NewSelector(cfg)
+	if err != nil {
+		t.Fatalf("NewSelector: %v", err)
+	}
+	cand, _ := first.Current()
+	first.ReportSilent(cand)
+
+	second, err := NewSelector(cfg)
+	if err != nil {
+		t.Fatalf("NewSelector: %v", err)
+	}
+	next, ok := second.Reconsider(second.Now())
+	if !ok {
+		t.Fatal("Reconsider found no candidate")
+	}
+	if next.Addr == cand.Addr {
+		t.Fatalf("the rebuilt client went straight back to %s, which the previous one had just parked", cand.Addr)
+	}
+}
+
+// TestSharedKeySeparatesEveryPolicyField perturbs each field of Config in turn.
+// A field missing from the fingerprint would let two different policies share
+// one set of verdicts - a client configured with a one-minute cooldown would
+// inherit the parking decisions of one configured with thirty.
+//
+// Endpoints are covered field by field too, because a pool that differs only in
+// weight or in per-endpoint secret is a different pool.
+func TestSharedKeySeparatesEveryPolicyField(t *testing.T) {
+	base := Config{Endpoints: sharedTestEndpoints()}
+	base.applyDefaults()
+
+	v6 := V6Only
+	cases := map[string]func(c *Config){
+		"family":           func(c *Config) { c.Family = v6 },
+		"selection":        func(c *Config) { c.Selection = SelectLatency },
+		"failureThreshold": func(c *Config) { c.FailureThreshold++ },
+		"cooldown":         func(c *Config) { c.Cooldown += time.Second },
+		"maxCooldown":      func(c *Config) { c.MaxCooldown += time.Second },
+		"minDwell":         func(c *Config) { c.MinDwell += time.Second },
+		"jitterFrac":       func(c *Config) { c.JitterFrac += 0.05 },
+		"probeTimeout":     func(c *Config) { c.ProbeTimeout += time.Second },
+		"endpointCount":    func(c *Config) { c.Endpoints = c.Endpoints[:1] },
+		"endpointName":     func(c *Config) { c.Endpoints[0].Name = "other" },
+		"endpointV4":       func(c *Config) { c.Endpoints[0].V4 = "198.51.100.9:443" },
+		"endpointV6":       func(c *Config) { c.Endpoints[0].V6 = "[2001:db8::9]:443" },
+		"endpointWeight":   func(c *Config) { c.Endpoints[0].Weight += 7 },
+		"endpointOrder":    func(c *Config) { c.Endpoints[0].Order += 7 },
+		"endpointSecret":   func(c *Config) { c.Endpoints[0].Secret = "other" },
+		"endpointSNI":      func(c *Config) { c.Endpoints[0].SNI = "other.example" },
+	}
+
+	baseKey := sharedKey(base)
+	for name, mutate := range cases {
+		t.Run(name, func(t *testing.T) {
+			c := base
+			c.Endpoints = sharedTestEndpoints()
+			mutate(&c)
+			if got := sharedKey(c); got == baseKey {
+				t.Fatalf("changing %s left the fingerprint unchanged: two different policies would share one selector", name)
+			}
+		})
+	}
+
+	// The control: an untouched copy must still land on the same entry, or the
+	// test above would pass for a fingerprint that is simply random.
+	same := base
+	same.Endpoints = sharedTestEndpoints()
+	if got := sharedKey(same); got != baseKey {
+		t.Fatal("an identical config fingerprinted differently - nothing would ever be shared")
+	}
+}
+
+// TestSharedSelectorExpires: a phone that spent the night in a pocket must not
+// wake up still parking servers it last measured on a network it has left.
+func TestSharedSelectorExpires(t *testing.T) {
+	ResetSharedSelectors()
+	t.Cleanup(ResetSharedSelectors)
+
+	cfg := Config{Endpoints: sharedTestEndpoints(), Shared: true}
+	first, err := NewSelector(cfg)
+	if err != nil {
+		t.Fatalf("NewSelector: %v", err)
+	}
+
+	sharedMu.Lock()
+	for _, e := range sharedSel {
+		e.used = e.used.Add(-sharedSelectorTTL - time.Minute)
+	}
+	sharedMu.Unlock()
+
+	second, err := NewSelector(cfg)
+	if err != nil {
+		t.Fatalf("NewSelector: %v", err)
+	}
+	if second == first {
+		t.Fatal("a selector older than the TTL was handed out again")
+	}
+}

--- a/internal/strategy/endpoint_restart_test.go
+++ b/internal/strategy/endpoint_restart_test.go
@@ -1,0 +1,402 @@
+package strategy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/tiredvpn/tiredvpn/internal/endpoint"
+)
+
+// blackholeListener accepts TCP and then says nothing, holding the connection
+// open. That is the signature this whole file is about: on MTS the TSPU lets the
+// handshake to a burnt VPN address complete and drops everything after it, so
+// every transport in the scan dies on the connect timeout rather than on a
+// refusal.
+//
+// It must hold the accepted connections. Closing them would send a FIN, the
+// strategy's read would return EOF instead of a timeout, and the test would
+// exercise the ordinary-failure path instead of the silent one.
+type blackholeListener struct {
+	ln      net.Listener
+	addr    string
+	accepts atomic.Int64
+
+	mu   sync.Mutex
+	held []net.Conn
+	done chan struct{}
+	once sync.Once
+}
+
+func newBlackholeListener(t *testing.T) *blackholeListener {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	l := &blackholeListener{ln: ln, addr: ln.Addr().String(), done: make(chan struct{})}
+	go func() {
+		defer close(l.done)
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			l.accepts.Add(1)
+			l.mu.Lock()
+			l.held = append(l.held, conn)
+			l.mu.Unlock()
+		}
+	}()
+	t.Cleanup(l.stop)
+	return l
+}
+
+func (l *blackholeListener) stop() {
+	l.once.Do(func() {
+		l.ln.Close()
+		<-l.done
+		l.mu.Lock()
+		for _, c := range l.held {
+			c.Close()
+		}
+		l.held = nil
+		l.mu.Unlock()
+	})
+}
+
+// helloListener answers every connection with one byte, which is what
+// greetingStrategy takes as "this transport works".
+type helloListener struct {
+	ln      net.Listener
+	addr    string
+	accepts atomic.Int64
+	done    chan struct{}
+	once    sync.Once
+}
+
+func newHelloListener(t *testing.T) *helloListener {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	l := &helloListener{ln: ln, addr: ln.Addr().String(), done: make(chan struct{})}
+	go func() {
+		defer close(l.done)
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			l.accepts.Add(1)
+			_, _ = conn.Write([]byte{'x'})
+			conn.Close()
+		}
+	}()
+	t.Cleanup(l.stop)
+	return l
+}
+
+func (l *helloListener) stop() {
+	l.once.Do(func() {
+		l.ln.Close()
+		<-l.done
+	})
+}
+
+// greetingStrategy dials the target and waits for the server to speak first, so
+// a blackhole fails with a timeout and a live server succeeds. Every real
+// strategy has the same shape - write a handshake, wait for the answer - which
+// is why the device log shows all of them failing at exactly connectTimeout.
+type greetingStrategy struct {
+	id       string
+	priority int
+
+	// refuse makes the strategy fail immediately with an error that is not a
+	// timeout, standing in for a reset, a refusal, or a handshake the peer
+	// answered and rejected.
+	refuse bool
+	tries  *atomic.Int64
+}
+
+func (s *greetingStrategy) Name() string         { return s.id }
+func (s *greetingStrategy) ID() string           { return s.id }
+func (s *greetingStrategy) Priority() int        { return s.priority }
+func (s *greetingStrategy) RequiresServer() bool { return true }
+func (s *greetingStrategy) Description() string  { return "test strategy awaiting a server greeting" }
+
+func (s *greetingStrategy) Probe(ctx context.Context, target string) error {
+	conn, err := s.Connect(ctx, target)
+	if err != nil {
+		return err
+	}
+	conn.Close()
+	return nil
+}
+
+func (s *greetingStrategy) Connect(ctx context.Context, target string) (net.Conn, error) {
+	if s.tries != nil {
+		s.tries.Add(1)
+	}
+	if s.refuse {
+		return nil, errors.New("connection refused by peer")
+	}
+	conn, err := (&net.Dialer{}).DialContext(ctx, "tcp", target)
+	if err != nil {
+		return nil, err
+	}
+	if dl, ok := ctx.Deadline(); ok {
+		_ = conn.SetReadDeadline(dl)
+	}
+	if _, err := conn.Read(make([]byte, 1)); err != nil {
+		conn.Close()
+		return nil, err
+	}
+	_ = conn.SetReadDeadline(time.Time{})
+	return conn, nil
+}
+
+// restartedManagerScanTimeout is the per-strategy connect timeout these tests
+// run with. The device uses 10s; the ratios below are what matters.
+const restartedManagerScanTimeout = 300 * time.Millisecond
+
+// newRestartedManager builds a manager exactly the way a fresh client does:
+// through NewTunedSelector, the constructor initManagerTransport and
+// SetEndpointsTuned both use. Calling it twice with the same endpoints is the
+// Android lifecycle - the service throws the client away on every failed
+// connect and builds a new one in the same process.
+func newRestartedManager(t *testing.T, tuning endpoint.Tuning, strategies int, addrs ...string) *Manager {
+	t.Helper()
+	eps := make([]endpoint.Endpoint, len(addrs))
+	for i, a := range addrs {
+		eps[i] = endpoint.Endpoint{Name: fmt.Sprintf("ep%d", i), V4: a, Order: i}
+	}
+	sel, err := endpoint.NewTunedSelector(eps, tuning, endpoint.V4Only)
+	if err != nil {
+		t.Fatalf("NewTunedSelector: %v", err)
+	}
+
+	m := NewManager()
+	m.endpoints = sel
+	// The real Android tuning, from the initializer that applies it, so a
+	// change to the abort threshold shows up here instead of in the field.
+	initManagerAndroidMode(m, DefaultManagerConfig{AndroidMode: true})
+	m.maxRetries = 1
+	m.connectTimeout = restartedManagerScanTimeout
+	m.probeTimeout = restartedManagerScanTimeout
+	// The device has RTT masking on, which doubles the cost of every scan: the
+	// whole strategy list is walked once more with masking before the endpoint
+	// layer is told anything.
+	m.rttMaskingEnabled = true
+	m.rttProfile = MoscowToYandexProfile
+	for i := range strategies {
+		m.Register(&greetingStrategy{id: fmt.Sprintf("s%d", i), priority: i + 1})
+	}
+	return m
+}
+
+// TestAnAnsweringAddressStillGetsTheWholeScan is the case the scan exists for,
+// and the one the silence rule must not eat: an address that answers, on a
+// transport the DPI happens to recognise and cut. Only silence - no answer at
+// all, transport after transport - is a verdict about the address.
+//
+// The strategies alternate so the streak is broken by an answering transport
+// every other time. A rule that never resets the streak would abandon this
+// address on the third strategy and leave three of the six untried.
+func TestAnAnsweringAddressStillGetsTheWholeScan(t *testing.T) {
+	silent := newBlackholeListener(t)
+	live := newHelloListener(t)
+
+	const strategies = 6
+	var tries atomic.Int64
+
+	m := newRestartedManager(t, endpoint.Tuning{FailureThreshold: 2, Cooldown: time.Minute}, 0, silent.addr, live.addr)
+	for i := range strategies {
+		m.Register(&greetingStrategy{
+			id:       fmt.Sprintf("s%d", i),
+			priority: i + 1,
+			refuse:   i%2 == 1,
+			tries:    &tries,
+		})
+	}
+
+	conn, _, err := m.Connect(context.Background(), "")
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	conn.Close()
+
+	// The first pass runs every strategy against the first endpoint before the
+	// loop moves on; anything less means the scan was cut short.
+	if got := tries.Load(); got < strategies {
+		t.Fatalf("the scan stopped after %d of %d strategies on an address that was answering", got, strategies)
+	}
+	if st := endpointState(t, m, silent.addr); !st.CooldownUntil.IsZero() {
+		t.Fatal("an answering endpoint was parked after one failed cycle, ahead of the failure threshold")
+	}
+}
+
+// cancellingStrategy fails without touching the network and cancels the connect
+// context once it has been called cancelAt times.
+type cancellingStrategy struct {
+	id       string
+	priority int
+	tries    *atomic.Int64
+	cancelAt int64
+	cancel   context.CancelFunc
+	atCancel *atomic.Int64
+}
+
+func (s *cancellingStrategy) Name() string         { return s.id }
+func (s *cancellingStrategy) ID() string           { return s.id }
+func (s *cancellingStrategy) Priority() int        { return s.priority }
+func (s *cancellingStrategy) RequiresServer() bool { return true }
+func (s *cancellingStrategy) Description() string  { return "test strategy that cancels the cycle" }
+
+func (s *cancellingStrategy) Probe(ctx context.Context, target string) error {
+	return errors.New("not probed")
+}
+
+func (s *cancellingStrategy) Connect(_ context.Context, _ string) (net.Conn, error) {
+	n := s.tries.Add(1)
+	if n == s.cancelAt {
+		s.atCancel.Store(n)
+		s.cancel()
+	}
+	return nil, errors.New("connection refused by peer")
+}
+
+// TestCancelledConnectDoesNotStartASecondPass: once the caller has walked away
+// there is nobody left to hand a connection to, and on Android that caller is
+// the VPN service tearing this very client down. The device log shows the
+// opposite - "All strategies failed, retrying with RTT masking enabled" and a
+// fresh 21-strategy scan starting one millisecond after "Stopping client",
+// twelve times over.
+func TestCancelledConnectDoesNotStartASecondPass(t *testing.T) {
+	live := newHelloListener(t)
+
+	m := newRestartedManager(t, endpoint.Tuning{}, 0, live.addr)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var tries, atCancel atomic.Int64
+	for i := range 4 {
+		m.Register(&cancellingStrategy{
+			id:       fmt.Sprintf("s%d", i),
+			priority: i + 1,
+			tries:    &tries,
+			cancelAt: 2,
+			cancel:   cancel,
+			atCancel: &atCancel,
+		})
+	}
+
+	if _, _, err := m.Connect(ctx, ""); err == nil {
+		t.Fatal("Connect succeeded although every strategy refused")
+	}
+
+	if atCancel.Load() == 0 {
+		t.Fatal("the context was never cancelled - the test proves nothing")
+	}
+	if got, want := tries.Load(), atCancel.Load(); got != want {
+		t.Fatalf("%d strategy attempts ran after the context was cancelled", got-want)
+	}
+}
+
+// TestSilentEndpointDoesNotEatTheWholeConnectBudget is the first half of the
+// Pixel 9 report: the client had a working server configured and never dialled
+// it, because one connect cycle against the silent address costs longer than
+// the caller is willing to wait.
+//
+// The budget here stands in for the Android service's own deadline on the
+// control socket: it gives up after ~26s and restarts the client, which is
+// less than one scan (21 strategies x 10s, twice over with RTT masking).
+func TestSilentEndpointDoesNotEatTheWholeConnectBudget(t *testing.T) {
+	silent := newBlackholeListener(t)
+	live := newHelloListener(t)
+
+	const strategies = 6
+	// A full scan is strategies*timeout, and the RTT pass doubles it. The
+	// budget sits between "two strategies timed out" and "the whole list did",
+	// so it can only be met by giving up on the silent address early.
+	budget := 3 * restartedManagerScanTimeout
+
+	m := newRestartedManager(t, endpoint.Tuning{FailureThreshold: 2}, strategies, silent.addr, live.addr)
+
+	ctx, cancel := context.WithTimeout(context.Background(), budget)
+	defer cancel()
+
+	conn, _, err := m.Connect(ctx, "")
+	if err != nil {
+		t.Fatalf("Connect gave up on a pool with one live server: %v", err)
+	}
+	conn.Close()
+
+	if got := m.GetServerAddr(context.Background()); got != live.addr {
+		t.Fatalf("pinned %s, want the live server %s", got, live.addr)
+	}
+	if silent.accepts.Load() == 0 {
+		t.Fatal("the silent endpoint was never dialled - the test proves nothing")
+	}
+}
+
+// TestEndpointHealthSurvivesClientRecreation is the second half, and the one
+// that explains why the desktop fallback works while Android stays stuck.
+//
+// The Android service builds a new client for every reconnect. A verdict that
+// lives only in the selector instance dies with it, so the next cycle starts
+// from the top of the pool and rediscovers the same dead server forever - the
+// device log shows 60 dials, all to one address, and not one to the other five
+// configured servers.
+//
+// The pool here is two silent servers and a live one. maxEndpointAttempts caps
+// a single cycle at two candidates, so cycle one CANNOT reach the live server;
+// only a verdict carried into cycle two can.
+func TestEndpointHealthSurvivesClientRecreation(t *testing.T) {
+	silentA := newBlackholeListener(t)
+	silentB := newBlackholeListener(t)
+	live := newHelloListener(t)
+
+	tuning := endpoint.Tuning{
+		FailureThreshold: 2,
+		// Long enough that cycle two, which runs immediately, still sees a
+		// parked candidate.
+		Cooldown: time.Minute,
+		MinDwell: 5 * time.Minute,
+	}
+	const strategies = 4
+
+	first := newRestartedManager(t, tuning, strategies, silentA.addr, silentB.addr, live.addr)
+	if _, _, err := first.Connect(context.Background(), ""); err == nil {
+		t.Fatal("cycle one reached a server it has no budget for - retune the test")
+	}
+
+	dialsBefore := silentA.accepts.Load() + silentB.accepts.Load()
+	if dialsBefore == 0 {
+		t.Fatal("cycle one dialled neither silent server - the test proves nothing")
+	}
+
+	// The service throws the client away and builds a new one. Same process,
+	// same configuration, no state of its own carried across.
+	second := newRestartedManager(t, tuning, strategies, silentA.addr, silentB.addr, live.addr)
+	conn, _, err := second.Connect(context.Background(), "")
+	if err != nil {
+		t.Fatalf("cycle two: %v", err)
+	}
+	conn.Close()
+
+	if got := second.GetServerAddr(context.Background()); got != live.addr {
+		t.Fatalf("cycle two pinned %s, want the live server %s", got, live.addr)
+	}
+	if after := silentA.accepts.Load() + silentB.accepts.Load(); after != dialsBefore {
+		t.Fatalf("cycle two dialled the silent servers %d more times; a fresh client "+
+			"must inherit the verdict, not rediscover it", after-dialsBefore)
+	}
+}

--- a/internal/strategy/endpoint_selection.go
+++ b/internal/strategy/endpoint_selection.go
@@ -2,8 +2,13 @@ package strategy
 
 import "github.com/tiredvpn/tiredvpn/internal/endpoint"
 
-// SetEndpointSelection replaces the endpoint selector with one built from cfg,
-// discarding accumulated candidate health.
+// SetEndpointSelection replaces the endpoint selector with one built from cfg.
+//
+// Candidate health is not discarded when cfg describes the same pool and the
+// same policy: the selector comes from a process-scoped table, so a client
+// rebuilt after a failed connect - which is what the Android service does on
+// every retry - inherits what its predecessor measured instead of starting
+// again at the first server in the pool.
 //
 // It is the richer sibling of SetEndpoints: that one takes a list and a family
 // policy, this one takes the whole endpoint.Config, which is what a client

--- a/internal/strategy/strategy.go
+++ b/internal/strategy/strategy.go
@@ -210,6 +210,25 @@ const (
 // "nothing was eligible", which say nothing about the address.
 var errStrategyScanFailed = errors.New("all strategies failed")
 
+// errAddrSilent narrows errStrategyScanFailed: the scan was abandoned because
+// the address accepted connections and then answered nothing, on one transport
+// after another. Every failure was a timeout at connectTimeout - no refusal, no
+// reset, no protocol error - which is what a blackholed address looks like and
+// what no application-layer disguise can talk its way out of.
+//
+// Errors carrying it also carry errStrategyScanFailed, so dialEndpoints still
+// treats it as an endpoint verdict; the extra sentinel only says the verdict is
+// strong enough to act on at once.
+var errAddrSilent = errors.New("address answered no transport")
+
+// androidSilentScanAbort is how many consecutive non-UDP strategies must die on
+// the connect timeout before an Android scan gives up on the address.
+//
+// Two rather than the desktop three because the VPN service abandons a connect
+// after ~26s and rebuilds the client: with connectTimeout at 10s, a verdict
+// reached at 30s is a verdict nobody is left to hear.
+const androidSilentScanAbort = 2
+
 // preflightFailThreshold is how many consecutive failed connects must pile up
 // before Connect re-arms the blocking pre-flight connectivity check. See
 // Manager.consecutiveConnectFailures.
@@ -812,7 +831,11 @@ func (m *Manager) dialEndpoints(ctx context.Context, target string) (net.Conn, S
 			// anything about this endpoint.
 			break
 		}
-		sel.Report(cand, false, 0)
+		if errors.Is(err, errAddrSilent) {
+			sel.ReportSilent(cand)
+		} else {
+			sel.Report(cand, false, 0)
+		}
 	}
 
 	return nil, nil, lastErr
@@ -895,10 +918,29 @@ func (m *Manager) preflightCandidate(ctx context.Context, sel *endpoint.Selector
 	return other, nil
 }
 
+// scanState is what one connect cycle learns about the ADDRESS rather than
+// about any single transport, carried across both passes ConnectExcluding
+// makes over the strategy list.
+//
+// It has to outlive a pass. Every failure re-sorts the list by confidence, so
+// the masked pass sees the same transports in a different order, and a per-pass
+// counter would let that reordering manufacture a silence verdict for an
+// address that had already answered.
+type scanState struct {
+	// answered records that some transport got a reply - a refusal, a reset, a
+	// rejected handshake. One is enough: whatever is wrong from there on is a
+	// property of a transport, which is what the scan exists to work around.
+	answered bool
+	// timeouts counts non-UDP strategies that died on the connect timeout.
+	timeouts int
+}
+
 // ConnectExcluding tries strategies excluding specified ones (for fallback)
 func (m *Manager) ConnectExcluding(ctx context.Context, target string, excludeIDs []string) (net.Conn, Strategy, error) {
+	scan := &scanState{}
+
 	// First pass: try all strategies WITHOUT RTT masking
-	conn, strategy, err := m.connectWithRTT(ctx, target, excludeIDs, false)
+	conn, strategy, err := m.connectWithRTTScan(ctx, target, excludeIDs, false, scan)
 	if err == nil {
 		return conn, strategy, nil
 	}
@@ -908,16 +950,34 @@ func (m *Manager) ConnectExcluding(ctx context.Context, target string, excludeID
 	rttEnabled := m.rttMaskingEnabled
 	m.mu.RUnlock()
 
+	// Two cases where the second pass is pure cost. A cancelled context has
+	// nobody left to hand a connection to - on Android the service has already
+	// given up and is tearing this client down, and the log still showed a
+	// fresh 21-strategy scan starting underneath it. And RTT masking reshapes
+	// the timing of an established session; it cannot make an address that
+	// answered nothing answer, so repeating the whole scan against a silent
+	// address doubles the time before the endpoint layer hears the verdict.
+	if ctx.Err() != nil || errors.Is(err, errAddrSilent) {
+		return nil, nil, err
+	}
+
 	if rttEnabled {
 		log.Info("All strategies failed, retrying with RTT masking enabled...")
-		return m.connectWithRTT(ctx, target, excludeIDs, true)
+		return m.connectWithRTTScan(ctx, target, excludeIDs, true, scan)
 	}
 
 	return nil, nil, err
 }
 
-// connectWithRTT is the internal connect method with optional RTT masking
+// connectWithRTT is the internal connect method with optional RTT masking. It
+// scans on its own, for callers that make a single pass.
 func (m *Manager) connectWithRTT(ctx context.Context, target string, excludeIDs []string, useRTTMasking bool) (net.Conn, Strategy, error) {
+	return m.connectWithRTTScan(ctx, target, excludeIDs, useRTTMasking, &scanState{})
+}
+
+// connectWithRTTScan is connectWithRTT with the cycle-wide scan state supplied
+// by the caller.
+func (m *Manager) connectWithRTTScan(ctx context.Context, target string, excludeIDs []string, useRTTMasking bool, scan *scanState) (net.Conn, Strategy, error) {
 	// Every path that reaches a strategy's Connect goes through here, so this is
 	// where a dial that nobody labelled picks up the pinned endpoint's secret.
 	// dialEndpoints labels its own, per candidate, and that label wins.
@@ -1035,7 +1095,7 @@ func (m *Manager) connectWithRTT(ctx context.Context, target string, excludeIDs 
 		if !m.forced && m.stormDetector.AnyParked() {
 			log.Warn("All strategies parked by storm cooldown - unparking to avoid total outage")
 			m.stormDetector.Reset()
-			return m.connectWithRTT(ctx, target, excludeIDs, useRTTMasking)
+			return m.connectWithRTTScan(ctx, target, excludeIDs, useRTTMasking, scan)
 		}
 		return nil, nil, fmt.Errorf("no available strategies (all excluded or circuit-broken)")
 	}
@@ -1048,49 +1108,58 @@ func (m *Manager) connectWithRTT(ctx context.Context, target string, excludeIDs 
 
 	var lastErr error
 	attemptCount := 0
-	tcpTimeoutCount := 0 // Track consecutive TCP timeouts in this connection attempt
+	addrSilent := false
 
 	for i, s := range strategies {
-		// Android fast QUIC fallback: after N TCP timeouts, skip remaining TCP and try QUIC
-		if androidMode && tcpTimeoutCount >= tcpFailuresThreshold && !isUDPBasedStrategy(s) {
-			log.Info("Fast QUIC fallback: %d TCP timeouts, skipping remaining TCP strategies", tcpTimeoutCount)
-			// Jump to QUIC strategies
-			for _, qs := range quicStrategies {
-				if excludeMap[qs.ID()] || !m.circuitBreakers.Allow(qs.ID()) {
-					continue
-				}
+		if !scan.answered && scan.timeouts >= tcpFailuresThreshold && !isUDPBasedStrategy(s) {
+			// Nothing has come back from this address on any transport. Walking
+			// the rest of the list means one connect timeout per strategy for a
+			// verdict already in hand, and the endpoint layer is waiting for
+			// that verdict to move the client to another server.
+			log.Info("Address %s answered nothing on %d transports - abandoning the scan%s",
+				target, scan.timeouts, modeStr)
+			addrSilent = true
 
-				log.Debug("Trying QUIC fallback: %s", qs.Name())
-				connectCtx, cancel := context.WithTimeout(ctx, m.connectTimeout)
-				start := time.Now()
-				conn, err := qs.Connect(connectCtx, target)
-				latency := time.Since(start)
-				cancel()
-
-				if err == nil {
-					m.mu.Lock()
-					m.lastSuccessfulStrategy = qs
-					m.lastSuccessfulTime = time.Now()
-					m.consecutiveTCPTimeouts = 0
-					m.updateConfidenceWithLatency(qs.ID(), true, latency)
-					m.sortStrategies()
-					m.lastConnectionLatency = latency
-					m.lastConnectionAttempts = attemptCount
-					m.lastConnectionStrategy = qs.Name()
-					m.lastConnectionStrategyID = qs.ID()
-					m.mu.Unlock()
-
-					optimizeTCPConn(conn)
-					if useRTTMasking {
-						conn = WrapWithRTTMasking(conn, rttProfile)
+			// QUIC rides UDP, which the TCP verdict says nothing about. Android
+			// jumps to it here rather than losing it with the rest of the list.
+			if androidMode {
+				log.Info("Fast QUIC fallback: %d TCP timeouts, skipping remaining TCP strategies", scan.timeouts)
+				for _, qs := range quicStrategies {
+					if excludeMap[qs.ID()] || !m.circuitBreakers.Allow(qs.ID()) {
+						continue
 					}
 
-					log.Info("Connected via QUIC fallback %s (latency=%v)", qs.Name(), latency)
-					return conn, qs, nil
+					log.Debug("Trying QUIC fallback: %s", qs.Name())
+					connectCtx, cancel := context.WithTimeout(ctx, m.connectTimeout)
+					start := time.Now()
+					conn, err := qs.Connect(connectCtx, target)
+					latency := time.Since(start)
+					cancel()
+
+					if err == nil {
+						m.mu.Lock()
+						m.lastSuccessfulStrategy = qs
+						m.lastSuccessfulTime = time.Now()
+						m.consecutiveTCPTimeouts = 0
+						m.updateConfidenceWithLatency(qs.ID(), true, latency)
+						m.sortStrategies()
+						m.lastConnectionLatency = latency
+						m.lastConnectionAttempts = attemptCount
+						m.lastConnectionStrategy = qs.Name()
+						m.lastConnectionStrategyID = qs.ID()
+						m.mu.Unlock()
+
+						optimizeTCPConn(conn)
+						if useRTTMasking {
+							conn = WrapWithRTTMasking(conn, rttProfile)
+						}
+
+						log.Info("Connected via QUIC fallback %s (latency=%v)", qs.Name(), latency)
+						return conn, qs, nil
+					}
+					lastErr = fmt.Errorf("%s: %w", qs.Name(), err)
 				}
-				lastErr = fmt.Errorf("%s: %w", qs.Name(), err)
 			}
-			// All QUIC failed too, continue with remaining strategies
 			break
 		}
 
@@ -1156,19 +1225,27 @@ func (m *Manager) connectWithRTT(ctx context.Context, target string, excludeIDs 
 				log.Debug("  Failed: %s TIMEOUT (latency=%v)", s.Name(), latency)
 				strategyTimedOut = true
 
+				if !isUDPBasedStrategy(s) {
+					scan.timeouts++
+					log.Debug("TCP timeout count: %d/%d", scan.timeouts, tcpFailuresThreshold)
+				}
 				// Track TCP timeouts for Android fast fallback
 				if androidMode && !isUDPBasedStrategy(s) {
-					tcpTimeoutCount++
 					m.mu.Lock()
 					m.consecutiveTCPTimeouts++
 					// Re-sort strategies with updated penalty
 					m.sortStrategies()
 					m.mu.Unlock()
-					log.Debug("TCP timeout count: %d/%d (adaptive penalty adjusted)", tcpTimeoutCount, tcpFailuresThreshold)
 				}
 			} else {
 				log.Debug("  Failed: %v (latency=%v)", err, latency)
 				strategyTimedOut = false
+				// A refusal, a reset, a handshake that got an answer it did not
+				// like: the address is talking. Whatever is wrong here is a
+				// property of this transport, which is precisely the case the
+				// full scan exists for, so the address is no longer a candidate
+				// for the silence verdict this cycle.
+				scan.answered = true
 			}
 
 			// Brief pause before retry
@@ -1195,6 +1272,13 @@ func (m *Manager) connectWithRTT(ctx context.Context, target string, excludeIDs 
 		m.mu.Unlock()
 
 		log.Debug("Strategy %s exhausted, moving to next", s.Name())
+	}
+
+	if addrSilent {
+		// No emergency reprobe here: it exists to find a way back to an address
+		// that went dark, and this scan's whole point is that the client should
+		// stop asking this one and try another server.
+		return nil, nil, fmt.Errorf("%w: %w, last error: %w", errAddrSilent, errStrategyScanFailed, lastErr)
 	}
 
 	log.Error("All %d strategies failed after %d attempts%s", len(strategies), attemptCount, modeStr)
@@ -1415,14 +1499,19 @@ func initManagerTransport(m *Manager, cfg DefaultManagerConfig) {
 	}
 }
 
-// SetEndpoints replaces the endpoint list and the family policy, discarding all
-// accumulated candidate health.
+// SetEndpoints replaces the endpoint list and the family policy.
+//
+// Health is discarded only when the new list is genuinely different: selectors
+// are process-scoped per configuration, so re-applying the same endpoints hands
+// back the same instance rather than forgetting everything it measured. Use
+// ResetHealth to discard verdicts deliberately - that is what a network change
+// does.
 func (m *Manager) SetEndpoints(eps []endpoint.Endpoint, policy endpoint.FamilyPolicy) error {
 	return m.SetEndpointsTuned(eps, endpoint.Tuning{Family: &policy})
 }
 
 // SetEndpointsTuned is SetEndpoints with the whole [selection] section rather
-// than the family policy alone.
+// than the family policy alone, and with the same health semantics.
 func (m *Manager) SetEndpointsTuned(eps []endpoint.Endpoint, tuning endpoint.Tuning) error {
 	sel, err := endpoint.NewTunedSelector(eps, tuning, endpoint.PreferV6)
 	if err != nil {
@@ -1471,6 +1560,7 @@ func initManagerAndroidMode(m *Manager, cfg DefaultManagerConfig) {
 	m.connectTimeout = 10 * time.Second
 	m.maxRetries = 1
 	m.androidMode = true
+	m.tcpFailuresBeforeQUIC = androidSilentScanAbort
 	log.Info("Android mode: using optimized timeouts (probe=%v, connect=%v, retries=%d, TCP-first)",
 		m.probeTimeout, m.connectTimeout, m.maxRetries)
 }


### PR DESCRIPTION
Reported from a Pixel 9 on MTS: "не подключался, ротация не работала, залипал". Reproduced by turning Wi-Fi off so the device fell back to LTE, and captured 1627 lines of the core's log over three and a half minutes.

What it showed:

- `Connecting to 38.54.6.76:443` **sixty times, and that is the only address in the whole log**. The five other servers in the pool were never tried.
- The full 21-strategy scan failed **twelve times**, each followed by a second pass with RTT masking.
- **Zero** occurrences of cooldown, parked, or candidate anywhere. The endpoint layer was never told a thing.
- `Endpoint pool: 6 servers` printed **ten times** — the line that runs when the manager is built.

That last one is the shape of it. The Android service gives up on a connect at ~26s and rebuilds the client; each rebuild constructed a fresh selector, so measured health was discarded and selection restarted at the top of the pool. `failure_threshold = 2` wants two failed cycles in a row from one selector instance, and no instance lived that long. The desktop fallback we verified on a stand last week works because that process is long-lived — on a phone this path could never have worked.

## Two fixes, for two separate causes

**Health outlives the client.** Endpoint health now lives in a process-scoped selector keyed by the configuration, so a client rebuilt after a failed connect inherits what its predecessor measured. Entries older than a TTL are dropped, because they describe a network the device may have left hours ago. The key fingerprints every field of the config that changes what the selector decides — with a test that perturbs each field in turn, since a field left out would let two policies quietly share one set of verdicts.

**A silent address stops eating the connect budget.** When an address returns nothing but timeouts — no refusal, no reset — the scan is abandoned after two transports on Android and the candidate is parked immediately. An address that answers still gets the full scan, because that is the case the scan exists for: TCP gets through and DPI kills a particular strategy. The masked second pass no longer runs against a silent address, or after the caller has already given up.

## Verification

The failing scenario was written as a test first and confirmed red before anything was fixed.

Both halves were then broken one at a time against the finished code: disabling selector reuse reddens `TestEndpointHealthSurvivesClientRecreation`, `TestSharedSelectorIsReusedForTheSameConfig` and `TestSharedSelectorVerdictsSurviveRebuild`; disabling the silent-address exit reddens `TestSilentEndpointDoesNotEatTheWholeConnectBudget` and the recreation test.

Gate clean: build, vet, `go test ./... -race -short`, `golangci-lint run` 0 issues. Wire format unchanged.