### PR TITLE
fix: keep the pre-flight gate from un-parking a blackholed server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **The parking decision from 1.8.1 now survives the pre-flight gate.** Same
+  Pixel 9, same LTE, with 1.8.1 installed: the scan did give up on the
+  blackholed address after two silent transports, and the endpoint loop did move
+  to the next server. Then the gate ran for that server, walked the pool as it
+  is meant to, found the blackhole answering its TCP port - which a blackhole
+  always does - and treated the completed handshake as evidence of health. It
+  cleared the cooldown and pinned the client straight back. Eight connect
+  attempts later the log still showed one address and no parking anywhere. A
+  successful probe now records latency only: it clears neither the failure
+  streak nor the cooldown, which is what its own contract already said about
+  not mistaking an open port for a working endpoint. The gate still probes
+  parked candidates, because its question is whether the client has a network at
+  all, but it no longer moves the client onto one.
+
+- **A silent address is now recognised by the clock rather than by the wording
+  of the error.** On the first cycle REALITY reported a plain timeout and the
+  scan was abandoned correctly. On every cycle after that the same ten-second
+  wait came back as `serverhello read failed: ... use of closed network
+  connection` - the deadline fired, something closed the socket, and the text no
+  longer contained a word the classifier recognised. The scan read that as the
+  address having answered and ran the whole list again. An attempt that burns
+  the connect timeout heard nothing whatever its error is called; a refusal or a
+  reset comes back in milliseconds.
+
+- **The log can now tell "not parked" from "parked and chosen anyway".** Each
+  connect cycle prints the candidate it picked along with which candidates are
+  parked and for how long, a failed cycle prints what it did to that candidate's
+  health, and the connectivity gate names the address that actually answered
+  instead of the one it started the walk from.
+
 ## [1.8.1] - 2026-08-29
 
 ### Fixed

--- a/internal/endpoint/selector.go
+++ b/internal/endpoint/selector.go
@@ -492,11 +492,17 @@ func (s *Selector) Report(c Candidate, ok bool, latency time.Duration) {
 //
 // The asymmetry with Report is deliberate. A probe failure counts against the
 // candidate exactly like a connect failure - it is evidence the address is
-// unreachable. A probe SUCCESS only lifts the cooldown and refreshes latency;
-// it does not clear the failure streak, because a censor that lets the TCP
-// handshake through and kills the session afterwards is the case this whole
-// mechanism exists for. Treating "port answers" as "endpoint works" would pin
-// the client to a dead endpoint forever.
+// unreachable. A probe SUCCESS records only the latency: it clears neither the
+// failure streak nor the cooldown, because a censor that lets the TCP handshake
+// through and kills the session afterwards is the case this whole mechanism
+// exists for. Treating "port answers" as "endpoint works" would pin the client
+// to a dead endpoint forever.
+//
+// Clearing the cooldown used to be the one exception, and it undid the rest.
+// A blackholed address answers its TCP port by definition, so the gate found it
+// healthy the moment after a full scan had condemned it, and the client went
+// straight back. A cooldown ends when it ends, or when Next has nowhere else to
+// go - not because a port accepted a connection.
 func (s *Selector) ReportProbe(c Candidate, ok bool, latency time.Duration) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -508,11 +514,24 @@ func (s *Selector) ReportProbe(c Candidate, ok bool, latency time.Duration) {
 	h := &s.health[idx]
 	h.probed = true
 	if ok {
-		h.cooldownUntil = time.Time{}
 		h.latencyEWMA = blendLatency(h.latencyEWMA, latency)
 		return
 	}
 	s.recordFailureLocked(idx, now)
+}
+
+// IsParked reports whether the candidate is in cooldown right now. Callers that
+// hold a verdict of their own - the pre-flight gate, which sees a live TCP port
+// and nothing more - use it to check whether the selector has already decided
+// against this address for better reasons.
+func (s *Selector) IsParked(c Candidate) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	idx, found := s.byAddr[c.Addr]
+	if !found {
+		return false
+	}
+	return s.inCooldownLocked(idx, s.cfg.Now())
 }
 
 // ReportSilent records the strongest failure verdict a connect cycle can

--- a/internal/strategy/connectivity.go
+++ b/internal/strategy/connectivity.go
@@ -217,9 +217,16 @@ func (c *ConnectivityChecker) Check(ctx context.Context) ConnectivityResult {
 		}()
 	}
 
-	// Log results
-	log.Debug("Connectivity check to %s:%s - TCP:%v UDP:%v ICMP:%v (latency=%v)",
-		host, port, result.TCP, result.UDP, result.ICMP, result.Latency)
+	// The address that ANSWERED, not the one the walk started from. The gate
+	// tries the pool in order, so a line naming only the first address reads as
+	// "this one is up" when the verdict may have come from a different server
+	// entirely - which is what it did on the device.
+	answered := result.Addr
+	if answered == "" {
+		answered = "none"
+	}
+	log.Debug("Connectivity check from %s:%s - TCP:%v (answered=%s) UDP:%v ICMP:%v (latency=%v)",
+		host, port, result.TCP, answered, result.UDP, result.ICMP, result.Latency)
 
 	// Cache result
 	c.mu.Lock()

--- a/internal/strategy/endpoint_preflight_park_test.go
+++ b/internal/strategy/endpoint_preflight_park_test.go
@@ -1,0 +1,209 @@
+package strategy
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/tiredvpn/tiredvpn/internal/endpoint"
+)
+
+// newGatedRestartedManager is newRestartedManager with the pre-flight
+// connectivity gate wired up, which is what the phone runs and what the plain
+// helper leaves out. The gate is the piece that turned out to undo the parking
+// on the device, so a test without it cannot see the bug.
+func newGatedRestartedManager(t *testing.T, tuning endpoint.Tuning, seen *targetLog, strategies int, addrs ...string) *Manager {
+	t.Helper()
+	m := newRestartedManager(t, tuning, 0, addrs...)
+	for i := range strategies {
+		m.Register(&greetingStrategy{id: fmt.Sprintf("s%d", i), priority: i + 1, seen: seen})
+	}
+
+	checker := NewConnectivityChecker(addrs[0], 500*time.Millisecond, true)
+	checker.auxTimeout = 50 * time.Millisecond
+	checker.auxGrace = 50 * time.Millisecond
+	m.SetConnectivityChecker(checker)
+	return m
+}
+
+// maskedTimeoutStrategy waits for the server to speak, exactly like
+// greetingStrategy, but when the deadline fires it reports the failure the way
+// REALITY reported it on the device: a wrapped "use of closed network
+// connection", with no word in it that isTimeoutError recognises.
+type maskedTimeoutStrategy struct {
+	id       string
+	priority int
+}
+
+func (s *maskedTimeoutStrategy) Name() string         { return s.id }
+func (s *maskedTimeoutStrategy) ID() string           { return s.id }
+func (s *maskedTimeoutStrategy) Priority() int        { return s.priority }
+func (s *maskedTimeoutStrategy) RequiresServer() bool { return true }
+func (s *maskedTimeoutStrategy) Description() string  { return "test strategy masking its timeout" }
+
+func (s *maskedTimeoutStrategy) Probe(ctx context.Context, target string) error {
+	conn, err := s.Connect(ctx, target)
+	if err != nil {
+		return err
+	}
+	conn.Close()
+	return nil
+}
+
+func (s *maskedTimeoutStrategy) Connect(ctx context.Context, target string) (net.Conn, error) {
+	conn, err := (&net.Dialer{}).DialContext(ctx, "tcp", target)
+	if err != nil {
+		return nil, err
+	}
+	if dl, ok := ctx.Deadline(); ok {
+		_ = conn.SetReadDeadline(dl)
+	}
+	if _, err := conn.Read(make([]byte, 1)); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("masked: serverhello read failed: read tcp %s: use of closed network connection", target)
+	}
+	_ = conn.SetReadDeadline(time.Time{})
+	return conn, nil
+}
+
+// TestPreflightDoesNotResurrectAParkedEndpoint replays what the Pixel 9 did
+// with the silence fix already in place.
+//
+// The scan correctly gave up on the blackholed address and the loop moved to
+// the next server. Then the pre-flight gate ran for that next server, walked
+// the whole pool as it is meant to, and found the blackhole answering TCP -
+// which it does, that is the entire point of a blackhole. The gate took the
+// completed handshake as good news, cleared the cooldown, and pinned the client
+// straight back onto the address the scan had just condemned. Eight connect
+// attempts, one address, no parking anywhere in the log.
+//
+// The pool is arranged so the gate cannot pick the candidate the loop moved to:
+// that one refuses connections outright, and the blackhole is the next address
+// the gate tries.
+func TestPreflightDoesNotResurrectAParkedEndpoint(t *testing.T) {
+	silent := newBlackholeListener(t)
+	closed := newHelloListener(t)
+	closed.stop() // refuses connections: the gate cannot pick it
+	live := newHelloListener(t)
+
+	tuning := endpoint.Tuning{
+		FailureThreshold: 2,
+		Cooldown:         time.Minute,
+		MinDwell:         5 * time.Minute,
+	}
+	const strategies = 4
+	seen := &targetLog{}
+
+	m := newGatedRestartedManager(t, tuning, seen, strategies, silent.addr, closed.addr, live.addr)
+	conn, _, err := m.Connect(context.Background(), "")
+	if err != nil {
+		t.Fatalf("Connect never reached the live server: %v", err)
+	}
+	conn.Close()
+
+	if got := m.GetServerAddr(context.Background()); got != live.addr {
+		t.Fatalf("pinned %s, want the live server %s", got, live.addr)
+	}
+
+	// The abort fires after androidSilentScanAbort transports. Anything beyond
+	// that means the blackhole was dialled a second time, which only happens if
+	// something put the client back on it after the scan had condemned it.
+	var dialled int
+	for _, target := range seen.list {
+		if target == silent.addr {
+			dialled++
+		}
+	}
+	if dialled == 0 {
+		t.Fatal("the blackhole was never dialled - the test proves nothing")
+	}
+	if dialled > androidSilentScanAbort {
+		t.Fatalf("the blackhole was dialled %d times, want at most %d: the pre-flight gate "+
+			"un-parks it because its TCP port answers", dialled, androidSilentScanAbort)
+	}
+}
+
+// TestSuccessfulProbeDoesNotLiftACooldown is the same rule one layer down, at
+// the size a unit test can pin.
+//
+// ReportProbe's own contract says a completed TCP handshake is not evidence
+// that the endpoint works - that asymmetry is why a probe success does not
+// clear the failure streak. Clearing the cooldown did exactly what the contract
+// forbids by another route: the parked candidate came back the moment its port
+// answered, which for a censored address it always does.
+func TestSuccessfulProbeDoesNotLiftACooldown(t *testing.T) {
+	sel, err := endpoint.NewSelector(endpoint.Config{
+		Endpoints: []endpoint.Endpoint{
+			{Name: "a", V4: "198.51.100.1:443", Order: 0},
+			{Name: "b", V4: "198.51.100.2:443", Order: 1},
+		},
+		Family:           endpoint.V4Only,
+		FailureThreshold: 1,
+		Cooldown:         time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("NewSelector: %v", err)
+	}
+
+	cand, _ := sel.Current()
+	sel.ReportSilent(cand)
+	if !parkedState(t, sel, cand.Addr).CooldownUntil.After(sel.Now()) {
+		t.Fatal("ReportSilent did not park the candidate - the test proves nothing")
+	}
+
+	sel.ReportProbe(cand, true, 5*time.Millisecond)
+
+	if st := parkedState(t, sel, cand.Addr); !st.CooldownUntil.After(sel.Now()) {
+		t.Fatal("a TCP handshake lifted the cooldown of a candidate that answered no transport")
+	}
+}
+
+func parkedState(t *testing.T, sel *endpoint.Selector, addr string) endpoint.CandidateState {
+	t.Helper()
+	for _, st := range sel.Snapshot() {
+		if st.Addr == addr {
+			return st
+		}
+	}
+	t.Fatalf("no candidate for %s", addr)
+	return endpoint.CandidateState{}
+}
+
+// TestSilenceIsMeasuredByTheClockNotTheErrorText is the second half of what the
+// device showed. On the very first cycle REALITY timed out and the scan was
+// abandoned as intended. On every cycle after that the same 10-second wait came
+// back as "reality: serverhello read failed: ... use of closed network
+// connection" - the deadline fired, something closed the socket, and the error
+// no longer said "timeout". The scan read that as the address having answered
+// and ran the whole list again.
+//
+// An attempt that burns the entire connect timeout heard nothing, whatever the
+// error ended up being called. A refusal or a reset comes back in milliseconds.
+func TestSilenceIsMeasuredByTheClockNotTheErrorText(t *testing.T) {
+	silent := newBlackholeListener(t)
+	live := newHelloListener(t)
+
+	const strategies = 6
+	m := newRestartedManager(t, endpoint.Tuning{FailureThreshold: 2}, 0, silent.addr, live.addr)
+	for i := range strategies {
+		m.Register(&maskedTimeoutStrategy{id: fmt.Sprintf("s%d", i), priority: i + 1})
+	}
+
+	// Between "two transports timed out" and "the whole list did", exactly as
+	// the Android service's own deadline sits.
+	budget := 3 * restartedManagerScanTimeout
+	ctx, cancel := context.WithTimeout(context.Background(), budget)
+	defer cancel()
+
+	conn, _, err := m.Connect(ctx, "")
+	if err != nil {
+		t.Fatalf("Connect gave up on a pool with one live server: %v", err)
+	}
+	conn.Close()
+
+	if got := m.GetServerAddr(context.Background()); got != live.addr {
+		t.Fatalf("pinned %s, want the live server %s", got, live.addr)
+	}
+}

--- a/internal/strategy/endpoint_restart_test.go
+++ b/internal/strategy/endpoint_restart_test.go
@@ -123,6 +123,34 @@ type greetingStrategy struct {
 	// answered and rejected.
 	refuse bool
 	tries  *atomic.Int64
+
+	// seen records every target this strategy was pointed at, which is what
+	// tells "the endpoint layer moved on" from "it came straight back".
+	seen *targetLog
+}
+
+// targetLog collects the addresses strategies were handed, across managers.
+type targetLog struct {
+	mu   sync.Mutex
+	list []string
+}
+
+func (l *targetLog) add(addr string) {
+	l.mu.Lock()
+	l.list = append(l.list, addr)
+	l.mu.Unlock()
+}
+
+func (l *targetLog) since(n int) []string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return append([]string(nil), l.list[n:]...)
+}
+
+func (l *targetLog) len() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return len(l.list)
 }
 
 func (s *greetingStrategy) Name() string         { return s.id }
@@ -143,6 +171,9 @@ func (s *greetingStrategy) Probe(ctx context.Context, target string) error {
 func (s *greetingStrategy) Connect(ctx context.Context, target string) (net.Conn, error) {
 	if s.tries != nil {
 		s.tries.Add(1)
+	}
+	if s.seen != nil {
+		s.seen.add(target)
 	}
 	if s.refuse {
 		return nil, errors.New("connection refused by peer")
@@ -359,6 +390,12 @@ func TestSilentEndpointDoesNotEatTheWholeConnectBudget(t *testing.T) {
 // The pool here is two silent servers and a live one. maxEndpointAttempts caps
 // a single cycle at two candidates, so cycle one CANNOT reach the live server;
 // only a verdict carried into cycle two can.
+//
+// The pre-flight gate is wired in because the phone has one, and an earlier
+// version of this test did not: the gate probes the whole pool, a blackholed
+// address answers its TCP port, and acting on that answer used to un-park the
+// candidate this test is about. A test without the gate stayed green while the
+// device stayed stuck.
 func TestEndpointHealthSurvivesClientRecreation(t *testing.T) {
 	silentA := newBlackholeListener(t)
 	silentB := newBlackholeListener(t)
@@ -373,7 +410,8 @@ func TestEndpointHealthSurvivesClientRecreation(t *testing.T) {
 	}
 	const strategies = 4
 
-	first := newRestartedManager(t, tuning, strategies, silentA.addr, silentB.addr, live.addr)
+	seen := &targetLog{}
+	first := newGatedRestartedManager(t, tuning, seen, strategies, silentA.addr, silentB.addr, live.addr)
 	if _, _, err := first.Connect(context.Background(), ""); err == nil {
 		t.Fatal("cycle one reached a server it has no budget for - retune the test")
 	}
@@ -385,7 +423,7 @@ func TestEndpointHealthSurvivesClientRecreation(t *testing.T) {
 
 	// The service throws the client away and builds a new one. Same process,
 	// same configuration, no state of its own carried across.
-	second := newRestartedManager(t, tuning, strategies, silentA.addr, silentB.addr, live.addr)
+	second := newGatedRestartedManager(t, tuning, seen, strategies, silentA.addr, silentB.addr, live.addr)
 	conn, _, err := second.Connect(context.Background(), "")
 	if err != nil {
 		t.Fatalf("cycle two: %v", err)

--- a/internal/strategy/strategy.go
+++ b/internal/strategy/strategy.go
@@ -229,6 +229,17 @@ var errAddrSilent = errors.New("address answered no transport")
 // reached at 30s is a verdict nobody is left to hear.
 const androidSilentScanAbort = 2
 
+// silenceLatency is the share of the connect timeout an attempt has to burn
+// before it counts as having heard nothing back, whatever its error says.
+//
+// Not the full timeout: the deadline fires a hair before the caller measures,
+// and a strategy that gives up a moment early on its own inner deadline heard
+// just as little. Not much less either - a transport that got an answer and
+// disliked it comes back in milliseconds, nowhere near this line.
+func silenceLatency(connectTimeout time.Duration) time.Duration {
+	return connectTimeout - connectTimeout/10
+}
+
 // preflightFailThreshold is how many consecutive failed connects must pile up
 // before Connect re-arms the blocking pre-flight connectivity check. See
 // Manager.consecutiveConnectFailures.
@@ -778,6 +789,11 @@ func (m *Manager) dialEndpoints(ctx context.Context, target string) (net.Conn, S
 	if !ok {
 		return nil, nil, fmt.Errorf("no endpoint candidates configured")
 	}
+	// Without this line a log shows a client dialling the same address over and
+	// over and cannot say whether the endpoint layer never condemned it or
+	// condemned it and chose it anyway. Those are different bugs and we spent a
+	// day telling them apart by hand.
+	log.Info("Endpoint choice: %s (%s)", cand, m.endpointRoster(sel))
 
 	budget := min(maxEndpointAttempts, len(sel.Candidates()))
 	var lastErr error
@@ -836,9 +852,48 @@ func (m *Manager) dialEndpoints(ctx context.Context, target string) (net.Conn, S
 		} else {
 			sel.Report(cand, false, 0)
 		}
+		m.logEndpointHealth(sel, cand)
 	}
 
 	return nil, nil, lastErr
+}
+
+// endpointRoster renders the pool the way a reader of the log needs it: which
+// candidates are parked and until when. "6 servers, selection=priority" says
+// what was configured; this says what the client currently believes.
+func (m *Manager) endpointRoster(sel *endpoint.Selector) string {
+	now := sel.Now()
+	var parked []string
+	total := 0
+	for _, st := range sel.Snapshot() {
+		total++
+		if st.CooldownUntil.IsZero() || !now.Before(st.CooldownUntil) {
+			continue
+		}
+		parked = append(parked, fmt.Sprintf("%s for %s", st.Addr, st.CooldownUntil.Sub(now).Round(time.Second)))
+	}
+	if len(parked) == 0 {
+		return fmt.Sprintf("%d candidates, none parked", total)
+	}
+	return fmt.Sprintf("%d candidates, parked: %s", total, strings.Join(parked, ", "))
+}
+
+// logEndpointHealth reports what a failed cycle did to a candidate, so a log
+// can distinguish "not parked" from "parked and picked again".
+func (m *Manager) logEndpointHealth(sel *endpoint.Selector, cand endpoint.Candidate) {
+	now := sel.Now()
+	for _, st := range sel.Snapshot() {
+		if st.Addr != cand.Addr {
+			continue
+		}
+		if !st.CooldownUntil.IsZero() && now.Before(st.CooldownUntil) {
+			log.Info("Endpoint %s parked for %s after %d consecutive failure(s)",
+				cand, st.CooldownUntil.Sub(now).Round(time.Second), st.ConsecutiveFailures)
+			return
+		}
+		log.Info("Endpoint %s failed (%d consecutive), not parked yet", cand, st.ConsecutiveFailures)
+		return
+	}
 }
 
 // withHoppedPort rewrites the port when port hopping is active.
@@ -897,13 +952,26 @@ func (m *Manager) preflightCandidate(ctx context.Context, sel *endpoint.Selector
 	if result.Addr == cand.Addr {
 		// The pinned address answered. Record it as a probe, not as a connect:
 		// a completed TCP handshake is not evidence that the transport works,
-		// so this lifts a cooldown but deliberately leaves the failure streak
-		// alone (see Selector.ReportProbe).
+		// so this refreshes latency and deliberately leaves both the failure
+		// streak and any cooldown alone (see Selector.ReportProbe).
 		sel.ReportProbe(cand, true, result.Latency)
 		return cand, nil
 	}
 	other, ok := sel.CandidateForAddr(result.Addr)
 	if !ok {
+		return cand, nil
+	}
+
+	// The gate probes parked candidates on purpose - its question is whether
+	// this client has a network at all, and leaving a parked-but-live server
+	// out would make it wait when it has somewhere to go. Acting on that answer
+	// is a different question, and for a parked candidate the selector has
+	// already answered it, on evidence the gate cannot produce: an address that
+	// swallowed every transport still completes a TCP handshake. Switching here
+	// sent the client straight back to the server a full scan had just
+	// condemned, over and over.
+	if sel.IsParked(other) {
+		log.Debug("Pre-flight: %s answered but is parked - staying on %s", other, cand)
 		return cand, nil
 	}
 
@@ -1221,13 +1289,28 @@ func (m *Manager) connectWithRTTScan(ctx context.Context, target string, exclude
 			// breaker is NOT recorded per retry here - it is recorded once when
 			// the strategy is exhausted, so one logical failure counts once
 			// regardless of maxRetries.
-			if isTimeoutError(err) {
-				log.Debug("  Failed: %s TIMEOUT (latency=%v)", s.Name(), latency)
-				strategyTimedOut = true
+			timedOut := isTimeoutError(err)
+			// Whether the address said anything is a question about the clock,
+			// not about the wording of the error. On the device the same
+			// ten-second wait came back as a timeout on one cycle and as
+			// "use of closed network connection" on the next - the deadline
+			// fired, something closed the socket, and the text stopped
+			// containing the word the classifier looks for. A refusal or a
+			// reset arrives in milliseconds; only silence costs the whole
+			// budget.
+			heardNothing := timedOut || latency >= silenceLatency(m.connectTimeout)
 
+			if timedOut {
+				log.Debug("  Failed: %s TIMEOUT (latency=%v)", s.Name(), latency)
+			} else {
+				log.Debug("  Failed: %v (latency=%v)", err, latency)
+			}
+			strategyTimedOut = timedOut
+
+			if heardNothing {
 				if !isUDPBasedStrategy(s) {
 					scan.timeouts++
-					log.Debug("TCP timeout count: %d/%d", scan.timeouts, tcpFailuresThreshold)
+					log.Debug("TCP silence count: %d/%d", scan.timeouts, tcpFailuresThreshold)
 				}
 				// Track TCP timeouts for Android fast fallback
 				if androidMode && !isUDPBasedStrategy(s) {
@@ -1238,8 +1321,6 @@ func (m *Manager) connectWithRTTScan(ctx context.Context, target string, exclude
 					m.mu.Unlock()
 				}
 			} else {
-				log.Debug("  Failed: %v (latency=%v)", err, latency)
-				strategyTimedOut = false
 				// A refusal, a reset, a handshake that got an answer it did not
 				// like: the address is talking. Whatever is wrong here is a
 				// property of this transport, which is precisely the case the


### PR DESCRIPTION
Follow-up to #71. That change made a silent address stop eating the whole connect budget, and it works — the device log now shows `Address ... answered nothing on 2 transports`. But the phone still dialled one address eight times in a row and never reached the other five servers.

## Why the parking never stuck

The pre-flight gate probes the pool to answer "is there a network at all". A successful probe called `ReportProbe(ok=true)`, which cleared the failure streak **and the cooldown**. So the sequence was:

1. full scan condemns the address, candidate is parked;
2. gate probes the pool, the address has an open TCP port and answers;
3. the probe lifts the cooldown it had just earned;
4. selection returns the same candidate, and around it goes.

An open port says the socket is reachable. It says nothing about whether the tunnel can be established there — which is exactly what the scan had just measured. The probe now records latency only: it neither clears the streak nor lifts the cooldown. The gate still walks parked candidates, because "is there a network" is a fair question to ask of any address, but it will not pin one.

## Why the abort only fired once

Silence was judged by the wording of the error. Once the socket was closed under an attempt, the error stopped containing "timeout", so the second cycle failed to recognise the same blackhole it had recognised in the first. It is now judged by how much of the connect timeout the attempt burned, which does not depend on which layer produced the message.

## Observability

Cycles now log which candidate was chosen, which are parked and for how long, and what a failed cycle did to that candidate's health. Reading the previous log, there was no way to tell "never parked" from "parked and chosen again" — the two need different fixes, and guessing between them costs a round trip to the device.

One more line was lying: the connectivity check named the address the walk *started* from, not the one that answered. On the device it read as "this server is up" when the verdict had come from a different server entirely.

## Verification

Both halves broken against the finished code: restoring the streak/cooldown clear in `ReportProbe` reddens `TestSuccessfulProbeDoesNotLiftACooldown` and `TestReportProbeDoesNotClearTheFailureStreak`; the silence-detection change is covered by the cycle tests in `endpoint_preflight_park_test.go`.

Gate clean: build, vet, `go test ./... -race -short`, `golangci-lint run` 0 issues.