### PR TITLE
feat(tun): exceptions for the IPv6 leak block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **`-tun-ipv6-allow`: exceptions to the IPv6 leak block.** A node holding a
+  Hurricane Electric 6in4 tunnel lost its IPv6 entirely when four tiredvpn
+  clients came up on it. None of them set `-tun-ipv6`, so the default `dual`
+  applied; none of the exits could carry IPv6, so each client fell back to
+  blocking; and each block ended in a reject that swallowed everything leaving
+  through `he6`. The interface stayed up and kept its address, which is what
+  made it read as a routing fault rather than a firewall one. There was no way
+  to punch a hole: the allow list existed, but it was computed from the
+  client's own server addresses and nothing outside could add to it.
+  `-tun-ipv6-allow` takes a comma-separated list of interface names
+  (`he6`) and IPv6 prefixes or addresses (`2001:db8:77b::/64`), each of
+  which becomes an accept rule ahead of the final reject. An interface that
+  does not exist yet is accepted, since a tunnel unit may start after the
+  client and nftables matches the name once the device appears; a malformed
+  prefix is a startup error, because it cannot become correct later and
+  skipping it would leave an operator believing in a hole that was never
+  punched. Also available as `[tun] ipv6_allow` in the client TOML, so a unit
+  configured entirely from a file can use it.
+
 ## [1.8.2] - 2026-08-29
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,17 @@ Versions follow [Semantic Versioning](https://semver.org/).
   punched. Also available as `[tun] ipv6_allow` in the client TOML, so a unit
   configured entirely from a file can use it.
 
+- **The block now says what it is about to cut on a host that carries IPv6 of
+  its own.** At install time the client names any v6 tunnel interface (`sit`,
+  `wireguard`, `gre` and friends) that holds a global address and is not
+  excepted, with the flag that would spare it. On a host with
+  `net.ipv6.conf.all.forwarding=1` it adds what that does and does not mean:
+  the chain is hooked at `output`, which only sees locally originated packets,
+  so IPv6 the host *forwards* is not touched and a router keeps routing. What
+  stops is the router's own outbound IPv6 - DNS, updates, tunnel and
+  monitoring traffic. The block still goes in either way; the decision stays
+  with the operator.
+
 ## [1.8.2] - 2026-08-29
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -277,6 +277,10 @@ what a split tunnel usually wants - `dual` sends *all* IPv6 into the tunnel,
 including destinations you deliberately routed around it on IPv4. The blocking
 half is Linux-only; on macOS it warns instead.
 
+If the host carries IPv6 of its own - a 6in4 tunnel, another VPN, a routed
+prefix - name it with `-tun-ipv6-allow he6,2001:db8::/32` (interface names,
+prefixes, or both) and the block leaves it alone.
+
 ---
 
 ## Configuration
@@ -351,6 +355,7 @@ Generate the B1 key pair with `tiredvpn reality-keygen`.
 | `-tun` | `false` | Enable TUN mode (full VPN) |
 | `-tun-routes` | | Routes to tunnel (e.g. `0.0.0.0/0`) |
 | `-tun-ipv6` | `dual` | IPv6 while the tunnel is up: `dual`, `block`, `off` |
+| `-tun-ipv6-allow` | | Exceptions to the IPv6 block: interface names and/or prefixes, comma-separated |
 | `-tun-mtu` | `1280` | TUN MTU; with `-auto-mtu` this is the upper bound |
 | `-auto-mtu` | `true` | Probe the real end-to-end MTU and apply `min(probed, -tun-mtu)` |
 | `-quic` | `false` | Enable QUIC transport |

--- a/cmd/tiredvpn/config.go
+++ b/cmd/tiredvpn/config.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/tiredvpn/tiredvpn/internal/client"
 	tomlcfg "github.com/tiredvpn/tiredvpn/internal/config/toml"
@@ -25,6 +26,8 @@ import (
 //   - [selection]                  → cfg.Selection
 //   - strategy.mode                → cfg.StrategyName
 //   - tls.fingerprint              → cfg.TLSFingerprint
+//   - tun.ipv6_allow               → cfg.TunIPv6Allow (joined back to the
+//     comma-separated form -tun-ipv6-allow uses)
 //   - shaper.{preset|custom}       → cfg.Shaper (built via presets.FromConfig)
 //   - logging.level                → log.SetDebug when "debug"
 //
@@ -48,6 +51,12 @@ func applyClientTOMLConfig(cfg *client.Config, path string, fs *flag.FlagSet) er
 	}
 	if tcfg.TLS.Fingerprint != "" {
 		cfg.TLSFingerprint = tcfg.TLS.Fingerprint
+	}
+	// Back to the flag's comma-separated form, which is what the runtime
+	// parses. The schema validated that no entry contains a comma, so the
+	// join round-trips.
+	if len(tcfg.Tun.IPv6Allow) > 0 {
+		cfg.TunIPv6Allow = strings.Join(tcfg.Tun.IPv6Allow, ",")
 	}
 	if tcfg.Logging.Level == "debug" {
 		log.SetDebug(true)

--- a/cmd/tiredvpn/config_servers_test.go
+++ b/cmd/tiredvpn/config_servers_test.go
@@ -209,3 +209,41 @@ func TestCollapseServers(t *testing.T) {
 		t.Errorf("collapsing an empty list = %+v, want nil", got)
 	}
 }
+
+// TestApplyClientTOMLConfig_TunIPv6Allow is the last hop of the exception list:
+// the [tun] block has to arrive in client.Config in the comma-separated form
+// the runtime parses. A schema key nobody copies over is a key that does
+// nothing, which is indistinguishable from a typo in the file.
+func TestApplyClientTOMLConfig_TunIPv6Allow(t *testing.T) {
+	path := writeClientTOML(t, `
+[server]
+address = "203.0.113.10"
+port = 443
+
+[tun]
+ipv6_allow = ["he6", "2001:db8:77b::/64"]
+`)
+	cfg := &client.Config{}
+	if err := applyClientTOMLConfig(cfg, path, clientFlagSetForTOML()); err != nil {
+		t.Fatalf("applyClientTOMLConfig: %v", err)
+	}
+	if want := "he6,2001:db8:77b::/64"; cfg.TunIPv6Allow != want {
+		t.Errorf("cfg.TunIPv6Allow = %q, want %q", cfg.TunIPv6Allow, want)
+	}
+}
+
+// TestApplyClientTOMLConfig_TunIPv6AllowAbsent: a file that says nothing must
+// not clear a list the command line already put there.
+func TestApplyClientTOMLConfig_TunIPv6AllowAbsent(t *testing.T) {
+	path := writeClientTOML(t, `
+[server]
+address = "203.0.113.10"
+`)
+	cfg := &client.Config{TunIPv6Allow: "he6"}
+	if err := applyClientTOMLConfig(cfg, path, clientFlagSetForTOML()); err != nil {
+		t.Fatalf("applyClientTOMLConfig: %v", err)
+	}
+	if cfg.TunIPv6Allow != "he6" {
+		t.Errorf("cfg.TunIPv6Allow = %q, want the CLI value to survive a silent file", cfg.TunIPv6Allow)
+	}
+}

--- a/cmd/tiredvpn/main.go
+++ b/cmd/tiredvpn/main.go
@@ -317,6 +317,14 @@ TUN MODE (Full VPN):
         Note for split tunnels: dual sends ALL IPv6 into the tunnel, including
         destinations deliberately routed around it on IPv4. Linux only; on
         macOS the blocking half is not implemented and warns.
+  -tun-ipv6-allow string
+        Exceptions to that block, comma-separated. An entry is either an
+        interface name (he6) or an IPv6 prefix or address
+        (2001:db8:77b::/64), and gets an accept rule ahead of the final
+        reject. For a host with IPv6 of its own the client knows nothing
+        about: a 6in4 tunnel, another VPN, a routed prefix. An interface that
+        does not exist yet is accepted (it may appear later); a malformed
+        prefix is a startup error.
   -tun-fd int
         Use existing TUN file descriptor - for Android VpnService (default -1)
 
@@ -646,6 +654,7 @@ func runClient(args []string) {
 	fs.BoolVar(&cfg.AutoMTU, "auto-mtu", true, "Actively probe the real end-to-end MTU and apply min(probed, -tun-mtu); floor 1280")
 	fs.StringVar(&cfg.TunRoutes, "tun-routes", "", "Routes to add (comma-separated, e.g. '0.0.0.0/0' for full tunnel)")
 	fs.StringVar(&cfg.TunIPv6Policy, "tun-ipv6", tun.DefaultIPv6Policy, "IPv6 while the tunnel is up: dual (route it through the tunnel, rejecting it when the exit cannot carry it), block (reject it without asking the exit), off (IPv4-only tunnel, host IPv6 bypasses the VPN)")
+	fs.StringVar(&cfg.TunIPv6Allow, "tun-ipv6-allow", "", "Exceptions to the IPv6 block (comma-separated): interface names (he6) and/or IPv6 prefixes or addresses (2001:db8:77b::/64) that keep working while the block is up")
 
 	// Android VpnService flags
 	fs.IntVar(&cfg.TunFd, "tun-fd", -1, "Use existing TUN file descriptor (for Android VpnService)")

--- a/cmd/tiredvpn/main_test.go
+++ b/cmd/tiredvpn/main_test.go
@@ -240,3 +240,17 @@ func TestClientHelpIPv6Default(t *testing.T) {
 		}
 	}
 }
+
+// TestClientHelpIPv6Allow keeps the hand-written help in step with the
+// -tun-ipv6-allow flag. The help is the only place the flag's two accepted
+// forms are spelled out, and it is a raw string literal nothing else reads.
+func TestClientHelpIPv6Allow(t *testing.T) {
+	if !strings.Contains(clientHelpText, "-tun-ipv6-allow string") {
+		t.Fatal("client help does not document -tun-ipv6-allow at all")
+	}
+	for _, want := range []string{"interface name", "prefix"} {
+		if !strings.Contains(clientHelpText, want) {
+			t.Errorf("client help does not describe the %q form of -tun-ipv6-allow", want)
+		}
+	}
+}

--- a/configs/client.example.toml
+++ b/configs/client.example.toml
@@ -62,6 +62,16 @@ port = 443
 # health_check = "off"   # off | active
 # recheck_interval = "5m"
 
+# --- Tunnel: exceptions to the IPv6 leak block ---
+# With -tun-ipv6 at its default (dual), an exit that cannot carry IPv6 makes
+# the client reject outbound IPv6 host-wide, so it cannot leave around the
+# tunnel. List here anything that must keep working: an interface name, an
+# IPv6 prefix, or a single address. Same as -tun-ipv6-allow, which replaces
+# this list when passed.
+#
+# [tun]
+# ipv6_allow = ["he6", "2001:db8:77b::/64"]
+
 [strategy]
 # TLS-mimicry transport. Options: reality, grpc, morph, ...
 # Optional: omit it (or leave it empty) to let the client pick a strategy.

--- a/docs/client.md
+++ b/docs/client.md
@@ -213,6 +213,14 @@ may well start after the client, and nftables matches the name once the device
 appears. A malformed prefix is a startup error: it cannot become correct later,
 and skipping it would leave you with a hole you believe is open.
 
+On a host with IPv6 forwarding on, the client says so at install time. What it
+says is narrow on purpose. The chain is hooked at `output`, which only sees
+packets the host originates, so IPv6 the host **forwards** for its LAN is not
+affected - a router keeps routing. What stops is the router's own outbound
+IPv6: DNS, updates, tunnel and monitoring traffic. The client also names any v6
+tunnel interface (`sit`, `wireguard`, `gre` and friends) that holds a global
+address and is not excepted, since that is the case worth acting on.
+
 Two things to know before flipping this on:
 
 - **Split tunnels change behaviour.** `dual` sends *all* IPv6 into the tunnel,

--- a/docs/client.md
+++ b/docs/client.md
@@ -135,6 +135,7 @@ Defaults are `failure_threshold=2`, `cooldown=1m`, `max_cooldown=30m`,
 | `-auto-mtu` | `true` | Probe the real end-to-end MTU and apply `min(probed, -tun-mtu)`; floor 1280 |
 | `-tun-routes` | | Comma-separated CIDRs to route through VPN |
 | `-tun-ipv6` | `dual` | What happens to IPv6 while the tunnel is up: `dual`, `block`, `off` |
+| `-tun-ipv6-allow` | | Exceptions to that block: comma-separated interface names and/or IPv6 prefixes that keep working |
 | `-tun-fd` | `-1` | Use an existing TUN file descriptor (Android VpnService) |
 
 An MTU outside 1280-9000 is a startup error, whether it came from the flag or
@@ -187,6 +188,30 @@ Platform coverage: Linux only. On macOS the blocking half is not implemented
 and the client warns once per session. On Android filtering belongs to
 `VpnService`, and the block is skipped because the client does not own the
 interface.
+
+##### Exceptions: `-tun-ipv6-allow`
+
+The block is host-wide, and a host may carry IPv6 the client knows nothing
+about. A node holding a Hurricane Electric 6in4 tunnel lost its IPv6 to exactly
+this: four clients came up with the default `dual`, none of their exits could
+carry IPv6, and each installed a block whose final reject swallowed everything
+leaving through `he6`. The interface stayed up and kept its address, which is
+what made it look like a routing fault.
+
+`-tun-ipv6-allow` takes a comma-separated list. An entry is either an interface
+name or an IPv6 prefix (a bare address counts as its `/128`), and each one
+becomes an accept rule ahead of the final reject:
+
+```bash
+-tun-ipv6-allow he6
+-tun-ipv6-allow he6,2001:db8:77b::/64
+-tun-ipv6-allow 2001:db8:77b::2
+```
+
+An interface that does not exist is accepted without complaint - a tunnel unit
+may well start after the client, and nftables matches the name once the device
+appears. A malformed prefix is a startup error: it cannot become correct later,
+and skipping it would leave you with a hole you believe is open.
 
 Two things to know before flipping this on:
 
@@ -435,6 +460,7 @@ which is what the bare `-strategy` default does.
 | `[tls]` | `ca_cert` | string | accepted, not yet read by the runtime |
 | `[tls]` | `insecure_skip_verify` | bool | accepted, not yet read by the runtime |
 | `[logging]` | `level` | string | only `"debug"` acts on anything - it turns on debug logging, as `-debug` does |
+| `[tun]` | `ipv6_allow` | array | same as `-tun-ipv6-allow`; one interface name or IPv6 prefix per entry |
 | `[logging]` | `format` | string | accepted, not yet read by the runtime |
 | `[logging]` | `output` | string | accepted, not yet read by the runtime |
 
@@ -442,11 +468,23 @@ which is what the bare `-strategy` default does.
 consumes it. It is listed rather than hidden so a config that sets it is not
 mistaken for a config that changes behaviour.
 
-The TUN, port-hopping, ECH, post-quantum, benchmarking and monitoring knobs
-have no TOML keys at all and stay command-line only - including `-tun-ipv6`,
-whose default therefore applies to a TOML-only client too. See the
-[migration guide](../internal/config/toml/MIGRATION.md) for the field-by-field
-table.
+The port-hopping, ECH, post-quantum, benchmarking and monitoring knobs have no
+TOML keys at all and stay command-line only. So do the TUN knobs, with one
+exception: `[tun] ipv6_allow`, which a pooled unit configured entirely from a
+file would otherwise have no way to set. `-tun-ipv6` itself is still
+command-line only, so its default applies to a TOML-only client - and a file
+that lists exceptions describes exceptions to whatever the unit's command line
+asked for. See the [migration guide](../internal/config/toml/MIGRATION.md) for
+the field-by-field table.
+
+```toml
+[tun]
+ipv6_allow = ["he6", "2001:db8:77b::/64"]
+```
+
+Passing `-tun-ipv6-allow` replaces this list rather than adding to it: "except
+these" is one statement, and a command line that has to know what the file
+already said is not an override.
 
 ### Several servers
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -74,8 +74,14 @@ type Config struct {
 
 	// TunIPv6Policy is the -tun-ipv6 value ("off" default, "dual" to route
 	// IPv6 through the tunnel when the exit negotiates dual-stack). Parsed
-	// via tun.ParseIPv6Policy in runTUNMode.
+	// via tun.ParseIPv6Policy in newTUNVPNConfig.
 	TunIPv6Policy string
+
+	// TunIPv6Allow is the -tun-ipv6-allow value: a comma-separated list of
+	// interface names and IPv6 prefixes the leak block must leave alone, in
+	// the same raw form TunRoutes has. Parsed via tun.ParseIPv6AllowList in
+	// newTUNVPNConfig. Empty means no exceptions, the historical behaviour.
+	TunIPv6Allow string
 
 	// Host-supplied TUN integration (Android VpnService / macOS NetworkExtension).
 	// In both modes the TUN fd is created by the host and passed in via TunFd;
@@ -774,9 +780,13 @@ func sendReconnectHandshake(conn net.Conn, currentIP net.IP, mtu int, dualStack 
 	return serverIP, assignedIP, serverIP6, assignedIP6, nil
 }
 
-func runTUNMode(cfg *Config, mgr *strategy.Manager, sigChan chan os.Signal) error {
-	log.Info("Starting TUN mode")
-
+// newTUNVPNConfig maps the client config onto the TUN layer's VPNConfig.
+//
+// Its own function rather than a block inside runTUNMode because everything it
+// does is a mapping that can be wrong quietly: a flag parsed correctly and then
+// not carried into the struct behaves exactly like a flag that was never
+// passed.
+func newTUNVPNConfig(cfg *Config, mgr *strategy.Manager) (tun.VPNConfig, error) {
 	// IPv6 policy: dual (the default) opts into the v0x04 dual-stack handshake
 	// and blocks outbound IPv6 when the exit declines it; off keeps the tunnel
 	// v4-only and leaves host IPv6 alone. Empty means the flag was never set -
@@ -788,7 +798,15 @@ func runTUNMode(cfg *Config, mgr *strategy.Manager, sigChan chan os.Signal) erro
 	}
 	policy, err := tun.ParseIPv6Policy(ipv6Policy)
 	if err != nil {
-		return err
+		return tun.VPNConfig{}, err
+	}
+
+	// Exceptions to that block. A bad prefix here fails the start: it can only
+	// be a typo, and a client that ran anyway would leave the operator with a
+	// hole they believe is open.
+	ipv6Allow, err := tun.ParseIPv6AllowList(cfg.TunIPv6Allow)
+	if err != nil {
+		return tun.VPNConfig{}, err
 	}
 
 	// Parse routes
@@ -797,14 +815,13 @@ func runTUNMode(cfg *Config, mgr *strategy.Manager, sigChan chan os.Signal) erro
 		routes = append(routes, splitRoutes(cfg.TunRoutes)...)
 	}
 
-	// Create VPN client
 	// Handle "auto" TunIP for Android VpnService
 	localIP := net.ParseIP(cfg.TunIP)
 	if localIP == nil && cfg.TunIP == "auto" {
 		localIP = net.ParseIP("10.8.0.2") // Default client IP
 	}
 
-	vpnCfg := tun.VPNConfig{
+	return tun.VPNConfig{
 		TunName:  cfg.TunName,
 		MTU:      cfg.TunMTU,
 		LocalIP:  localIP,
@@ -825,8 +842,18 @@ func runTUNMode(cfg *Config, mgr *strategy.Manager, sigChan chan os.Signal) erro
 		// "dual or not" silently turns -tun-ipv6 block into off, since block
 		// negotiates nothing and would be indistinguishable from it.
 		IPv6Policy:  policy,
+		IPv6Allow:   ipv6Allow,
 		TunFd:       cfg.TunFd,       // Android VpnService TUN fd
 		ProtectPath: cfg.ProtectPath, // Android socket protection path
+	}, nil
+}
+
+func runTUNMode(cfg *Config, mgr *strategy.Manager, sigChan chan os.Signal) error {
+	log.Info("Starting TUN mode")
+
+	vpnCfg, err := newTUNVPNConfig(cfg, mgr)
+	if err != nil {
+		return err
 	}
 
 	vpnClient, err := tun.NewVPNClient(vpnCfg)
@@ -877,8 +904,8 @@ func runTUNMode(cfg *Config, mgr *strategy.Manager, sigChan chan os.Signal) erro
 	// echoed back the requested one. Which of the two gets printed is decided
 	// inside logVPNStarted, where a test can hold it to the assigned one.
 	logVPNStarted(cfg, vpnClient)
-	if len(routes) > 0 {
-		log.Info("Routes: %v", routes)
+	if len(vpnCfg.Routes) > 0 {
+		log.Info("Routes: %v", vpnCfg.Routes)
 	}
 
 	// Initialize metrics if API addr is configured (TUN mode, no pool yet)

--- a/internal/client/tunvpnconfig_test.go
+++ b/internal/client/tunvpnconfig_test.go
@@ -1,0 +1,60 @@
+package client
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestNewTUNVPNConfigIPv6Allow is the callsite test for -tun-ipv6-allow: the
+// value has to survive the trip from the client config into the TUN layer's
+// VPNConfig. Parsing it correctly and then leaving it behind here would look
+// exactly like never passing the flag.
+func TestNewTUNVPNConfigIPv6Allow(t *testing.T) {
+	cfg := &Config{
+		TunName:    "tiredvpn0",
+		TunIP:      "10.8.0.2",
+		TunPeerIP:  "10.8.0.1",
+		ServerAddr: "203.0.113.10:443",
+		// The ruhop spelling: an interface and the prefix behind it.
+		TunIPv6Allow: "he6,2001:db8:77b::/64",
+	}
+
+	vpnCfg, err := newTUNVPNConfig(cfg, nil)
+	if err != nil {
+		t.Fatalf("newTUNVPNConfig: %v", err)
+	}
+	if got := vpnCfg.IPv6Allow.Interfaces; len(got) != 1 || got[0] != "he6" {
+		t.Errorf("IPv6Allow.Interfaces = %v, want [he6]", got)
+	}
+	if got := vpnCfg.IPv6Allow.Prefixes; len(got) != 1 || got[0].String() != "2001:db8:77b::/64" {
+		t.Errorf("IPv6Allow.Prefixes = %v, want [2001:db8:77b::/64]", got)
+	}
+}
+
+// TestNewTUNVPNConfigIPv6AllowEmpty: an unset flag must leave the block exactly
+// as it was, not produce a one-entry list of "".
+func TestNewTUNVPNConfigIPv6AllowEmpty(t *testing.T) {
+	vpnCfg, err := newTUNVPNConfig(&Config{TunIP: "10.8.0.2", ServerAddr: "203.0.113.10:443"}, nil)
+	if err != nil {
+		t.Fatalf("newTUNVPNConfig: %v", err)
+	}
+	if !vpnCfg.IPv6Allow.Empty() {
+		t.Errorf("an unset -tun-ipv6-allow produced %v", vpnCfg.IPv6Allow)
+	}
+}
+
+// TestNewTUNVPNConfigIPv6AllowBadSpec: a malformed prefix stops the client
+// instead of quietly leaving the operator with a hole that was never punched.
+func TestNewTUNVPNConfigIPv6AllowBadSpec(t *testing.T) {
+	_, err := newTUNVPNConfig(&Config{
+		TunIP:        "10.8.0.2",
+		ServerAddr:   "203.0.113.10:443",
+		TunIPv6Allow: "he6,2001:db8:::/64",
+	}, nil)
+	if err == nil {
+		t.Fatal("a malformed prefix started the client anyway")
+	}
+	if !strings.Contains(err.Error(), "tun-ipv6-allow") {
+		t.Errorf("error %q does not name the flag at fault", err)
+	}
+}

--- a/internal/config/toml/MIGRATION.md
+++ b/internal/config/toml/MIGRATION.md
@@ -27,6 +27,7 @@ default: loading fails and the error names the key and its position.
 | `--prefer-ipv6` / `--fallback-v4` | `[selection] family`       | `true`+`true` → `prefer_v6`, `true`+`false` → `v6_only`, `false` → `v4_only` for any fallback |
 | `--strategy=NAME`             | `[strategy] mode`              | optional; empty means the client picks |
 | `--tls-fingerprint=NAME`      | `[tls] fingerprint`            | **exception to the precedence rule**: a non-empty key in the file overwrites the flag |
+| `--tun-ipv6-allow=LIST`       | `[tun] ipv6_allow`             | comma-separated flag, one entry per array element in the file; the flag replaces the list, it does not extend it |
 | `--shaper=NAME`               | `[shaper] preset`              | an explicit `--shaper` is applied after TOML and wins |
 | `--shaper-seed=N`             | `[shaper] seed`                | the flag is read only alongside `--shaper`; the file's `seed` belongs to `[shaper]` |
 | `--debug`                     | `[logging] level = "debug"`    | flag forces level only when `true`; no other level value does anything yet |
@@ -72,9 +73,10 @@ yet: a server config that omits them fails validation.
 ## Flags with no TOML key
 
 Everything not in the tables above is still read straight from the FlagSet by
-`cmd/tiredvpn`: `--listen` and `--secret` on the client, the whole `--tun-*`
-family (including `--tun-ipv6`, whose default of `dual` therefore applies to a
-TOML-only client as well), port hopping, ECH, post-quantum, REALITY B1,
+`cmd/tiredvpn`: `--listen` and `--secret` on the client, the `--tun-*` family
+except `--tun-ipv6-allow` (`--tun-ipv6` itself included, so its default of
+`dual` applies to a TOML-only client as well), port hopping, ECH,
+post-quantum, REALITY B1,
 burst-reshape, benchmarking, `--api-addr`, `--pprof`, `--list`. They will be
 migrated in follow-up issues.
 

--- a/internal/config/toml/client.go
+++ b/internal/config/toml/client.go
@@ -15,6 +15,12 @@ type ClientConfig struct {
 	TLS      ClientTLS      `toml:"tls"`
 	Logging  Logging        `toml:"logging"`
 
+	// Tun holds the tunnel settings that have to survive in a config file
+	// rather than a command line. Most -tun-* flags are still CLI-only; this
+	// block exists for the ones a pooled, file-configured unit cannot do
+	// without.
+	Tun ClientTun `toml:"tun"`
+
 	// Selection tunes how the client picks among the servers above. It is a
 	// pointer so "absent" is distinguishable from "all zero": absent means the
 	// legacy CLI flags decide, all-zero would mean the same but says it
@@ -57,6 +63,41 @@ type ClientServer struct {
 // does not: it is the default that DefaultClient() puts there.
 func (s ClientServer) hasAddress() bool {
 	return s.Address != "" || s.AddressV6 != ""
+}
+
+// ClientTun is the [tun] block.
+type ClientTun struct {
+	// IPv6Allow lists exceptions to the IPv6 leak block: interface names
+	// ("he6") and/or IPv6 prefixes and addresses
+	// ("2001:db8:77b::/64"). It is a list rather than the flag's
+	// comma-separated string because a TOML file has arrays and nothing is
+	// gained by making the reader split one by eye; the runtime joins it back
+	// into the flag's form, which is why entries must not contain a comma
+	// (neither an interface name nor an IPv6 prefix ever does).
+	//
+	// The block itself has no key here: -tun-ipv6 stays CLI-only, so a file
+	// that only lists exceptions describes exceptions to whatever the unit's
+	// command line asked for.
+	IPv6Allow []string `toml:"ipv6_allow,omitempty"`
+}
+
+// validate checks only what is a property of this representation: the entries
+// are joined with commas on the way to the runtime, so a comma inside one would
+// silently become two exceptions, and an empty entry would become none.
+//
+// What an entry MEANS - interface name, prefix, or nonsense - is decided by
+// tun.ParseIPv6AllowList at startup, in one place, for the flag and the file
+// alike. Re-deciding it here would give the two forms two chances to disagree.
+func (t ClientTun) validate() error {
+	for i, entry := range t.IPv6Allow {
+		if strings.Contains(entry, ",") {
+			return fmt.Errorf("tun.ipv6_allow[%d]: %q contains a comma; put each interface or prefix in its own list entry", i, entry)
+		}
+		if strings.TrimSpace(entry) == "" {
+			return fmt.Errorf("tun.ipv6_allow[%d] is empty", i)
+		}
+	}
+	return nil
 }
 
 // Selection is the [selection] block: which server to dial and when to give up
@@ -298,6 +339,10 @@ func (c *ClientConfig) Validate() error {
 	// manager pick", which is the default of the -strategy flag and the only
 	// sane setting for a censorship-resistant client. Demanding it here made
 	// automatic strategy selection unreachable from a config file.
+
+	if err := c.Tun.validate(); err != nil {
+		return err
+	}
 
 	if _, err := c.Selection.Resolve(); err != nil {
 		return err

--- a/internal/config/toml/override.go
+++ b/internal/config/toml/override.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"strconv"
+	"strings"
 
 	"github.com/tiredvpn/tiredvpn/internal/endpoint"
 	"github.com/tiredvpn/tiredvpn/internal/log"
@@ -23,6 +24,7 @@ import (
 //	-prefer-ipv6   → selection.family (with -fallback-v4; see familyFromLegacyFlags)
 //	-fallback-v4   → selection.family
 //	-strategy      → strategy.mode
+//	-tun-ipv6-allow → tun.ipv6_allow (comma-separated → list)
 //	-debug         → logging.level = "debug" (when true)
 //
 // Flags absent from this mapping are ignored — they belong to subsystems
@@ -65,6 +67,11 @@ func ApplyClientFlags(cfg *ClientConfig, fs *flag.FlagSet) error {
 			}
 		case "server-policy":
 			cfg.selection().Policy = f.Value.String()
+		case "tun-ipv6-allow":
+			// The flag replaces the file's list rather than adding to it:
+			// "except these" is one statement, and a command line that has to
+			// know what the file already said is not an override.
+			cfg.Tun.IPv6Allow = splitCommaList(f.Value.String())
 		case "strategy":
 			cfg.Strategy.Mode = f.Value.String()
 		case "debug":
@@ -293,6 +300,11 @@ func mergeClient(dst, src *ClientConfig) {
 	if src.Shaper != nil {
 		dst.Shaper = src.Shaper
 	}
+	// Atomic, like the server list and ALPN: an exception list half from the
+	// defaults and half from the file is not something a reader could predict.
+	if len(src.Tun.IPv6Allow) > 0 {
+		dst.Tun.IPv6Allow = src.Tun.IPv6Allow
+	}
 	if src.TLS.ServerName != "" {
 		dst.TLS.ServerName = src.TLS.ServerName
 	}
@@ -361,6 +373,19 @@ func mergeLogging(dst, src *Logging) {
 	if src.Output != "" {
 		dst.Output = src.Output
 	}
+}
+
+// splitCommaList turns a comma-separated flag value into the list form the
+// schema stores, dropping empty entries and surrounding whitespace so that
+// "he6, 2001:db8::/64" and "he6,2001:db8::/64" are the same two exceptions.
+func splitCommaList(s string) []string {
+	var out []string
+	for _, part := range strings.Split(s, ",") {
+		if part = strings.TrimSpace(part); part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
 }
 
 // splitHostPort accepts "host:port" or bare ":port" and returns parts.

--- a/internal/config/toml/tun_test.go
+++ b/internal/config/toml/tun_test.go
@@ -1,0 +1,105 @@
+package toml
+
+import (
+	"flag"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeTunTOML(t *testing.T, body string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "client.toml")
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func tunFlagSet() *flag.FlagSet {
+	fs := flag.NewFlagSet("client", flag.ContinueOnError)
+	fs.String("server", "", "")
+	fs.String("tun-ipv6-allow", "", "")
+	return fs
+}
+
+// TestClientTOML_TunIPv6Allow: the whole point of putting the exceptions in the
+// schema is that a unit configured from a file - the server pool - can carry
+// them. A flag-only knob would be unreachable there.
+func TestClientTOML_TunIPv6Allow(t *testing.T) {
+	path := writeTunTOML(t, `
+[server]
+address = "203.0.113.10"
+port = 443
+
+[tun]
+ipv6_allow = ["he6", "2001:db8:77b::/64"]
+`)
+	cfg, err := ResolveClient(path, tunFlagSet())
+	if err != nil {
+		t.Fatalf("ResolveClient: %v", err)
+	}
+	if got := strings.Join(cfg.Tun.IPv6Allow, ","); got != "he6,2001:db8:77b::/64" {
+		t.Errorf("tun.ipv6_allow = %q, want the two entries from the file", got)
+	}
+}
+
+// TestClientTOML_TunIPv6AllowFlagWins pins the precedence the rest of the
+// schema follows: an explicit flag replaces the file's list rather than adding
+// to it.
+func TestClientTOML_TunIPv6AllowFlagWins(t *testing.T) {
+	path := writeTunTOML(t, `
+[server]
+address = "203.0.113.10"
+
+[tun]
+ipv6_allow = ["he6"]
+`)
+	fs := tunFlagSet()
+	if err := fs.Parse([]string{"-tun-ipv6-allow", "wg0, 2001:db8::/32"}); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := ResolveClient(path, fs)
+	if err != nil {
+		t.Fatalf("ResolveClient: %v", err)
+	}
+	if got := strings.Join(cfg.Tun.IPv6Allow, "|"); got != "wg0|2001:db8::/32" {
+		t.Errorf("tun.ipv6_allow = %q, want the flag's two entries with whitespace trimmed", got)
+	}
+}
+
+// TestClientTOML_TunIPv6AllowUntouched: a file that says nothing about the
+// block leaves it alone. An empty flag value must not read as "the operator
+// asked for an empty list".
+func TestClientTOML_TunIPv6AllowUntouched(t *testing.T) {
+	path := writeTunTOML(t, `
+[server]
+address = "203.0.113.10"
+
+[tun]
+ipv6_allow = ["he6"]
+`)
+	cfg, err := ResolveClient(path, tunFlagSet()) // flag registered, never passed
+	if err != nil {
+		t.Fatalf("ResolveClient: %v", err)
+	}
+	if got := strings.Join(cfg.Tun.IPv6Allow, ","); got != "he6" {
+		t.Errorf("an unpassed flag overwrote the file: %q", got)
+	}
+}
+
+// TestClientTOML_TunIPv6AllowRejectsUnjoinable guards the representation: the
+// list is joined with commas on the way to the runtime, so an entry holding one
+// would silently become two exceptions.
+func TestClientTOML_TunIPv6AllowRejectsUnjoinable(t *testing.T) {
+	for _, body := range []string{
+		`ipv6_allow = ["he6,wg0"]`,
+		`ipv6_allow = ["he6", "  "]`,
+	} {
+		path := writeTunTOML(t, "[server]\naddress = \"203.0.113.10\"\n\n[tun]\n"+body+"\n")
+		if _, err := ResolveClient(path, tunFlagSet()); err == nil {
+			t.Errorf("%s was accepted", body)
+		}
+	}
+}

--- a/internal/tun/ipv6allow.go
+++ b/internal/tun/ipv6allow.go
@@ -1,0 +1,166 @@
+package tun
+
+import (
+	"fmt"
+	"net"
+	"strings"
+)
+
+// The -tun-ipv6-allow exception list.
+//
+// The IPv6 leak block (ipv6block_linux.go) rejects every outbound IPv6 packet
+// that is not going through the tunnel. On a plain host that is the whole
+// point. On a host that carries IPv6 for a reason of its own it is a
+// regression: a node holding a Hurricane Electric 6in4 tunnel (interface he6,
+// 2001:db8:77b::2/64) lost its IPv6 outright the moment four tiredvpn
+// clients came up on it — none of them had -tun-ipv6 set, the default dual
+// policy found exits that could not carry IPv6, and each installed a block
+// whose final reject swallowed everything leaving through he6.
+//
+// The exceptions are the operator's answer to that: name the interface, or the
+// prefix, that has to keep working, and it gets an accept rule ahead of the
+// reject.
+
+// ipv6AllowMaxIfNameLen is IFNAMSIZ-1: the longest interface name the kernel
+// stores. The nftables oifname match is a fixed 16-byte field, so a longer name
+// would be silently truncated into a match on something else — rejected at
+// parse time instead.
+const ipv6AllowMaxIfNameLen = 15
+
+// IPv6AllowList is a parsed -tun-ipv6-allow value: outbound interfaces whose
+// IPv6 stays untouched, and destination prefixes that stay reachable whatever
+// interface they leave through.
+//
+// The zero value is an empty list, which is the pre-flag behaviour.
+type IPv6AllowList struct {
+	// Interfaces are matched on oifname, the same way the tunnel's own accept
+	// rule is. This is the form that fits a v6 transport the host owns (he6,
+	// a WireGuard link, another VPN): the operator knows the device, not the
+	// set of addresses that will travel over it.
+	Interfaces []string
+
+	// Prefixes are matched on the destination address. A bare address parses
+	// to its /128, so "keep this one peer reachable" needs no mask.
+	Prefixes []*net.IPNet
+}
+
+// Empty reports whether the list holds nothing, i.e. the block is built exactly
+// as it was before the flag existed.
+func (a IPv6AllowList) Empty() bool {
+	return len(a.Interfaces) == 0 && len(a.Prefixes) == 0
+}
+
+// String renders the list the way it was written on the command line, for logs.
+func (a IPv6AllowList) String() string {
+	parts := make([]string, 0, len(a.Interfaces)+len(a.Prefixes))
+	parts = append(parts, a.Interfaces...)
+	for _, p := range a.Prefixes {
+		parts = append(parts, p.String())
+	}
+	return strings.Join(parts, ",")
+}
+
+// ParseIPv6AllowList parses a comma-separated -tun-ipv6-allow value. Each entry
+// is either an interface name ("he6"), an IPv6 prefix
+// ("2001:db8:77b::/64") or a single IPv6 address, which becomes its /128.
+// An empty string parses to an empty list.
+//
+// Telling the two forms apart is not a guess: the kernel's dev_valid_name
+// rejects '/' and ':' in an interface name, and every IPv6 literal contains a
+// ':'. So an entry with either character is an address and is parsed as one;
+// anything else is a device name.
+//
+// What is an error and what is not follows from when it can be detected:
+//
+//   - An interface that does not exist is NOT an error. Names come and go — a
+//     6in4 tunnel is created by a unit that may start after the client, and
+//     nftables stores an oifname match for a device that does not exist yet,
+//     matching it once it appears. Refusing to start here would turn a boot
+//     ordering detail into a failure.
+//   - A malformed prefix IS an error. "2001:db8:77b::/129" or "2001:db8:::/64"
+//     cannot become correct later; skipping it silently would leave the
+//     operator with a running client, no message, and a hole they believe is
+//     open. The same goes for an IPv4 entry: the block is an ip6 table and
+//     never sees IPv4, so a v4 exception is a misunderstanding worth stopping
+//     for rather than a no-op.
+func ParseIPv6AllowList(spec string) (IPv6AllowList, error) {
+	var out IPv6AllowList
+	for _, raw := range strings.Split(spec, ",") {
+		entry := strings.TrimSpace(raw)
+		if entry == "" {
+			continue
+		}
+		if strings.ContainsAny(entry, ":/") {
+			netw, err := parseIPv6AllowPrefix(entry)
+			if err != nil {
+				return IPv6AllowList{}, err
+			}
+			out.Prefixes = append(out.Prefixes, netw)
+			continue
+		}
+		// A bare IPv4 address has neither ':' nor '/', so the rule above would
+		// file it as a device name and the client would start with an
+		// exception matching an interface literally called "192.0.2.1". It is
+		// a misunderstanding of what the block filters, and it is caught here
+		// rather than left to look like it worked.
+		if ip := net.ParseIP(entry); ip != nil && ip.To4() != nil {
+			return IPv6AllowList{}, fmt.Errorf(
+				"tun-ipv6-allow: %q is an IPv4 address; the leak block only filters IPv6, so IPv4 needs no exception", entry)
+		}
+		if len(entry) > ipv6AllowMaxIfNameLen {
+			return IPv6AllowList{}, fmt.Errorf(
+				"tun-ipv6-allow: interface name %q is %d characters, the kernel allows at most %d",
+				entry, len(entry), ipv6AllowMaxIfNameLen)
+		}
+		out.Interfaces = append(out.Interfaces, entry)
+	}
+	return out, nil
+}
+
+// parseIPv6AllowPrefix turns one address-shaped entry into the network its
+// accept rule matches: a prefix as written (masked, so host bits in
+// "2001:db8::1/64" do not narrow the rule), a bare address as its /128.
+func parseIPv6AllowPrefix(entry string) (*net.IPNet, error) {
+	if strings.Contains(entry, "/") {
+		ip, netw, err := net.ParseCIDR(entry)
+		if err != nil {
+			return nil, fmt.Errorf("tun-ipv6-allow: %q is not a valid IPv6 prefix: %w", entry, err)
+		}
+		if ip.To4() != nil {
+			return nil, fmt.Errorf(
+				"tun-ipv6-allow: %q is an IPv4 prefix; the leak block only filters IPv6, so IPv4 needs no exception", entry)
+		}
+		return netw, nil
+	}
+	ip := net.ParseIP(entry)
+	if ip == nil {
+		return nil, fmt.Errorf("tun-ipv6-allow: %q is neither an interface name nor an IPv6 address", entry)
+	}
+	if ip.To4() != nil {
+		return nil, fmt.Errorf(
+			"tun-ipv6-allow: %q is an IPv4 address; the leak block only filters IPv6, so IPv4 needs no exception", entry)
+	}
+	return &net.IPNet{IP: ip.To16(), Mask: net.CIDRMask(128, 128)}, nil
+}
+
+// coversIP reports whether some prefix in the list contains ip. Used by the
+// router warning to tell "this interface loses its IPv6" from "this interface
+// is already excepted".
+func (a IPv6AllowList) coversIP(ip net.IP) bool {
+	for _, p := range a.Prefixes {
+		if p.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// hasInterface reports whether name is excepted by device name.
+func (a IPv6AllowList) hasInterface(name string) bool {
+	for _, iface := range a.Interfaces {
+		if iface == name {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/tun/ipv6allow_test.go
+++ b/internal/tun/ipv6allow_test.go
@@ -1,0 +1,149 @@
+package tun
+
+import (
+	"net"
+	"strings"
+	"testing"
+)
+
+// TestParseIPv6AllowList pins the flag surface: which entries are interfaces,
+// which are prefixes, and which stop the client from starting at all. The last
+// group is the one that matters most — an exception silently dropped leaves the
+// operator with a block they believe has a hole in it.
+func TestParseIPv6AllowList(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		spec       string
+		wantIfaces []string
+		wantNets   []string
+		wantErr    string
+	}{
+		{name: "empty", spec: ""},
+		{name: "only separators", spec: " , ,"},
+		{
+			name:       "interface",
+			spec:       "he6",
+			wantIfaces: []string{"he6"},
+		},
+		{
+			name:     "prefix",
+			spec:     "2001:db8:77b::/64",
+			wantNets: []string{"2001:db8:77b::/64"},
+		},
+		{
+			name:     "bare address becomes a /128",
+			spec:     "2001:db8:77b::2",
+			wantNets: []string{"2001:db8:77b::2/128"},
+		},
+		{
+			name:     "host bits in a prefix do not narrow it",
+			spec:     "2001:db8:77b::2/64",
+			wantNets: []string{"2001:db8:77b::/64"},
+		},
+		{
+			name:       "mixed, with whitespace",
+			spec:       " he6 , 2001:db8:77b::/64 ,wg0",
+			wantIfaces: []string{"he6", "wg0"},
+			wantNets:   []string{"2001:db8:77b::/64"},
+		},
+		{
+			// An interface that does not exist yet is deliberately accepted:
+			// the 6in4 unit may start after the client, and nftables matches
+			// an oifname that appears later.
+			name:       "unknown interface is not an error",
+			spec:       "definitely-no",
+			wantIfaces: []string{"definitely-no"},
+		},
+		{
+			name:    "malformed prefix",
+			spec:    "he6,2001:db8:::/64",
+			wantErr: "not a valid IPv6 prefix",
+		},
+		{
+			name:    "prefix length out of range",
+			spec:    "2001:db8:77b::/129",
+			wantErr: "not a valid IPv6 prefix",
+		},
+		{
+			name:    "IPv4 prefix",
+			spec:    "192.0.2.0/24",
+			wantErr: "only filters IPv6",
+		},
+		{
+			name:    "IPv4 address",
+			spec:    "192.0.2.1",
+			wantErr: "only filters IPv6",
+		},
+		{
+			name:    "interface name longer than IFNAMSIZ",
+			spec:    "a-very-long-interface-name",
+			wantErr: "the kernel allows at most",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseIPv6AllowList(tc.spec)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("ParseIPv6AllowList(%q) = %v, want error containing %q", tc.spec, got, tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("error %q does not mention %q", err, tc.wantErr)
+				}
+				if !got.Empty() {
+					t.Errorf("a failed parse returned %v, want nothing usable", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseIPv6AllowList(%q): %v", tc.spec, err)
+			}
+			if !equalStrings(got.Interfaces, tc.wantIfaces) {
+				t.Errorf("interfaces = %v, want %v", got.Interfaces, tc.wantIfaces)
+			}
+			var nets []string
+			for _, n := range got.Prefixes {
+				nets = append(nets, n.String())
+			}
+			if !equalStrings(nets, tc.wantNets) {
+				t.Errorf("prefixes = %v, want %v", nets, tc.wantNets)
+			}
+			if want := len(tc.wantIfaces)+len(tc.wantNets) == 0; got.Empty() != want {
+				t.Errorf("Empty() = %v, want %v", got.Empty(), want)
+			}
+		})
+	}
+}
+
+// TestIPv6AllowListLookups covers the two questions the router warning asks of
+// a parsed list: is this interface excepted, and is this address already inside
+// an excepted prefix.
+func TestIPv6AllowListLookups(t *testing.T) {
+	a, err := ParseIPv6AllowList("he6,2001:db8:77b::/64")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !a.hasInterface("he6") {
+		t.Error("he6 is in the list but hasInterface says no")
+	}
+	if a.hasInterface("he60") {
+		t.Error("he60 is not in the list but hasInterface says yes")
+	}
+	if !a.coversIP(net.ParseIP("2001:db8:77b::2")) {
+		t.Error("an address inside the excepted prefix reads as not covered")
+	}
+	if a.coversIP(net.ParseIP("2001:db8:77c::2")) {
+		t.Error("an address outside the excepted prefix reads as covered")
+	}
+}
+
+func equalStrings(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/tun/ipv6block_linux.go
+++ b/internal/tun/ipv6block_linux.go
@@ -327,6 +327,9 @@ func (t *TUNDevice) ApplyIPv6LeakBlock() {
 		log.Debug("IPv6 leak block re-asserted for %s (allow: %v %s)", t.name, allow, extra)
 		return
 	}
+	for _, w := range ipv6BlockWarnings(t.name, extra, readHostV6State()) {
+		log.Warn("%s", w)
+	}
 	log.Info("IPv6 leak block active: outbound IPv6 rejected except %s, %s, %s, %v and %q "+
 		"(the tunnel is not carrying IPv6; use -tun-ipv6=off to opt out). "+
 		"If the client is killed without cleanup, remove it with "+

--- a/internal/tun/ipv6block_linux.go
+++ b/internal/tun/ipv6block_linux.go
@@ -72,8 +72,13 @@ type v6BlockRule struct {
 //  4. ff00::/8          — multicast: RA/NS/MLD, mDNS, LLMNR
 //  5. <allow>/128       — the VPN server itself, so the transport can still
 //     reach an exit dialled over IPv6
-//  6. reject            — everything else, including all global unicast
-func ipv6BlockPlan(ifName string, allow []net.IP) []v6BlockRule {
+//  6. <extra>           — the operator's -tun-ipv6-allow exceptions, by
+//     outbound interface and by destination prefix
+//  7. reject            — everything else, including all global unicast
+//
+// The exceptions come last among the accepts on purpose: with an empty list the
+// plan is the one that shipped before the flag existed, rule for rule.
+func ipv6BlockPlan(ifName string, allow []net.IP, extra IPv6AllowList) []v6BlockRule {
 	rules := []v6BlockRule{
 		{Name: "accept " + loopbackIfName, Exprs: v6AcceptOifRule(loopbackIfName)},
 	}
@@ -103,6 +108,29 @@ func ipv6BlockPlan(ifName string, allow []net.IP) []v6BlockRule {
 		rules = append(rules, v6BlockRule{
 			Name:  "accept " + host.String(),
 			Exprs: v6AcceptDaddrRule(host),
+		})
+	}
+	// Operator exceptions. Both forms are already expressible: an interface is
+	// the same oifname match the tunnel's own accept uses, a prefix the same
+	// destination match as the server holes — the only thing the server holes
+	// could not express is a mask other than /128, which ParseIPv6AllowList
+	// hands over ready-made.
+	for _, iface := range extra.Interfaces {
+		if iface == "" {
+			continue
+		}
+		rules = append(rules, v6BlockRule{
+			Name:  "accept " + iface,
+			Exprs: v6AcceptOifRule(iface),
+		})
+	}
+	for _, pfx := range extra.Prefixes {
+		if pfx == nil {
+			continue
+		}
+		rules = append(rules, v6BlockRule{
+			Name:  "accept " + pfx.String(),
+			Exprs: v6AcceptDaddrRule(pfx),
 		})
 	}
 	return append(rules, v6BlockRule{Name: "reject", Exprs: v6RejectRule()})
@@ -139,11 +167,14 @@ func v6RejectRule() []expr.Any {
 	return []expr.Any{&expr.Reject{Type: nftRejectICMPUnreach, Code: icmp6AdminProhibited}}
 }
 
-// installIPv6LeakBlock creates (or replaces) the leak-block table for ifName.
-// The delete runs in its own flush first, mirroring installNAT6Rules, so
-// re-running after a reconnect replaces the rule set wholesale instead of
-// appending a second copy of every accept.
-func installIPv6LeakBlock(ifName string, allow []net.IP) error {
+// installIPv6LeakBlock creates (or replaces) the leak-block table for ifName
+// and fills its chain with plan. The delete runs in its own flush first,
+// mirroring installNAT6Rules, so re-running after a reconnect replaces the rule
+// set wholesale instead of appending a second copy of every accept.
+//
+// It takes the finished plan rather than the inputs it is built from, so the
+// caller's plan and the installed plan cannot be two different things.
+func installIPv6LeakBlock(ifName string, plan []v6BlockRule) error {
 	if delConn, err := nftables.New(); err == nil {
 		delConn.DelTable(&nftables.Table{Family: nftables.TableFamilyIPv6, Name: v6BlockTableName(ifName)})
 		_ = delConn.Flush()
@@ -169,7 +200,7 @@ func installIPv6LeakBlock(ifName string, allow []net.IP) error {
 		Priority: nftables.ChainPriorityFilter,
 		Policy:   chainPolicyAcceptPtr(),
 	})
-	for _, r := range ipv6BlockPlan(ifName, allow) {
+	for _, r := range plan {
 		conn.AddRule(&nftables.Rule{Table: tbl, Chain: chain, Exprs: r.Exprs})
 	}
 
@@ -211,11 +242,40 @@ func (t *TUNDevice) SetIPv6BlockAllow(ips []net.IP) {
 	t.bypassMu.Unlock()
 }
 
+// SetIPv6BlockAllowList records the operator's -tun-ipv6-allow exceptions:
+// interfaces and destination prefixes that keep working while the block is up.
+// Unlike SetIPv6BlockAllow, which the client computes from its own endpoints,
+// this list is configuration — the host has IPv6 of its own (a 6in4 tunnel,
+// another VPN, a routed prefix) that the block must not take down.
+func (t *TUNDevice) SetIPv6BlockAllowList(a IPv6AllowList) {
+	t.bypassMu.Lock()
+	t.v6BlockAllowList = a
+	t.bypassMu.Unlock()
+}
+
 // blockAllow returns a copy of the allow list under the lock.
 func (t *TUNDevice) blockAllow() []net.IP {
 	t.bypassMu.Lock()
 	defer t.bypassMu.Unlock()
 	return append([]net.IP(nil), t.v6BlockAllow...)
+}
+
+// blockAllowList returns the operator exceptions under the lock. The slices
+// inside are not copied: nothing mutates them after ParseIPv6AllowList built
+// them.
+func (t *TUNDevice) blockAllowList() IPv6AllowList {
+	t.bypassMu.Lock()
+	defer t.bypassMu.Unlock()
+	return t.v6BlockAllowList
+}
+
+// v6BlockPlan is the rule set this device would install right now. Everything
+// that decides the chain's content goes through here — the server holes, the
+// operator exceptions and the interface name — so a test can ask what the
+// device will actually do instead of what ipv6BlockPlan does when called with
+// hand-picked arguments.
+func (t *TUNDevice) v6BlockPlan() []v6BlockRule {
+	return ipv6BlockPlan(t.name, t.blockAllow(), t.blockAllowList())
 }
 
 // setV6BlockInstalled records the block's state and returns the previous one.
@@ -257,20 +317,22 @@ func (t *TUNDevice) ApplyIPv6LeakBlock() {
 		return
 	}
 	allow := t.blockAllow()
-	if err := installIPv6LeakBlock(t.name, allow); err != nil {
+	extra := t.blockAllowList()
+	if err := installIPv6LeakBlock(t.name, t.v6BlockPlan()); err != nil {
 		log.Error("IPv6 leak block: failed to install nftables rules: %v; "+
 			"IPv6 traffic may leave outside the tunnel", err)
 		return
 	}
 	if t.setV6BlockInstalled(true) {
-		log.Debug("IPv6 leak block re-asserted for %s (allow: %v)", t.name, allow)
+		log.Debug("IPv6 leak block re-asserted for %s (allow: %v %s)", t.name, allow, extra)
 		return
 	}
-	log.Info("IPv6 leak block active: outbound IPv6 rejected except %s, %s, %s and %v "+
+	log.Info("IPv6 leak block active: outbound IPv6 rejected except %s, %s, %s, %v and %q "+
 		"(the tunnel is not carrying IPv6; use -tun-ipv6=off to opt out). "+
 		"If the client is killed without cleanup, remove it with "+
 		"'nft delete table ip6 %s'",
-		loopbackIfName, ipv6BlockLinkLocalNet, ipv6BlockMulticastNet, allow, v6BlockTableName(t.name))
+		loopbackIfName, ipv6BlockLinkLocalNet, ipv6BlockMulticastNet, allow, extra,
+		v6BlockTableName(t.name))
 }
 
 // RemoveIPv6LeakBlock takes the block down. Failures are loud: a table left

--- a/internal/tun/ipv6block_linux_test.go
+++ b/internal/tun/ipv6block_linux_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"net"
 	"os"
+	"reflect"
 	"testing"
 
 	"github.com/google/nftables"
@@ -79,7 +80,7 @@ func evalV6BlockPlan(t *testing.T, plan []v6BlockRule, oif string, dst net.IP) s
 func TestIPv6BlockPlanVerdicts(t *testing.T) {
 	const ifName = "tiredvpn0"
 	server6 := net.ParseIP("2001:db8::10")
-	plan := ipv6BlockPlan(ifName, []net.IP{server6})
+	plan := ipv6BlockPlan(ifName, []net.IP{server6}, IPv6AllowList{})
 
 	for _, tc := range []struct {
 		name string
@@ -115,7 +116,7 @@ func TestIPv6BlockPlanVerdicts(t *testing.T) {
 // takes for granted: the reject is last and unconditional, and nothing follows
 // it.
 func TestIPv6BlockPlanShape(t *testing.T) {
-	plan := ipv6BlockPlan("tiredvpn0", nil)
+	plan := ipv6BlockPlan("tiredvpn0", nil, IPv6AllowList{})
 	if len(plan) < 2 {
 		t.Fatalf("plan has %d rules, want the accepts plus a reject", len(plan))
 	}
@@ -142,24 +143,185 @@ func TestIPv6BlockPlanShape(t *testing.T) {
 // real IPv6 addresses. An IPv4 server address needs no hole (the block is ip6
 // only) and a nil entry must not turn into a match-anything rule.
 func TestIPv6BlockPlanAllowList(t *testing.T) {
-	base := len(ipv6BlockPlan("tiredvpn0", nil))
+	base := len(ipv6BlockPlan("tiredvpn0", nil, IPv6AllowList{}))
 
 	junk := []net.IP{nil, net.ParseIP("203.0.113.10"), net.IPv4(10, 0, 0, 1)}
-	if got := len(ipv6BlockPlan("tiredvpn0", junk)); got != base {
+	if got := len(ipv6BlockPlan("tiredvpn0", junk, IPv6AllowList{})); got != base {
 		t.Errorf("non-IPv6 allow entries added %d rules, want 0", got-base)
 	}
 
 	real6 := []net.IP{net.ParseIP("2001:db8::10"), net.ParseIP("2001:db8::20")}
-	if got := len(ipv6BlockPlan("tiredvpn0", real6)); got != base+2 {
+	if got := len(ipv6BlockPlan("tiredvpn0", real6, IPv6AllowList{})); got != base+2 {
 		t.Errorf("two IPv6 allow entries produced %d rules, want %d", got, base+2)
 	}
 
 	// A device with no interface name must not produce a rule matching the
 	// empty ifname, which would accept traffic leaving through an unnamed
 	// interface.
-	if got := len(ipv6BlockPlan("", nil)); got != base-1 {
+	if got := len(ipv6BlockPlan("", nil, IPv6AllowList{})); got != base-1 {
 		t.Errorf("empty ifname produced %d rules, want %d", got, base-1)
 	}
+}
+
+// TestIPv6BlockPlanExceptions is the flag doing its job: the interface and the
+// prefix named in -tun-ipv6-allow survive the block, and everything the block
+// was there for still does not.
+//
+// The Hurricane Electric case is the row that made the flag exist: he6 is up,
+// keeps its address, and every packet the host sends over it is rejected by a
+// chain installed for an unrelated tunnel.
+func TestIPv6BlockPlanExceptions(t *testing.T) {
+	const ifName = "tiredvpn0"
+	allow, err := ParseIPv6AllowList("he6,2001:db8:77b::/64")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	plan := ipv6BlockPlan(ifName, nil, allow)
+
+	for _, tc := range []struct {
+		name string
+		oif  string
+		dst  string
+		want string
+	}{
+		{"the excepted interface", "he6", "2606:4700:4700::1111", "accept"},
+		{"the excepted prefix, any interface", "eth0", "2001:db8:77b::2", "accept"},
+		{"a neighbour of the excepted prefix", "eth0", "2001:db8:77c::2", "reject"},
+		{"an interface with a similar name", "he60", "2606:4700:4700::1111", "reject"},
+		{"everything else still leaks nothing", "eth0", "2606:4700:4700::1111", "reject"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := evalV6BlockPlan(t, plan, tc.oif, net.ParseIP(tc.dst)); got != tc.want {
+				t.Errorf("%s via %s = %s, want %s", tc.dst, tc.oif, got, tc.want)
+			}
+		})
+	}
+
+	// The verdicts above are only true because the accepts come first: an
+	// exception appended after the reject would evaluate the same way in a
+	// careless reading of the plan and do nothing in the kernel.
+	rejectAt := -1
+	for i, r := range plan {
+		if r.Name == "reject" {
+			rejectAt = i
+		}
+	}
+	if rejectAt != len(plan)-1 {
+		t.Fatalf("reject is rule %d of %d, want last", rejectAt, len(plan))
+	}
+	for _, want := range []string{"accept he6", "accept 2001:db8:77b::/64"} {
+		at := -1
+		for i, r := range plan {
+			if r.Name == want {
+				at = i
+			}
+		}
+		if at < 0 {
+			t.Fatalf("no rule %q in the plan (%v)", want, planNames(plan))
+		}
+		if at > rejectAt {
+			t.Errorf("rule %q is at %d, after the reject at %d — it can never match", want, at, rejectAt)
+		}
+	}
+}
+
+// TestIPv6BlockPlanUnchangedWithoutExceptions pins what an empty
+// -tun-ipv6-allow must leave behind: exactly the rule set that shipped before
+// the flag existed, in the same order. The exceptions may only be inserted
+// between the last accept and the reject.
+func TestIPv6BlockPlanUnchangedWithoutExceptions(t *testing.T) {
+	const ifName = "tiredvpn0"
+	server6 := net.ParseIP("2001:db8::10")
+
+	base := ipv6BlockPlan(ifName, []net.IP{server6}, IPv6AllowList{})
+	want := []string{
+		"accept lo",
+		"accept tiredvpn0",
+		"accept fe80::/10",
+		"accept ff00::/8",
+		"accept 2001:db8::10/128",
+		"reject",
+	}
+	if got := planNames(base); !equalStrings(got, want) {
+		t.Fatalf("plan without exceptions = %v, want %v", got, want)
+	}
+
+	allow, err := ParseIPv6AllowList("he6")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	withExtra := ipv6BlockPlan(ifName, []net.IP{server6}, allow)
+	if len(withExtra) != len(base)+1 {
+		t.Fatalf("one exception produced %d rules, want %d", len(withExtra), len(base)+1)
+	}
+	// Everything up to the reject must be untouched, expression for
+	// expression: an exception that rewrote or reordered an existing accept
+	// would be a second change hiding inside this one.
+	for i := range base[:len(base)-1] {
+		if !reflect.DeepEqual(base[i], withExtra[i]) {
+			t.Errorf("rule %d changed: %q -> %q", i, base[i].Name, withExtra[i].Name)
+		}
+	}
+	if last := base[len(base)-1]; !reflect.DeepEqual(last, withExtra[len(withExtra)-1]) {
+		t.Errorf("the reject rule changed")
+	}
+}
+
+// TestTUNDeviceV6BlockPlanUsesExceptions checks the wiring one level up: the
+// list handed to the device is the list the device installs. Testing
+// ipv6BlockPlan alone would pass just as well with SetIPv6BlockAllowList
+// writing into a field nobody reads.
+func TestTUNDeviceV6BlockPlanUsesExceptions(t *testing.T) {
+	allow, err := ParseIPv6AllowList("he6")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	td := &TUNDevice{name: "tiredvpn0", ipv6Policy: IPv6PolicyDual}
+	td.SetIPv6BlockAllow([]net.IP{net.ParseIP("2001:db8::10")})
+	td.SetIPv6BlockAllowList(allow)
+
+	plan := td.v6BlockPlan()
+	if got := evalV6BlockPlan(t, plan, "he6", net.ParseIP("2606:4700:4700::1111")); got != "accept" {
+		t.Errorf("he6 via the device's own plan = %s, want accept (plan: %v)", got, planNames(plan))
+	}
+	if got := evalV6BlockPlan(t, plan, "eth0", net.ParseIP("2606:4700:4700::1111")); got != "reject" {
+		t.Errorf("eth0 = %s, want reject", got)
+	}
+	if got := evalV6BlockPlan(t, plan, "eth0", net.ParseIP("2001:db8::10")); got != "accept" {
+		t.Error("the server hole disappeared once exceptions were set")
+	}
+}
+
+// TestApplyIPv6BlockConfigCarriesExceptions closes the last gap between the
+// flag and the chain: VPNConfig.IPv6Allow has to reach the device. This is the
+// step that has been wrong before elsewhere in the tree — a value parsed
+// correctly, then not passed on, behaves exactly like a value never given.
+func TestApplyIPv6BlockConfigCarriesExceptions(t *testing.T) {
+	allow, err := ParseIPv6AllowList("he6")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	td := &TUNDevice{name: "tiredvpn0"}
+	applyIPv6BlockConfig(td, VPNConfig{
+		IPv6Policy: IPv6PolicyDual,
+		ServerAddr: "203.0.113.10:443",
+		IPv6Allow:  allow,
+	})
+
+	if !td.wantsIPv6Block() {
+		t.Fatal("the dual policy did not reach the device")
+	}
+	if got := evalV6BlockPlan(t, td.v6BlockPlan(), "he6", net.ParseIP("2606:4700:4700::1111")); got != "accept" {
+		t.Errorf("he6 = %s, want accept: the config's exceptions did not reach the device", got)
+	}
+}
+
+func planNames(plan []v6BlockRule) []string {
+	out := make([]string, 0, len(plan))
+	for _, r := range plan {
+		out = append(out, r.Name)
+	}
+	return out
 }
 
 // TestV6BlockTableNameDistinctFromMSS guards a collision that would make the
@@ -213,18 +375,19 @@ func TestIPv6LeakBlockInstallRemove(t *testing.T) {
 	const ifName = "tiredvpn-test0"
 	allow := []net.IP{net.ParseIP("2001:db8::10")}
 
-	if err := installIPv6LeakBlock(ifName, allow); err != nil {
+	plan := ipv6BlockPlan(ifName, allow, IPv6AllowList{})
+	if err := installIPv6LeakBlock(ifName, plan); err != nil {
 		t.Skipf("cannot install nftables rules here: %v", err)
 	}
 	defer func() { _ = removeIPv6LeakBlockTable(ifName) }()
 
 	rules := countBlockRules(t, ifName)
-	if want := len(ipv6BlockPlan(ifName, allow)); rules != want {
+	if want := len(plan); rules != want {
 		t.Errorf("installed %d rules, want %d", rules, want)
 	}
 
 	// Re-install (what a reconnect does) must replace, not append.
-	if err := installIPv6LeakBlock(ifName, allow); err != nil {
+	if err := installIPv6LeakBlock(ifName, plan); err != nil {
 		t.Fatalf("re-install: %v", err)
 	}
 	if got := countBlockRules(t, ifName); got != rules {

--- a/internal/tun/ipv6block_warn_linux.go
+++ b/internal/tun/ipv6block_warn_linux.go
@@ -1,0 +1,176 @@
+//go:build linux
+// +build linux
+
+package tun
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"strings"
+
+	"github.com/vishvananda/netlink"
+)
+
+// Operator warnings for the IPv6 leak block.
+//
+// The block is one chain, hooked at ip6 OUTPUT. That hook only sees packets
+// this host originates: netfilter sends an incoming packet to input or forward
+// after the routing decision, and never to output. So on a router the block
+// does NOT touch the IPv6 it forwards for its LAN — the traffic that stops is
+// the router's own. That distinction is the whole reason these warnings exist
+// as text rather than as a copy of "forwarding is on, transit will break",
+// which would have been false.
+//
+// What did break in the field was a node holding a Hurricane Electric 6in4
+// tunnel: locally originated packets routed out he6 hit the output hook, fell
+// through every accept, and were rejected. Nothing was being forwarded at the
+// time.
+
+// ipv6ForwardingSysctl is the switch the operator asked to be warned about.
+const ipv6ForwardingSysctl = "/proc/sys/net/ipv6/conf/all/forwarding"
+
+// v6TunnelKinds are netlink link kinds that carry IPv6 somewhere on purpose.
+// An interface of one of these kinds with a global address is infrastructure
+// somebody configured — a 6in4/6rd tunnel, a GRE link, a WireGuard peering —
+// as opposed to eth0/wlan0, whose global IPv6 is exactly the leak the block is
+// there to stop and needs no warning.
+var v6TunnelKinds = map[string]bool{
+	"sit":       true, // 6in4, what Hurricane Electric hands out
+	"ip6tnl":    true,
+	"ipip":      true,
+	"gre":       true,
+	"gretap":    true,
+	"ip6gre":    true,
+	"vti":       true,
+	"vti6":      true,
+	"wireguard": true,
+	"tun":       true, // another VPN's TUN device
+	"ppp":       true,
+}
+
+// hostV6Iface is one interface as the warning sees it: its name, its netlink
+// kind and the global IPv6 addresses it holds.
+type hostV6Iface struct {
+	Name   string
+	Kind   string
+	Global []net.IP
+}
+
+// hostV6State is the snapshot the warnings are computed from. Split from the
+// netlink/procfs reads so the message text can be tested without a router.
+type hostV6State struct {
+	Forwarding bool
+	Ifaces     []hostV6Iface
+}
+
+// ipv6BlockWarnings returns what the operator should be told before the block
+// goes in, given the tunnel's name, the exceptions in force and the host's
+// state. Empty when there is nothing to say.
+//
+// Two messages, in this order:
+//
+//  1. A v6 tunnel interface that keeps global addresses and is not excepted.
+//     This is the ruhop case: the interface will stay up, its addresses will
+//     stay assigned, and every packet the host sends over it will be rejected.
+//  2. IPv6 forwarding is on. Said only to place the first message correctly:
+//     a router keeps routing, so the operator does not go looking for a
+//     transit outage that is not there, and looks at the host's own traffic
+//     instead.
+func ipv6BlockWarnings(tunName string, extra IPv6AllowList, st hostV6State) []string {
+	var cut []hostV6Iface
+	for _, iface := range st.Ifaces {
+		if iface.Name == loopbackIfName || iface.Name == tunName || len(iface.Global) == 0 {
+			continue
+		}
+		if !v6TunnelKinds[iface.Kind] || extra.hasInterface(iface.Name) {
+			continue
+		}
+		if allCovered(iface.Global, extra) {
+			continue
+		}
+		cut = append(cut, iface)
+	}
+
+	var out []string
+	if len(cut) > 0 {
+		parts := make([]string, 0, len(cut))
+		names := make([]string, 0, len(cut))
+		for _, iface := range cut {
+			parts = append(parts, fmt.Sprintf("%s (%s, %s)", iface.Name, iface.Kind, iface.Global[0]))
+			names = append(names, iface.Name)
+		}
+		out = append(out, fmt.Sprintf(
+			"IPv6 leak block: %s carries global IPv6 and is not excepted, so IPv6 this host sends over it "+
+				"will be rejected while the tunnel is up — the interface stays up and keeps its addresses, "+
+				"which is what makes this look like a routing fault rather than a firewall one. "+
+				"Keep it working with -tun-ipv6-allow=%s (or -tun-ipv6=off to drop the block entirely).",
+			strings.Join(parts, ", "), strings.Join(names, ",")))
+	}
+	if st.Forwarding {
+		out = append(out, fmt.Sprintf(
+			"IPv6 leak block: %s=1, this host routes IPv6 for others. The block is hooked at ip6 output, "+
+				"which only sees locally originated packets, so IPv6 this host FORWARDS is not affected — "+
+				"what stops is the host's own outbound IPv6 (DNS, updates, tunnel and monitoring traffic). "+
+				"Except what has to keep working with -tun-ipv6-allow.",
+			ipv6ForwardingSysctl))
+	}
+	return out
+}
+
+// allCovered reports whether every address is already inside an excepted
+// prefix, i.e. the interface is spared without being named.
+func allCovered(addrs []net.IP, extra IPv6AllowList) bool {
+	for _, ip := range addrs {
+		if !extra.coversIP(ip) {
+			return false
+		}
+	}
+	return true
+}
+
+// readHostV6State collects the facts the warnings need. Every failure degrades
+// to "nothing to report": a warning that cannot be computed must not stop a
+// block the user asked for, and must not turn into a message about the client's
+// own troubles reading procfs.
+func readHostV6State() hostV6State {
+	st := hostV6State{Forwarding: ipv6ForwardingEnabled()}
+	links, err := netlink.LinkList()
+	if err != nil {
+		return st
+	}
+	for _, link := range links {
+		attrs := link.Attrs()
+		if attrs == nil {
+			continue
+		}
+		addrs, err := netlink.AddrList(link, netlink.FAMILY_V6)
+		if err != nil {
+			continue
+		}
+		iface := hostV6Iface{Name: attrs.Name, Kind: link.Type()}
+		for _, a := range addrs {
+			// Global unicast minus ULA: a public address is the one whose loss
+			// is visible outside the host.
+			if a.IP == nil || !a.IP.IsGlobalUnicast() || a.IP.IsPrivate() {
+				continue
+			}
+			iface.Global = append(iface.Global, a.IP)
+		}
+		if len(iface.Global) > 0 {
+			st.Ifaces = append(st.Ifaces, iface)
+		}
+	}
+	return st
+}
+
+// ipv6ForwardingEnabled reads net.ipv6.conf.all.forwarding. An unreadable
+// sysctl reads as "off": the warning it drives is advisory, and inventing one
+// from a read error would be noise.
+func ipv6ForwardingEnabled() bool {
+	b, err := os.ReadFile(ipv6ForwardingSysctl)
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(b)) == "1"
+}

--- a/internal/tun/ipv6block_warn_linux_test.go
+++ b/internal/tun/ipv6block_warn_linux_test.go
@@ -1,0 +1,141 @@
+//go:build linux
+// +build linux
+
+package tun
+
+import (
+	"net"
+	"strings"
+	"testing"
+)
+
+// heTunnel is the interface the flag was written for: the Hurricane Electric
+// 6in4 link on the ruhop node, a sit device with a global address.
+func heTunnel() hostV6Iface {
+	return hostV6Iface{
+		Name:   "he6",
+		Kind:   "sit",
+		Global: []net.IP{net.ParseIP("2001:db8:77b::2")},
+	}
+}
+
+func wan() hostV6Iface {
+	return hostV6Iface{
+		Name:   "eth0",
+		Kind:   "device",
+		Global: []net.IP{net.ParseIP("2a01:4f8::10")},
+	}
+}
+
+func mustAllow(t *testing.T, spec string) IPv6AllowList {
+	t.Helper()
+	a, err := ParseIPv6AllowList(spec)
+	if err != nil {
+		t.Fatalf("ParseIPv6AllowList(%q): %v", spec, err)
+	}
+	return a
+}
+
+// TestIPv6BlockWarningsTunnelInterface covers the message that would have saved
+// the ruhop outage: a v6 tunnel the block is about to cut, named, with the flag
+// that spares it.
+func TestIPv6BlockWarningsTunnelInterface(t *testing.T) {
+	st := hostV6State{Ifaces: []hostV6Iface{wan(), heTunnel()}}
+
+	got := ipv6BlockWarnings("tiredvpn0", IPv6AllowList{}, st)
+	if len(got) != 1 {
+		t.Fatalf("warnings = %v, want exactly the tunnel one", got)
+	}
+	for _, want := range []string{"he6", "sit", "-tun-ipv6-allow=he6"} {
+		if !strings.Contains(got[0], want) {
+			t.Errorf("warning does not mention %q: %s", want, got[0])
+		}
+	}
+	// eth0 losing its global IPv6 is the block working as intended and must
+	// not be reported as a problem, or the message becomes noise on every
+	// laptop.
+	if strings.Contains(got[0], "eth0") {
+		t.Errorf("the WAN interface is named in the warning: %s", got[0])
+	}
+}
+
+// TestIPv6BlockWarningsSilencedByException checks that acting on the warning
+// makes it stop — by name or by prefix, since either one spares the interface.
+func TestIPv6BlockWarningsSilencedByException(t *testing.T) {
+	st := hostV6State{Ifaces: []hostV6Iface{heTunnel()}}
+
+	for _, spec := range []string{"he6", "2001:db8:77b::/64"} {
+		if got := ipv6BlockWarnings("tiredvpn0", mustAllow(t, spec), st); len(got) != 0 {
+			t.Errorf("-tun-ipv6-allow=%s still warns: %v", spec, got)
+		}
+	}
+	// A prefix that does not cover the interface's address is not an
+	// exception for it.
+	if got := ipv6BlockWarnings("tiredvpn0", mustAllow(t, "2001:db8:77c::/64"), st); len(got) != 1 {
+		t.Errorf("an unrelated prefix silenced the warning: %v", got)
+	}
+}
+
+// TestIPv6BlockWarningsIgnoresOwnTunnel: our own TUN device is a "tun" kind
+// with, once dual-stack is up, a global address of its own. Warning about the
+// interface the block was built around would be nonsense.
+func TestIPv6BlockWarningsIgnoresOwnTunnel(t *testing.T) {
+	st := hostV6State{Ifaces: []hostV6Iface{{
+		Name:   "tiredvpn0",
+		Kind:   "tun",
+		Global: []net.IP{net.ParseIP("2001:db8:ff::2")},
+	}}}
+	if got := ipv6BlockWarnings("tiredvpn0", IPv6AllowList{}, st); len(got) != 0 {
+		t.Errorf("warned about our own tunnel: %v", got)
+	}
+}
+
+// TestIPv6BlockWarningsForwarding is the operator's request, held to what is
+// actually true: the chain is hooked at output, so forwarded traffic is not
+// touched. A message claiming transit breaks would be a lie, and the test says
+// so in both directions — the words that must be there and the claim that must
+// not.
+func TestIPv6BlockWarningsForwarding(t *testing.T) {
+	st := hostV6State{Forwarding: true}
+	got := ipv6BlockWarnings("tiredvpn0", IPv6AllowList{}, st)
+	if len(got) != 1 {
+		t.Fatalf("warnings = %v, want exactly the forwarding one", got)
+	}
+	msg := got[0]
+	for _, want := range []string{"output", "not affected", "own outbound IPv6"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("forwarding warning does not say %q: %s", want, msg)
+		}
+	}
+
+	st.Forwarding = false
+	if got := ipv6BlockWarnings("tiredvpn0", IPv6AllowList{}, st); len(got) != 0 {
+		t.Errorf("a host that forwards nothing was warned about forwarding: %v", got)
+	}
+}
+
+// TestIPv6BlockWarningsOrder: on the node that has both, the tunnel message
+// comes first. The forwarding note only exists to place it correctly, and a
+// reader who stops after the first line should get the actionable one.
+func TestIPv6BlockWarningsOrder(t *testing.T) {
+	st := hostV6State{Forwarding: true, Ifaces: []hostV6Iface{heTunnel()}}
+	got := ipv6BlockWarnings("tiredvpn0", IPv6AllowList{}, st)
+	if len(got) != 2 {
+		t.Fatalf("warnings = %v, want two", got)
+	}
+	if !strings.Contains(got[0], "he6") {
+		t.Errorf("first warning is not the tunnel one: %s", got[0])
+	}
+	if !strings.Contains(got[1], "forward") {
+		t.Errorf("second warning is not the forwarding one: %s", got[1])
+	}
+}
+
+// TestIPv6ForwardingEnabledReadsSysctl guards the one place the warning touches
+// the host: an unreadable or absent sysctl reads as off rather than as a crash
+// or a warning about procfs.
+func TestIPv6ForwardingEnabledReadsSysctl(t *testing.T) {
+	// The real path either exists (any Linux) or does not; both answers are
+	// valid, the call must simply not panic.
+	_ = ipv6ForwardingEnabled()
+}

--- a/internal/tun/tun_darwin.go
+++ b/internal/tun/tun_darwin.go
@@ -97,6 +97,10 @@ func (t *TUNDevice) SetIPv6Policy(p IPv6Policy) {
 // in. Present so the platform-independent caller in vpn.go needs no build tag.
 func (t *TUNDevice) SetIPv6BlockAllow([]net.IP) {}
 
+// SetIPv6BlockAllowList is a no-op on macOS for the same reason: -tun-ipv6-allow
+// describes exceptions to a block that is not implemented here.
+func (t *TUNDevice) SetIPv6BlockAllowList(IPv6AllowList) {}
+
 // ApplyIPv6LeakBlock is not implemented on macOS. The Linux block is an
 // nftables chain, which has no counterpart here — the equivalent would be a
 // pf anchor, which means owning /etc/pf.conf state that the OS and other VPN

--- a/internal/tun/tun_linux.go
+++ b/internal/tun/tun_linux.go
@@ -97,7 +97,11 @@ type TUNDevice struct {
 	// server's own transport addresses). Guarded by bypassMu, like the bypass
 	// state it mirrors.
 	v6BlockAllow []net.IP
-	bypassMu     sync.Mutex
+	// v6BlockAllowList are the operator's -tun-ipv6-allow exceptions: host
+	// interfaces and destination prefixes the block must leave alone. Same
+	// lock, same lifetime; set from VPNConfig before Configure.
+	v6BlockAllowList IPv6AllowList
+	bypassMu         sync.Mutex
 
 	// deferRoutes, when true, makes Configure bring the interface up and assign
 	// the tunnel address but NOT install the route set (notably a 0.0.0.0/0

--- a/internal/tun/vpn.go
+++ b/internal/tun/vpn.go
@@ -202,6 +202,13 @@ type VPNConfig struct {
 	// against old exits — they ignore the unknown version.
 	IPv6Policy IPv6Policy
 
+	// IPv6Allow is the parsed -tun-ipv6-allow list: interfaces and destination
+	// prefixes the leak block must not touch. It exists because the block is a
+	// host-wide reject and the host may carry IPv6 the client knows nothing
+	// about — a 6in4 tunnel, another VPN, a routed prefix. Empty by default,
+	// which is the block as it shipped.
+	IPv6Allow IPv6AllowList
+
 	// DualStack is the pre-policy spelling of IPv6Policy == IPv6PolicyDual,
 	// kept for callers that have not moved over (macOS, benchmarks). Ignored
 	// when IPv6Policy is set to anything but its zero value.
@@ -315,6 +322,23 @@ func (cfg VPNConfig) ipv6PolicyOrLegacy() IPv6Policy {
 	return IPv6PolicyOff
 }
 
+// applyIPv6BlockConfig records everything the leak block is built from onto a
+// device we own: the policy that decides whether it goes in at all, the holes
+// for the client's own exits, and the operator's exceptions.
+//
+// Extracted from NewVPNClient because that function needs a real TUN and root,
+// while this is three field writes — and the interesting failure is a config
+// field that never reaches the device, which is exactly what a test of
+// NewVPNClient cannot check and a test of this can.
+func applyIPv6BlockConfig(dev *TUNDevice, cfg VPNConfig) {
+	dev.SetIPv6Policy(cfg.ipv6PolicyOrLegacy())
+	// The client's own transport addresses, one layer below the /128 bypass
+	// routes: the block rejects outbound v6, and the dial to an exit reached
+	// over IPv6 must not be caught by it.
+	dev.SetIPv6BlockAllow(serverIP6s(cfg))
+	dev.SetIPv6BlockAllowList(cfg.IPv6Allow)
+}
+
 // NewVPNClient creates a new VPN client
 func NewVPNClient(cfg VPNConfig) (*VPNClient, error) {
 	if cfg.MTU == 0 {
@@ -364,7 +388,7 @@ func NewVPNClient(cfg VPNConfig) (*VPNClient, error) {
 		// known. Only on interfaces we own — the fd branch above leaves the
 		// device at IPv6PolicyOff, because on Android VpnService owns both
 		// routing and filtering.
-		tunDev.SetIPv6Policy(cfg.ipv6PolicyOrLegacy())
+		applyIPv6BlockConfig(tunDev, cfg)
 		// Pin a bypass route for EVERY configured endpoint before configuring
 		// routes, so a full-tunnel default route does not loop the client's own
 		// server traffic - not for the current endpoint alone, because by the
@@ -378,9 +402,6 @@ func NewVPNClient(cfg VPNConfig) (*VPNClient, error) {
 			tunDev.SetServerBypassIPs(bypassIPs)
 			log.Debug("Server bypass: %d endpoint address(es) will be pinned", len(bypassIPs))
 		}
-		// Same addresses, one layer down: the IPv6 leak block rejects outbound
-		// v6, and the client's own transport must not be caught by it.
-		tunDev.SetIPv6BlockAllow(serverIP6s(cfg))
 		// Defer route installation (notably the 0.0.0.0/0 default route) until a
 		// real connection + handshake to the server succeeds. Configure brings
 		// the interface up and assigns its address, but leaves the host's normal


### PR DESCRIPTION
The leak block killed working IPv6 on a node that had every right to it.

The node terminates a Hurricane Electric tunnel: interface `he6`, address `2001:470:1f0a:77b::2/64`. Four tiredvpn clients run there, none of them passing `-tun-ipv6`, so the default `dual` applied; the exits return no v6 pool, and for that case the policy blocks. Each client installed its own `ip6 tiredvpn-v6block-<ifname>` table, and everything the node sent over `he6` hit the final reject. `ping6` outbound: 100% loss.

Diagnosing it took a while because the rule is invisible from the usual angles — it lives in native nftables, the host has no `nft` CLI, and `ip6tables -S` and the routing table are both clean.

There was no way to make an exception: the allow list is filled once, from the VPN servers' own v6 addresses, and nothing outside can add to it.

## `-tun-ipv6-allow`

Takes a comma-separated list of interface names, IPv6 prefixes, or single addresses, and turns each into an accept rule placed before the final reject. Both forms are there because they answer different questions: a tunnel is easier to name whole (`he6`), a routed network as a prefix (`2001:470:1f0a:77b::/64`). Available through the TOML config too, otherwise it would be unusable from a server pool.

An unknown interface name is not an error — it may appear later, and refusing to start over a tunnel that has not come up yet would be worse than the leak. A malformed prefix is an error at startup rather than a silent skip.

## A warning that says what actually happens

The ask was to warn when `net.ipv6.conf.all.forwarding=1` because the block "may break transit". Checking that premise first showed it would have been false: the chain is hooked at **output**, forwarded packets go through the **forward** hook, so a router keeps routing. What stops is the router's own outbound traffic — which is exactly what broke on the node.

So the warning is built around the real effect instead. At install time it names any v6 tunnel interface (sit, wireguard, gre and friends) that holds a global address and is not excepted, plus the flag that would spare it; on a forwarding host it adds the note about output vs forward. The block still goes in — the operator decides.

## Verification

Tests broken one site at a time: dropping the exceptions on the way into the plan reddens four, including the call-site tests; moving the reject ahead of the accepts reddens the shape and verdict tests. Ordering is behaviour here, not cosmetics — an accept after the reject is a rule that never runs.

Gate clean: build, vet, `go test ./... -race -short`, `golangci-lint run` 0 issues. Documentation updated alongside the flag.