### PR TITLE
feat(tun): -tun-routes6, the IPv6 counterpart of -tun-routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **`-tun-routes6`: which IPv6 destinations the tunnel claims.** The 6in4 node
+  that motivated `-tun-ipv6-allow` in 1.9.0 lost its IPv6 a second time, to the
+  other half of the same feature. `-tun-ipv6-allow` fixed the filter; nothing
+  fixed the routing. `dual` installs `::/1` and `8000::/1` into the main table,
+  which between them cover every IPv6 address and beat the host's own `::/0` on
+  prefix length - metrics never enter that comparison - so four clients on one
+  node took its `default dev he6` away and sent every packet out of a tunnel
+  with a ULA source address nothing routes back. The interface was up, the
+  address was assigned, and every destination was 100% loss.
+  IPv4 never had this problem because it has a lever: an absent `-tun-routes`
+  installs no route at all, which is what lets an operator put the tunnel's
+  default into a table of their own (`ip rule` / `ip route ... table X`) and
+  keep `main` for the host. IPv6 had no equivalent, so `dual` was all-or-nothing.
+  `-tun-routes6` is that lever. `none` claims no destination: the tunnel still
+  negotiates dual-stack and still carries a v6 address, but the main table is
+  left alone. A comma-separated prefix list claims exactly those. Unset keeps
+  the `::/1` + `8000::/1` full tunnel, so nothing changes for a client that does
+  not pass the flag. Also available as `[tun] routes6` in the client TOML, where
+  "claim nothing" is written `["none"]` - an empty array and an absent key
+  serialize identically and mean opposite things. Requires `-tun-ipv6=dual`;
+  under `block` or `off` the tunnel never carries IPv6, and a flag that silently
+  does nothing is worse than one that refuses to start.
+
+### Changed
+
+- **Setting `-tun-routes6` disables the blanket IPv6 leak block.** This is a
+  behaviour change, and only for clients that pass the new flag: without it the
+  block is unchanged. The block rejects every outbound IPv6 packet that is not
+  the tunnel's, which is the right fallback exactly while the tunnel claims all
+  of IPv6. Once an operator has named the destinations, the rest of IPv6 is
+  theirs by construction - there is nothing there to leak, and a blanket reject
+  would only cut the host's own connectivity, which is the failure this whole
+  change exists to stop. `-tun-ipv6-allow` is unaffected and remains the right
+  tool when you want the block with a hole in it.
+
 ## [1.9.0] - 2026-08-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -281,6 +281,15 @@ If the host carries IPv6 of its own - a 6in4 tunnel, another VPN, a routed
 prefix - name it with `-tun-ipv6-allow he6,2001:db8::/32` (interface names,
 prefixes, or both) and the block leaves it alone.
 
+That covers the filter. The routing is a separate lever: `dual` also installs
+`::/1` + `8000::/1`, which beat the host's own default on prefix length and take
+IPv6 over entirely. On a node that must keep routing its own IPv6, pass
+`-tun-routes6 none` - the tunnel still gets a v6 address, but claims no
+destination, and you route into it from your own tables exactly as you already
+do for IPv4 with an absent `-tun-routes`. A prefix list works too
+(`-tun-routes6 2001:db8::/32`). Unset keeps the full tunnel, so a plain client
+is unaffected.
+
 ---
 
 ## Configuration
@@ -356,6 +365,7 @@ Generate the B1 key pair with `tiredvpn reality-keygen`.
 | `-tun-routes` | | Routes to tunnel (e.g. `0.0.0.0/0`) |
 | `-tun-ipv6` | `dual` | IPv6 while the tunnel is up: `dual`, `block`, `off` |
 | `-tun-ipv6-allow` | | Exceptions to the IPv6 block: interface names and/or prefixes, comma-separated |
+| `-tun-routes6` | | IPv6 destinations the tunnel claims; `none` leaves the host's own IPv6 routing alone |
 | `-tun-mtu` | `1280` | TUN MTU; with `-auto-mtu` this is the upper bound |
 | `-auto-mtu` | `true` | Probe the real end-to-end MTU and apply `min(probed, -tun-mtu)` |
 | `-quic` | `false` | Enable QUIC transport |

--- a/README.md
+++ b/README.md
@@ -273,9 +273,11 @@ Since 1.5.0 `-tun-ipv6` defaults to `dual`: IPv6 goes through the tunnel when
 the exit was started with `-ip-pool-v6`, and is rejected outright when it was
 not, so applications cannot reach the internet over a native IPv6 default route
 while the VPN is up. `-tun-ipv6 off` restores the pre-1.5.0 behaviour, which is
-what a split tunnel usually wants - `dual` sends *all* IPv6 into the tunnel,
-including destinations you deliberately routed around it on IPv4. The blocking
-half is Linux-only; on macOS it warns instead.
+one answer for a split tunnel - on its own, `dual` sends *all* IPv6 into the
+tunnel, including destinations you deliberately routed around it on IPv4. The
+other answer is `-tun-routes6`, which mirrors the v4 split on the v6 side
+instead of giving IPv6 up. The blocking half is Linux-only; on macOS it warns
+instead.
 
 If the host carries IPv6 of its own - a 6in4 tunnel, another VPN, a routed
 prefix - name it with `-tun-ipv6-allow he6,2001:db8::/32` (interface names,

--- a/cmd/tiredvpn/config.go
+++ b/cmd/tiredvpn/config.go
@@ -28,6 +28,7 @@ import (
 //   - tls.fingerprint              → cfg.TLSFingerprint
 //   - tun.ipv6_allow               → cfg.TunIPv6Allow (joined back to the
 //     comma-separated form -tun-ipv6-allow uses)
+//   - tun.routes6                  → cfg.TunRoutes6 (same join, for -tun-routes6)
 //   - shaper.{preset|custom}       → cfg.Shaper (built via presets.FromConfig)
 //   - logging.level                → log.SetDebug when "debug"
 //
@@ -57,6 +58,9 @@ func applyClientTOMLConfig(cfg *client.Config, path string, fs *flag.FlagSet) er
 	// join round-trips.
 	if len(tcfg.Tun.IPv6Allow) > 0 {
 		cfg.TunIPv6Allow = strings.Join(tcfg.Tun.IPv6Allow, ",")
+	}
+	if len(tcfg.Tun.Routes6) > 0 {
+		cfg.TunRoutes6 = strings.Join(tcfg.Tun.Routes6, ",")
 	}
 	if tcfg.Logging.Level == "debug" {
 		log.SetDebug(true)

--- a/cmd/tiredvpn/config_servers_test.go
+++ b/cmd/tiredvpn/config_servers_test.go
@@ -247,3 +247,60 @@ address = "203.0.113.10"
 		t.Errorf("cfg.TunIPv6Allow = %q, want the CLI value to survive a silent file", cfg.TunIPv6Allow)
 	}
 }
+
+// TestApplyClientTOMLConfig_TunRoutes6 is the last hop for -tun-routes6 out of
+// a file: a schema key nobody copies into client.Config does nothing, and on
+// the node this flag exists for "does nothing" means its IPv6 stays dead.
+func TestApplyClientTOMLConfig_TunRoutes6(t *testing.T) {
+	path := writeClientTOML(t, `
+[server]
+address = "203.0.113.10"
+port = 443
+
+[tun]
+routes6 = ["none"]
+`)
+	cfg := &client.Config{}
+	if err := applyClientTOMLConfig(cfg, path, clientFlagSetForTOML()); err != nil {
+		t.Fatalf("applyClientTOMLConfig: %v", err)
+	}
+	if cfg.TunRoutes6 != "none" {
+		t.Errorf("cfg.TunRoutes6 = %q, want %q", cfg.TunRoutes6, "none")
+	}
+}
+
+// TestApplyClientTOMLConfig_TunRoutes6List: a prefix list round-trips through
+// the join the runtime parser expects.
+func TestApplyClientTOMLConfig_TunRoutes6List(t *testing.T) {
+	path := writeClientTOML(t, `
+[server]
+address = "203.0.113.10"
+
+[tun]
+routes6 = ["2001:db8::/32", "2001:db9::/48"]
+`)
+	cfg := &client.Config{}
+	if err := applyClientTOMLConfig(cfg, path, clientFlagSetForTOML()); err != nil {
+		t.Fatalf("applyClientTOMLConfig: %v", err)
+	}
+	if want := "2001:db8::/32,2001:db9::/48"; cfg.TunRoutes6 != want {
+		t.Errorf("cfg.TunRoutes6 = %q, want %q", cfg.TunRoutes6, want)
+	}
+}
+
+// TestApplyClientTOMLConfig_TunRoutes6Absent: a silent file must not clear what
+// the command line set, and must not invent a value — an absent key is the
+// full tunnel, which is not something a file should start claiming by itself.
+func TestApplyClientTOMLConfig_TunRoutes6Absent(t *testing.T) {
+	path := writeClientTOML(t, `
+[server]
+address = "203.0.113.10"
+`)
+	cfg := &client.Config{TunRoutes6: "none"}
+	if err := applyClientTOMLConfig(cfg, path, clientFlagSetForTOML()); err != nil {
+		t.Fatalf("applyClientTOMLConfig: %v", err)
+	}
+	if cfg.TunRoutes6 != "none" {
+		t.Errorf("cfg.TunRoutes6 = %q, want the CLI value to survive a silent file", cfg.TunRoutes6)
+	}
+}

--- a/cmd/tiredvpn/main.go
+++ b/cmd/tiredvpn/main.go
@@ -325,6 +325,18 @@ TUN MODE (Full VPN):
         about: a 6in4 tunnel, another VPN, a routed prefix. An interface that
         does not exist yet is accepted (it may appear later); a malformed
         prefix is a startup error.
+  -tun-routes6 string
+        Which IPv6 destinations the tunnel claims, the v6 counterpart of
+        -tun-routes. Unset (the default) installs ::/1 + 8000::/1, which is
+        every IPv6 destination and takes over the host's IPv6 default route.
+        'none' claims nothing: the tunnel still gets a v6 address, but the
+        host keeps its own IPv6 routing and the operator routes into the
+        tunnel from their own tables (ip -6 rule / ip -6 route ... table X).
+        Otherwise a comma-separated list of prefixes or addresses to route in.
+        For a node with IPv6 of its own it must not surrender — a 6in4
+        tunnel, a router uplink, a second VPN. Setting it also disables the
+        blanket IPv6 leak block, which only makes sense while the tunnel is
+        claiming all of IPv6. Requires -tun-ipv6=dual.
   -tun-fd int
         Use existing TUN file descriptor - for Android VpnService (default -1)
 
@@ -655,6 +667,7 @@ func runClient(args []string) {
 	fs.StringVar(&cfg.TunRoutes, "tun-routes", "", "Routes to add (comma-separated, e.g. '0.0.0.0/0' for full tunnel)")
 	fs.StringVar(&cfg.TunIPv6Policy, "tun-ipv6", tun.DefaultIPv6Policy, "IPv6 while the tunnel is up: dual (route it through the tunnel, rejecting it when the exit cannot carry it), block (reject it without asking the exit), off (IPv4-only tunnel, host IPv6 bypasses the VPN)")
 	fs.StringVar(&cfg.TunIPv6Allow, "tun-ipv6-allow", "", "Exceptions to the IPv6 block (comma-separated): interface names (he6) and/or IPv6 prefixes or addresses (2001:db8:77b::/64) that keep working while the block is up")
+	fs.StringVar(&cfg.TunRoutes6, "tun-routes6", "", "IPv6 destinations to route into the tunnel, the v6 counterpart of -tun-routes: comma-separated prefixes, or 'none' to claim no IPv6 destination and leave the host's own IPv6 routing alone (default: the ::/1 + 8000::/1 full tunnel)")
 
 	// Android VpnService flags
 	fs.IntVar(&cfg.TunFd, "tun-fd", -1, "Use existing TUN file descriptor (for Android VpnService)")

--- a/configs/client.example.toml
+++ b/configs/client.example.toml
@@ -72,6 +72,21 @@ port = 443
 # [tun]
 # ipv6_allow = ["he6", "2001:db8:77b::/64"]
 
+# --- Tunnel: which IPv6 destinations the tunnel claims ---
+# The v6 counterpart of -tun-routes. Left out, dual installs ::/1 + 8000::/1,
+# which cover every IPv6 address and beat the host's own default route on
+# prefix length - the full tunnel a laptop wants. On a node that carries IPv6
+# of its own, say ["none"]: the tunnel still gets a v6 address, but claims no
+# destination, and you route into it from your own tables the way you already
+# do for IPv4. A prefix list works too. Setting this also disables the blanket
+# IPv6 leak block, which only makes sense while the tunnel claims all of IPv6.
+# Requires -tun-ipv6=dual. Same as -tun-routes6, which replaces this list when
+# passed. There is no empty-array spelling: [] and an absent key serialize the
+# same, so "claim nothing" is ["none"].
+#
+# [tun]
+# routes6 = ["none"]
+
 [strategy]
 # TLS-mimicry transport. Options: reality, grpc, morph, ...
 # Optional: omit it (or leave it empty) to let the client pick a strategy.

--- a/docs/client.md
+++ b/docs/client.md
@@ -741,8 +741,12 @@ tiredvpn client \
 
 ### Full VPN with split routing
 
-IPv6 is set to `off` here on purpose: `dual` would send all IPv6 into the
-tunnel, which is not a split tunnel any more.
+IPv6 is set to `off` here on purpose: on its own, `dual` sends all IPv6 into
+the tunnel, which is not a split tunnel any more. Since `-tun-routes6` exists
+there is a second option - keep `dual` and mirror the v4 split on the v6 side
+(`-tun-routes6 2001:db8::/32,...`), which keeps IPv6 working inside the tunnel
+for the destinations you actually want there. `off` remains the simpler answer
+when you do not need IPv6 in the tunnel at all.
 
 ```bash
 sudo tiredvpn client \

--- a/docs/client.md
+++ b/docs/client.md
@@ -136,6 +136,7 @@ Defaults are `failure_threshold=2`, `cooldown=1m`, `max_cooldown=30m`,
 | `-tun-routes` | | Comma-separated CIDRs to route through VPN |
 | `-tun-ipv6` | `dual` | What happens to IPv6 while the tunnel is up: `dual`, `block`, `off` |
 | `-tun-ipv6-allow` | | Exceptions to that block: comma-separated interface names and/or IPv6 prefixes that keep working |
+| `-tun-routes6` | | Which IPv6 destinations the tunnel claims, the v6 counterpart of `-tun-routes`. Unset means all of it. `none` means the host keeps its own IPv6 routing |
 | `-tun-fd` | `-1` | Use an existing TUN file descriptor (Android VpnService) |
 
 An MTU outside 1280-9000 is a startup error, whether it came from the flag or
@@ -212,6 +213,53 @@ An interface that does not exist is accepted without complaint - a tunnel unit
 may well start after the client, and nftables matches the name once the device
 appears. A malformed prefix is a startup error: it cannot become correct later,
 and skipping it would leave you with a hole you believe is open.
+
+##### Which destinations the tunnel claims: `-tun-routes6`
+
+The exception list above fixes the filter. It does not fix the routing, and the
+same node hit the routing next.
+
+`dual` installs `::/1` and `8000::/1` into the main table. Between them they
+cover every IPv6 address, and a `/1` beats a `/0` on prefix length - metrics
+never enter that comparison - so they also take over the host's own default
+route. On a laptop that is the whole point: without it every application with a
+working v6 default reaches the internet around the tunnel. On a node that
+carries IPv6 for a reason of its own it is a regression, and the symptom is
+total: `he6` up, address assigned, 100% loss, everything leaving through a
+tunnel with a ULA source address that nothing routes back.
+
+IPv4 never had this problem because it has a lever. An absent `-tun-routes`
+installs no v4 route at all, which is what lets you put the tunnel's default
+into a table of your own and keep `main` for the host:
+
+```bash
+ip route replace default dev tiredvpn-usa table usa_table
+ip rule add iif wg-mt-usa lookup usa_table
+```
+
+`-tun-routes6` is that lever for IPv6:
+
+```bash
+-tun-routes6 none            # claim nothing; the host routes v6 itself
+-tun-routes6 2001:db8::/32   # claim exactly this
+```
+
+Unset keeps the half-defaults, so nothing changes for a client that does not
+pass it. `none` still negotiates dual-stack and still puts a v6 address on the
+tunnel - what it drops is the claim on the main table, leaving you to route
+into the tunnel from your own tables the same way you already do for IPv4.
+
+Setting it also takes the blanket leak block out of play, which is deliberate
+rather than a convenience. The block rejects every outbound IPv6 packet that is
+not the tunnel's, and that is the right fallback exactly while the tunnel is
+claiming all of IPv6. Once you have named the destinations, the rest of IPv6 is
+yours by construction: there is nothing there to leak, and a blanket reject
+would only cut the host's own connectivity. `-tun-ipv6-allow` still works and is
+still the right tool when you want the block and one hole in it.
+
+The flag needs `-tun-ipv6=dual`. Under `block` or `off` the tunnel never carries
+IPv6, so there would be nothing to route into it, and a flag that silently does
+nothing is worse than one that refuses to start.
 
 On a host with IPv6 forwarding on, the client says so at install time. What it
 says is narrow on purpose. The chain is hooked at `output`, which only sees
@@ -469,6 +517,7 @@ which is what the bare `-strategy` default does.
 | `[tls]` | `insecure_skip_verify` | bool | accepted, not yet read by the runtime |
 | `[logging]` | `level` | string | only `"debug"` acts on anything - it turns on debug logging, as `-debug` does |
 | `[tun]` | `ipv6_allow` | array | same as `-tun-ipv6-allow`; one interface name or IPv6 prefix per entry |
+| `[tun]` | `routes6` | array | same as `-tun-routes6`; one IPv6 prefix per entry, or the single entry `"none"` |
 | `[logging]` | `format` | string | accepted, not yet read by the runtime |
 | `[logging]` | `output` | string | accepted, not yet read by the runtime |
 
@@ -477,22 +526,30 @@ consumes it. It is listed rather than hidden so a config that sets it is not
 mistaken for a config that changes behaviour.
 
 The port-hopping, ECH, post-quantum, benchmarking and monitoring knobs have no
-TOML keys at all and stay command-line only. So do the TUN knobs, with one
-exception: `[tun] ipv6_allow`, which a pooled unit configured entirely from a
-file would otherwise have no way to set. `-tun-ipv6` itself is still
-command-line only, so its default applies to a TOML-only client - and a file
-that lists exceptions describes exceptions to whatever the unit's command line
-asked for. See the [migration guide](../internal/config/toml/MIGRATION.md) for
-the field-by-field table.
+TOML keys at all and stay command-line only. So do the TUN knobs, with two
+exceptions: `[tun] ipv6_allow` and `[tun] routes6`, which a pooled unit
+configured entirely from a file would otherwise have no way to set. `-tun-ipv6`
+itself is still command-line only, so its default applies to a TOML-only client
+- and a file that lists exceptions describes exceptions to whatever the unit's
+command line asked for. See the
+[migration guide](../internal/config/toml/MIGRATION.md) for the field-by-field
+table.
 
 ```toml
 [tun]
 ipv6_allow = ["he6", "2001:db8:77b::/64"]
+routes6 = ["none"]
 ```
 
-Passing `-tun-ipv6-allow` replaces this list rather than adding to it: "except
-these" is one statement, and a command line that has to know what the file
-already said is not an override.
+Passing `-tun-ipv6-allow` or `-tun-routes6` replaces the corresponding list
+rather than adding to it: "except these" and "claim these" are each one
+statement, and a command line that has to know what the file already said is not
+an override.
+
+`routes6` has no empty-array spelling. `routes6 = []` and an absent key are the
+same bytes after serialization, and they mean opposite things - nothing versus
+the full tunnel - so "claim nothing" is written `["none"]`. Mixing `"none"` with
+a prefix is a startup error rather than a guess about which one you meant.
 
 ### Several servers
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -83,6 +83,13 @@ type Config struct {
 	// newTUNVPNConfig. Empty means no exceptions, the historical behaviour.
 	TunIPv6Allow string
 
+	// TunRoutes6 is the -tun-routes6 value: which IPv6 destinations the tunnel
+	// claims once dual-stack is negotiated, in the same raw comma-separated
+	// form TunRoutes has, plus the literal "none" for no destination at all.
+	// Empty means the ::/1 + 8000::/1 half-defaults, the historical behaviour.
+	// Parsed via tun.ParseIPv6Routes in newTUNVPNConfig.
+	TunRoutes6 string
+
 	// Host-supplied TUN integration (Android VpnService / macOS NetworkExtension).
 	// In both modes the TUN fd is created by the host and passed in via TunFd;
 	// the host (not Go) also owns route/DNS/firewall setup.
@@ -809,6 +816,20 @@ func newTUNVPNConfig(cfg *Config, mgr *strategy.Manager) (tun.VPNConfig, error) 
 		return tun.VPNConfig{}, err
 	}
 
+	// Which IPv6 destinations the tunnel claims. Only dual-stack installs any,
+	// so naming them under a policy that never negotiates IPv6 is a
+	// contradiction the operator cannot discover at runtime — the flag would
+	// simply do nothing — and it is refused here rather than ignored.
+	ipv6Routes, err := tun.ParseIPv6Routes(cfg.TunRoutes6)
+	if err != nil {
+		return tun.VPNConfig{}, err
+	}
+	if ipv6Routes.OperatorManaged() && policy != tun.IPv6PolicyDual {
+		return tun.VPNConfig{}, fmt.Errorf(
+			"-tun-routes6 needs -tun-ipv6=dual: under %q the tunnel never carries IPv6, so there is nothing to route into it",
+			policy)
+	}
+
 	// Parse routes
 	var routes []string
 	if cfg.TunRoutes != "" {
@@ -843,6 +864,7 @@ func newTUNVPNConfig(cfg *Config, mgr *strategy.Manager) (tun.VPNConfig, error) 
 		// negotiates nothing and would be indistinguishable from it.
 		IPv6Policy:  policy,
 		IPv6Allow:   ipv6Allow,
+		IPv6Routes:  ipv6Routes,
 		TunFd:       cfg.TunFd,       // Android VpnService TUN fd
 		ProtectPath: cfg.ProtectPath, // Android socket protection path
 	}, nil

--- a/internal/client/tunroutes6_test.go
+++ b/internal/client/tunroutes6_test.go
@@ -1,0 +1,134 @@
+package client
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tiredvpn/tiredvpn/internal/tun"
+)
+
+// baseTunConfig is the minimum a TUN client needs to build a VPNConfig.
+func baseTunConfig() *Config {
+	return &Config{
+		TunName:    "tiredvpn0",
+		TunIP:      "10.8.0.2",
+		TunPeerIP:  "10.8.0.1",
+		ServerAddr: "203.0.113.10:443",
+	}
+}
+
+// TestNewTUNVPNConfigRoutes6 is the callsite test for -tun-routes6: parsing the
+// value and then not putting it into VPNConfig looks exactly like never passing
+// the flag, which on the node this exists for means its IPv6 stays dead.
+func TestNewTUNVPNConfigRoutes6(t *testing.T) {
+	cfg := baseTunConfig()
+	cfg.TunRoutes6 = "none"
+
+	vpnCfg, err := newTUNVPNConfig(cfg, nil)
+	if err != nil {
+		t.Fatalf("newTUNVPNConfig: %v", err)
+	}
+	if !vpnCfg.IPv6Routes.OperatorManaged() {
+		t.Fatal("-tun-routes6 did not reach VPNConfig")
+	}
+	nets, err := vpnCfg.IPv6Routes.Nets()
+	if err != nil {
+		t.Fatalf("Nets: %v", err)
+	}
+	if len(nets) != 0 {
+		t.Errorf("-tun-routes6=none still claims %v", nets)
+	}
+}
+
+// TestNewTUNVPNConfigRoutes6List: an explicit list arrives intact.
+func TestNewTUNVPNConfigRoutes6List(t *testing.T) {
+	cfg := baseTunConfig()
+	cfg.TunRoutes6 = "2001:db8::/32,2001:db9::/48"
+
+	vpnCfg, err := newTUNVPNConfig(cfg, nil)
+	if err != nil {
+		t.Fatalf("newTUNVPNConfig: %v", err)
+	}
+	nets, err := vpnCfg.IPv6Routes.Nets()
+	if err != nil {
+		t.Fatalf("Nets: %v", err)
+	}
+	if len(nets) != 2 || nets[0].String() != "2001:db8::/32" || nets[1].String() != "2001:db9::/48" {
+		t.Errorf("IPv6Routes = %v, want the two prefixes as written", nets)
+	}
+}
+
+// TestNewTUNVPNConfigRoutes6Unset: without the flag the tunnel keeps claiming
+// all of IPv6. This is the half of the change that must NOT move — a laptop
+// that stops installing the half-defaults is issue #55 again.
+func TestNewTUNVPNConfigRoutes6Unset(t *testing.T) {
+	vpnCfg, err := newTUNVPNConfig(baseTunConfig(), nil)
+	if err != nil {
+		t.Fatalf("newTUNVPNConfig: %v", err)
+	}
+	if vpnCfg.IPv6Routes.OperatorManaged() {
+		t.Fatal("an unset -tun-routes6 was read as operator-managed")
+	}
+	nets, err := vpnCfg.IPv6Routes.Nets()
+	if err != nil {
+		t.Fatalf("Nets: %v", err)
+	}
+	if len(nets) != 2 {
+		t.Fatalf("default config claims %v, want the two half-defaults", nets)
+	}
+	if nets[0].String() != "::/1" || nets[1].String() != "8000::/1" {
+		t.Errorf("default config claims %v, want [::/1 8000::/1]", nets)
+	}
+}
+
+// TestNewTUNVPNConfigRoutes6BadSpec: a malformed prefix stops the client rather
+// than leaving it running with routing the operator believes is in place.
+func TestNewTUNVPNConfigRoutes6BadSpec(t *testing.T) {
+	cfg := baseTunConfig()
+	cfg.TunRoutes6 = "2001:db8:::/32"
+
+	_, err := newTUNVPNConfig(cfg, nil)
+	if err == nil {
+		t.Fatal("a malformed prefix started the client anyway")
+	}
+	if !strings.Contains(err.Error(), "tun-routes6") {
+		t.Errorf("error %q does not name the flag at fault", err)
+	}
+}
+
+// TestNewTUNVPNConfigRoutes6NeedsDual: only dual-stack installs IPv6 routes, so
+// naming destinations under a policy that never negotiates IPv6 is a
+// contradiction the operator cannot see at runtime — the flag would just do
+// nothing.
+func TestNewTUNVPNConfigRoutes6NeedsDual(t *testing.T) {
+	for _, policy := range []string{"off", "block"} {
+		cfg := baseTunConfig()
+		cfg.TunRoutes6 = "none"
+		cfg.TunIPv6Policy = policy
+
+		if _, err := newTUNVPNConfig(cfg, nil); err == nil {
+			t.Errorf("-tun-routes6 with -tun-ipv6=%s was accepted", policy)
+		}
+	}
+
+	// And the combination that does make sense is accepted.
+	cfg := baseTunConfig()
+	cfg.TunRoutes6 = "none"
+	cfg.TunIPv6Policy = "dual"
+	if _, err := newTUNVPNConfig(cfg, nil); err != nil {
+		t.Errorf("-tun-routes6 with -tun-ipv6=dual was refused: %v", err)
+	}
+}
+
+// TestDefaultPolicyIsStillDual guards the premise the validation above rests
+// on: -tun-routes6 alone has to work, which it only does while the default
+// policy negotiates dual-stack.
+func TestDefaultPolicyIsStillDual(t *testing.T) {
+	policy, err := tun.ParseIPv6Policy(tun.DefaultIPv6Policy)
+	if err != nil {
+		t.Fatalf("parse default policy: %v", err)
+	}
+	if policy != tun.IPv6PolicyDual {
+		t.Fatalf("default -tun-ipv6 is %s; -tun-routes6 on its own would now be refused", policy)
+	}
+}

--- a/internal/config/toml/MIGRATION.md
+++ b/internal/config/toml/MIGRATION.md
@@ -28,6 +28,7 @@ default: loading fails and the error names the key and its position.
 | `--strategy=NAME`             | `[strategy] mode`              | optional; empty means the client picks |
 | `--tls-fingerprint=NAME`      | `[tls] fingerprint`            | **exception to the precedence rule**: a non-empty key in the file overwrites the flag |
 | `--tun-ipv6-allow=LIST`       | `[tun] ipv6_allow`             | comma-separated flag, one entry per array element in the file; the flag replaces the list, it does not extend it |
+| `--tun-routes6=LIST`          | `[tun] routes6`                | same shape and same replace-not-extend rule; `none` is written `["none"]`, since `[]` and an absent key are indistinguishable and mean opposite things |
 | `--shaper=NAME`               | `[shaper] preset`              | an explicit `--shaper` is applied after TOML and wins |
 | `--shaper-seed=N`             | `[shaper] seed`                | the flag is read only alongside `--shaper`; the file's `seed` belongs to `[shaper]` |
 | `--debug`                     | `[logging] level = "debug"`    | flag forces level only when `true`; no other level value does anything yet |
@@ -74,8 +75,8 @@ yet: a server config that omits them fails validation.
 
 Everything not in the tables above is still read straight from the FlagSet by
 `cmd/tiredvpn`: `--listen` and `--secret` on the client, the `--tun-*` family
-except `--tun-ipv6-allow` (`--tun-ipv6` itself included, so its default of
-`dual` applies to a TOML-only client as well), port hopping, ECH,
+except `--tun-ipv6-allow` and `--tun-routes6` (`--tun-ipv6` itself included, so
+its default of `dual` applies to a TOML-only client as well), port hopping, ECH,
 post-quantum, REALITY B1,
 burst-reshape, benchmarking, `--api-addr`, `--pprof`, `--list`. They will be
 migrated in follow-up issues.

--- a/internal/config/toml/client.go
+++ b/internal/config/toml/client.go
@@ -79,6 +79,17 @@ type ClientTun struct {
 	// that only lists exceptions describes exceptions to whatever the unit's
 	// command line asked for.
 	IPv6Allow []string `toml:"ipv6_allow,omitempty"`
+
+	// Routes6 is -tun-routes6: which IPv6 destinations the tunnel claims once
+	// dual-stack is negotiated. A list of prefixes, or the single entry "none"
+	// for no destination at all — which is not the same as an absent key, and
+	// cannot be spelled as an empty array for exactly that reason: omitempty
+	// makes `routes6 = []` and no routes6 the same bytes, while they mean
+	// opposite things (nothing versus the ::/1 + 8000::/1 full tunnel).
+	//
+	// Joined back into the flag's comma-separated form by the runtime, so the
+	// same comma rule as IPv6Allow applies.
+	Routes6 []string `toml:"routes6,omitempty"`
 }
 
 // validate checks only what is a property of this representation: the entries
@@ -95,6 +106,19 @@ func (t ClientTun) validate() error {
 		}
 		if strings.TrimSpace(entry) == "" {
 			return fmt.Errorf("tun.ipv6_allow[%d] is empty", i)
+		}
+	}
+	for i, entry := range t.Routes6 {
+		if strings.Contains(entry, ",") {
+			return fmt.Errorf("tun.routes6[%d]: %q contains a comma; put each prefix in its own list entry", i, entry)
+		}
+		if strings.TrimSpace(entry) == "" {
+			return fmt.Errorf("tun.routes6[%d] is empty", i)
+		}
+		// "none" is a statement about the whole list, not a destination, so a
+		// list that mixes it with prefixes says two contradictory things.
+		if strings.TrimSpace(entry) == "none" && len(t.Routes6) > 1 {
+			return fmt.Errorf(`tun.routes6: "none" claims no destination at all, so it cannot appear alongside %d other entr(y/ies)`, len(t.Routes6)-1)
 		}
 	}
 	return nil

--- a/internal/config/toml/override.go
+++ b/internal/config/toml/override.go
@@ -25,6 +25,7 @@ import (
 //	-fallback-v4   → selection.family
 //	-strategy      → strategy.mode
 //	-tun-ipv6-allow → tun.ipv6_allow (comma-separated → list)
+//	-tun-routes6   → tun.routes6 (comma-separated → list)
 //	-debug         → logging.level = "debug" (when true)
 //
 // Flags absent from this mapping are ignored — they belong to subsystems
@@ -72,6 +73,11 @@ func ApplyClientFlags(cfg *ClientConfig, fs *flag.FlagSet) error {
 			// "except these" is one statement, and a command line that has to
 			// know what the file already said is not an override.
 			cfg.Tun.IPv6Allow = splitCommaList(f.Value.String())
+		case "tun-routes6":
+			// Same rule as the exception list: naming the destinations is one
+			// statement, so the flag replaces the file's list rather than
+			// extending it.
+			cfg.Tun.Routes6 = splitCommaList(f.Value.String())
 		case "strategy":
 			cfg.Strategy.Mode = f.Value.String()
 		case "debug":
@@ -304,6 +310,9 @@ func mergeClient(dst, src *ClientConfig) {
 	// defaults and half from the file is not something a reader could predict.
 	if len(src.Tun.IPv6Allow) > 0 {
 		dst.Tun.IPv6Allow = src.Tun.IPv6Allow
+	}
+	if len(src.Tun.Routes6) > 0 {
+		dst.Tun.Routes6 = src.Tun.Routes6
 	}
 	if src.TLS.ServerName != "" {
 		dst.TLS.ServerName = src.TLS.ServerName

--- a/internal/config/toml/tun_test.go
+++ b/internal/config/toml/tun_test.go
@@ -21,6 +21,7 @@ func tunFlagSet() *flag.FlagSet {
 	fs := flag.NewFlagSet("client", flag.ContinueOnError)
 	fs.String("server", "", "")
 	fs.String("tun-ipv6-allow", "", "")
+	fs.String("tun-routes6", "", "")
 	return fs
 }
 
@@ -101,5 +102,81 @@ func TestClientTOML_TunIPv6AllowRejectsUnjoinable(t *testing.T) {
 		if _, err := ResolveClient(path, tunFlagSet()); err == nil {
 			t.Errorf("%s was accepted", body)
 		}
+	}
+}
+
+// TestClientTOML_TunRoutes6 reads the key the way an operator writes it.
+func TestClientTOML_TunRoutes6(t *testing.T) {
+	cfg, err := ResolveClient(writeTunTOML(t, `
+[server]
+address = "203.0.113.10"
+
+[tun]
+routes6 = ["2001:db8::/32"]
+`), tunFlagSet())
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if got := strings.Join(cfg.Tun.Routes6, ","); got != "2001:db8::/32" {
+		t.Errorf("Tun.Routes6 = %q", got)
+	}
+}
+
+// TestClientTOML_TunRoutes6RejectsMixedNone: "none" is a statement about the
+// whole list, so a file that also names prefixes says two contradictory things
+// and is refused rather than resolved by guessing which one won.
+func TestClientTOML_TunRoutes6RejectsMixedNone(t *testing.T) {
+	_, err := ResolveClient(writeTunTOML(t, `
+[server]
+address = "203.0.113.10"
+
+[tun]
+routes6 = ["none", "2001:db8::/32"]
+`), tunFlagSet())
+	if err == nil {
+		t.Fatal("a list mixing none with a prefix was accepted")
+	}
+	if !strings.Contains(err.Error(), "routes6") {
+		t.Errorf("error %q does not name the key at fault", err)
+	}
+}
+
+// TestClientTOML_TunRoutes6RejectsUnjoinable guards the representation: the
+// entries are joined with commas on the way to the runtime, so a comma inside
+// one would silently become two destinations.
+func TestClientTOML_TunRoutes6RejectsUnjoinable(t *testing.T) {
+	_, err := ResolveClient(writeTunTOML(t, `
+[server]
+address = "203.0.113.10"
+
+[tun]
+routes6 = ["2001:db8::/32,2001:db9::/48"]
+`), tunFlagSet())
+	if err == nil {
+		t.Fatal("an entry containing a comma was accepted")
+	}
+}
+
+// TestClientTOML_TunRoutes6FlagWins pins the precedence the rest of the schema
+// follows: naming the destinations is one statement, so an explicit flag
+// replaces the file's list rather than extending it.
+func TestClientTOML_TunRoutes6FlagWins(t *testing.T) {
+	path := writeTunTOML(t, `
+[server]
+address = "203.0.113.10"
+
+[tun]
+routes6 = ["2001:db8::/32"]
+`)
+	fs := tunFlagSet()
+	if err := fs.Parse([]string{"-tun-routes6", "none"}); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	cfg, err := ResolveClient(path, fs)
+	if err != nil {
+		t.Fatalf("ResolveClient: %v", err)
+	}
+	if got := strings.Join(cfg.Tun.Routes6, ","); got != "none" {
+		t.Errorf("Tun.Routes6 = %q, want the flag to replace the file's list", got)
 	}
 }

--- a/internal/tun/dualstack.go
+++ b/internal/tun/dualstack.go
@@ -3,6 +3,7 @@ package tun
 import (
 	"fmt"
 	"net"
+	"strings"
 )
 
 // dualStackRouteCIDRs are the two IPv6 half-default routes installed into the
@@ -45,6 +46,158 @@ func v6HalfDefaultPriority(linkIndex int) int {
 		linkIndex = 0
 	}
 	return v6HalfDefaultMetricBase + linkIndex
+}
+
+// ipv6RoutesNoneValue is the -tun-routes6 value for "the tunnel claims no IPv6
+// destination at all". It exists because the empty string already means
+// something else — the flag was not given, i.e. the half-defaults — and on the
+// IPv6 side those two cannot be collapsed the way they are on the IPv4 side,
+// where an absent -tun-routes installs nothing.
+const ipv6RoutesNoneValue = "none"
+
+// IPv6RouteSpec is the parsed -tun-routes6 value: which IPv6 destinations the
+// tunnel claims once dual-stack is negotiated.
+//
+// This is the IPv6 counterpart of -tun-routes, and it exists because the two
+// families disagreed about who owns the main routing table. An absent
+// -tun-routes installs no IPv4 route at all, which is what lets an operator put
+// the tunnel's default into a table of their own (ip rule / ip route ... table
+// X) and keep the host's own routing in main. Dual-stack IPv6 had no such
+// lever: it wrote ::/1 + 8000::/1 into main unconditionally, and since a /1
+// beats a /0 on prefix length — metrics never enter that comparison — it took
+// over the host's own IPv6 default as well.
+//
+// That is fine, and wanted, on a laptop: it is issue #55, where a v4-only
+// tunnel is bypassed by every application with a working v6 default. It is
+// wrong on a node that carries IPv6 for a reason of its own (a 6in4 tunnel, a
+// second VPN, a router's uplink), which loses that IPv6 outright.
+//
+// The zero value is "not given" and resolves to the half-defaults, so the
+// default behaviour is unchanged.
+type IPv6RouteSpec struct {
+	// set records that the operator named a value at all. "No list" and "an
+	// empty list" mean opposite things here — the half-defaults versus nothing
+	// — so they must stay distinguishable, and a nil slice cannot carry that.
+	set bool
+	// nets are the destinations to install. Empty with set means the operator
+	// took over IPv6 routing entirely.
+	nets []*net.IPNet
+	// raw is the value as written, for logs and for String.
+	raw string
+}
+
+// OperatorManaged reports whether the operator named the tunnel's IPv6
+// destinations themselves, rather than leaving the half-defaults in place.
+//
+// Beyond route installation this also decides the leak block: rejecting every
+// outbound IPv6 packet is the right fallback only while the tunnel is claiming
+// all of IPv6, which is exactly what the half-defaults do and exactly what an
+// operator-supplied list does not. On a node that routes IPv6 itself, a blanket
+// block does not prevent a leak — there is nothing meant to be inside the
+// tunnel to leak out of — it just kills the host's own IPv6.
+func (s IPv6RouteSpec) OperatorManaged() bool { return s.set }
+
+// String renders the spec the way it was written, for logs.
+func (s IPv6RouteSpec) String() string {
+	if !s.set {
+		return strings.Join(dualStackRouteCIDRs, ",")
+	}
+	if len(s.nets) == 0 {
+		return ipv6RoutesNoneValue
+	}
+	return s.raw
+}
+
+// Nets resolves the destinations to install into the tunnel. Without a spec
+// that is the pair of half-defaults; with one it is exactly what the operator
+// asked for, down to the empty set.
+func (s IPv6RouteSpec) Nets() ([]*net.IPNet, error) {
+	if !s.set {
+		return dualStackRouteNets()
+	}
+	out := make([]*net.IPNet, len(s.nets))
+	copy(out, s.nets)
+	return out, nil
+}
+
+// CIDRs resolves the destinations as strings, for the platforms that hand
+// routes to a command line rather than to netlink.
+func (s IPv6RouteSpec) CIDRs() ([]string, error) {
+	nets, err := s.Nets()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(nets))
+	for _, n := range nets {
+		out = append(out, n.String())
+	}
+	return out, nil
+}
+
+// ParseIPv6Routes parses a -tun-routes6 value. An empty string is "not given"
+// and keeps the half-defaults. The literal "none" claims no destination at all,
+// leaving the host's IPv6 routing untouched while the tunnel still carries a v6
+// address for the operator to route into from their own tables. Anything else
+// is a comma-separated list of IPv6 prefixes, or bare addresses standing for
+// their /128.
+//
+// A malformed or IPv4 entry is an error rather than a skipped line: it cannot
+// become correct later, and a client that started anyway would leave the
+// operator with routing they believe is in place and is not.
+func ParseIPv6Routes(spec string) (IPv6RouteSpec, error) {
+	trimmed := strings.TrimSpace(spec)
+	if trimmed == "" {
+		return IPv6RouteSpec{}, nil
+	}
+	if trimmed == ipv6RoutesNoneValue {
+		return IPv6RouteSpec{set: true, raw: trimmed}, nil
+	}
+	out := IPv6RouteSpec{set: true, raw: trimmed}
+	for _, raw := range strings.Split(trimmed, ",") {
+		entry := strings.TrimSpace(raw)
+		if entry == "" {
+			continue
+		}
+		netw, err := parseIPv6RouteEntry(entry)
+		if err != nil {
+			return IPv6RouteSpec{}, err
+		}
+		out.nets = append(out.nets, netw)
+	}
+	if len(out.nets) == 0 {
+		// Reachable only from a value that is all separators (",", " , ").
+		// Silently treating it as "none" would hand the operator a kill of
+		// their IPv6 routing from what is plainly a typo.
+		return IPv6RouteSpec{}, fmt.Errorf(
+			"tun-routes6: %q lists no prefix; use %q to claim no IPv6 destination", spec, ipv6RoutesNoneValue)
+	}
+	return out, nil
+}
+
+// parseIPv6RouteEntry turns one entry into the destination it installs: a
+// prefix as written (masked, so host bits do not narrow it), a bare address as
+// its /128.
+func parseIPv6RouteEntry(entry string) (*net.IPNet, error) {
+	if strings.Contains(entry, "/") {
+		ip, netw, err := net.ParseCIDR(entry)
+		if err != nil {
+			return nil, fmt.Errorf("tun-routes6: %q is not a valid IPv6 prefix: %w", entry, err)
+		}
+		if ip.To4() != nil {
+			return nil, fmt.Errorf(
+				"tun-routes6: %q is an IPv4 prefix; IPv4 routes belong to -tun-routes", entry)
+		}
+		return netw, nil
+	}
+	ip := net.ParseIP(entry)
+	if ip == nil {
+		return nil, fmt.Errorf("tun-routes6: %q is not a valid IPv6 prefix or address", entry)
+	}
+	if ip.To4() != nil {
+		return nil, fmt.Errorf(
+			"tun-routes6: %q is an IPv4 address; IPv4 routes belong to -tun-routes", entry)
+	}
+	return &net.IPNet{IP: ip.To16(), Mask: net.CIDRMask(128, 128)}, nil
 }
 
 // dualStackRouteNets parses dualStackRouteCIDRs. The constants are known-good,

--- a/internal/tun/dualstack_routes_test.go
+++ b/internal/tun/dualstack_routes_test.go
@@ -1,0 +1,305 @@
+package tun
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestParseIPv6RoutesValues covers the three shapes the flag can take. The
+// distinction that matters is between "not given" and "given as empty": they
+// resolve to opposite route sets, and a bool-less representation would collapse
+// them.
+func TestParseIPv6RoutesValues(t *testing.T) {
+	cases := []struct {
+		name    string
+		spec    string
+		managed bool
+		want    []string
+	}{
+		{"unset keeps the half-defaults", "", false, dualStackRouteCIDRs},
+		{"none claims nothing", "none", true, nil},
+		{"single prefix", "2001:db8::/32", true, []string{"2001:db8::/32"}},
+		{"list", "2001:db8::/32,2001:db9::/48", true, []string{"2001:db8::/32", "2001:db9::/48"}},
+		{"bare address is its /128", "2001:db8::1", true, []string{"2001:db8::1/128"}},
+		{"host bits do not narrow the prefix", "2001:db8::1/32", true, []string{"2001:db8::/32"}},
+		{"whitespace around entries", " 2001:db8::/32 , 2001:db9::/48 ", true, []string{"2001:db8::/32", "2001:db9::/48"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			spec, err := ParseIPv6Routes(c.spec)
+			if err != nil {
+				t.Fatalf("ParseIPv6Routes(%q): %v", c.spec, err)
+			}
+			if spec.OperatorManaged() != c.managed {
+				t.Errorf("OperatorManaged() = %v, want %v", spec.OperatorManaged(), c.managed)
+			}
+			nets, err := spec.Nets()
+			if err != nil {
+				t.Fatalf("Nets: %v", err)
+			}
+			got := make([]string, 0, len(nets))
+			for _, n := range nets {
+				got = append(got, n.String())
+			}
+			if strings.Join(got, ",") != strings.Join(c.want, ",") {
+				t.Errorf("Nets() = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+// TestParseIPv6RoutesRejects checks the entries that cannot become correct
+// later. Skipping them would leave the operator with a running client and
+// routing they believe is in place — the same reasoning as the allow list.
+func TestParseIPv6RoutesRejects(t *testing.T) {
+	for _, spec := range []string{
+		"0.0.0.0/0",      // IPv4 prefix: belongs to -tun-routes
+		"192.0.2.1",      // IPv4 address, same
+		"2001:db8::/129", // impossible mask
+		"not-a-prefix",   // not an address at all
+		"he6",            // an interface name; that is -tun-ipv6-allow
+		",",              // all separators, no prefix
+		" , ",            // the same with whitespace
+	} {
+		if _, err := ParseIPv6Routes(spec); err == nil {
+			t.Errorf("ParseIPv6Routes(%q) = nil error, want a rejection", spec)
+		}
+	}
+
+	// A stray separator next to a real entry is not fatal: the prefix the
+	// operator wrote is unambiguous, so it is taken rather than refused.
+	spec, err := ParseIPv6Routes("2001:db8::/32,,")
+	if err != nil {
+		t.Fatalf("a trailing separator should not be fatal: %v", err)
+	}
+	nets, err := spec.Nets()
+	if err != nil {
+		t.Fatalf("Nets: %v", err)
+	}
+	if len(nets) != 1 || nets[0].String() != "2001:db8::/32" {
+		t.Errorf("got %v, want just 2001:db8::/32", nets)
+	}
+}
+
+// TestIPv6RouteSpecString keeps the log honest: it is read to find out what the
+// kernel was told, so it has to name the resolved set rather than the constant.
+func TestIPv6RouteSpecString(t *testing.T) {
+	unset, _ := ParseIPv6Routes("")
+	if got := unset.String(); got != "::/1,8000::/1" {
+		t.Errorf("unset spec prints %q, want the half-defaults", got)
+	}
+	none, _ := ParseIPv6Routes("none")
+	if got := none.String(); got != "none" {
+		t.Errorf("none spec prints %q", got)
+	}
+	list, _ := ParseIPv6Routes("2001:db8::/32")
+	if got := list.String(); got != "2001:db8::/32" {
+		t.Errorf("list spec prints %q", got)
+	}
+}
+
+// TestNetsReturnsACopy guards the shared backing array: EnableDualStack stores
+// what Nets returns in t.routes6 and DisableIPv6 later walks it, so handing out
+// the spec's own slice would let one tunnel's teardown reorder another's.
+func TestNetsReturnsACopy(t *testing.T) {
+	spec, err := ParseIPv6Routes("2001:db8::/32,2001:db9::/48")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	first, err := spec.Nets()
+	if err != nil {
+		t.Fatalf("Nets: %v", err)
+	}
+	first[0] = nil
+	second, err := spec.Nets()
+	if err != nil {
+		t.Fatalf("Nets: %v", err)
+	}
+	if second[0] == nil {
+		t.Error("Nets returned the spec's own slice; mutating one caller's copy changed the next")
+	}
+}
+
+// --- the ruhop and the laptop, at the level the device actually decides ---
+
+// TestRuhopConfigKeepsItsOwnDefault is the configuration this flag exists for:
+// a node with a Hurricane Electric 6in4 tunnel and several tiredvpn clients,
+// each of which used to install ::/1 + 8000::/1 into the main table and beat
+// `default dev he6` on prefix length.
+//
+// Two things have to hold together, and both are checked because either alone
+// still leaves the node without IPv6: the tunnel claims no destination, and the
+// blanket leak block does not fire when an exit declines dual-stack.
+func TestRuhopConfigKeepsItsOwnDefault(t *testing.T) {
+	spec, err := ParseIPv6Routes("none")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	dev := &TUNDevice{name: "tiredvpn-usa"}
+	applyIPv6BlockConfig(dev, VPNConfig{
+		IPv6Policy: IPv6PolicyDual,
+		ServerAddr: "203.0.113.10:443",
+		IPv6Routes: spec,
+	})
+
+	nets, err := dev.ipv6Routes.Nets()
+	if err != nil {
+		t.Fatalf("Nets: %v", err)
+	}
+	if len(nets) != 0 {
+		t.Errorf("the tunnel claims %v; on this node that steals `default dev he6`", nets)
+	}
+	if dev.wantsIPv6Block() {
+		t.Error("the leak block still applies; on this node it rejects the host's own he6 traffic")
+	}
+}
+
+// TestUserConfigStillLosesItsIPv6Default is the symmetric case and the reason
+// the default cannot simply be flipped: on a laptop the half-defaults are
+// wanted. Without them a v4-only tunnel is bypassed by every application with a
+// working v6 default route, which is issue #55.
+func TestUserConfigStillLosesItsIPv6Default(t *testing.T) {
+	dev := &TUNDevice{name: "tiredvpn0"}
+	applyIPv6BlockConfig(dev, VPNConfig{
+		IPv6Policy: IPv6PolicyDual,
+		ServerAddr: "203.0.113.10:443",
+		// No IPv6Routes: the zero value, i.e. the flag was not given.
+	})
+
+	nets, err := dev.ipv6Routes.Nets()
+	if err != nil {
+		t.Fatalf("Nets: %v", err)
+	}
+	got := make([]string, 0, len(nets))
+	for _, n := range nets {
+		got = append(got, n.String())
+	}
+	if strings.Join(got, ",") != strings.Join(dualStackRouteCIDRs, ",") {
+		t.Errorf("default config claims %v, want the half-defaults %v", got, dualStackRouteCIDRs)
+	}
+	if !dev.wantsIPv6Block() {
+		t.Error("the leak block stopped applying to a plain client; that is issue #55 back")
+	}
+	// The half-defaults have to beat an RA-learned ::/0, which they do on
+	// prefix length alone. Assert the property rather than the constant, since
+	// the constant is what a regression would rewrite.
+	for _, n := range nets {
+		ones, _ := n.Mask.Size()
+		if ones == 0 {
+			t.Errorf("%s is a /0 and would tie with the host's default instead of beating it", n)
+		}
+	}
+}
+
+// TestBlockGateIgnoresAnExplicitList checks the gate reads "did the operator
+// name the destinations", not "is the list empty": a narrow list leaves most of
+// IPv6 outside the tunnel by the operator's own choice, and a blanket reject
+// would cut exactly that.
+func TestBlockGateIgnoresAnExplicitList(t *testing.T) {
+	spec, err := ParseIPv6Routes("2001:db8::/32")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	dev := &TUNDevice{name: "tiredvpn0", ipv6Policy: IPv6PolicyDual}
+	dev.SetIPv6Routes(spec)
+	if dev.wantsIPv6Block() {
+		t.Error("a narrow -tun-routes6 list still armed the blanket block")
+	}
+}
+
+// TestBlockPolicyStillBlocksWithoutTheFlag pins the other half: -tun-ipv6=block
+// is unaffected as long as the operator did not take routing over.
+func TestBlockPolicyStillBlocksWithoutTheFlag(t *testing.T) {
+	dev := &TUNDevice{name: "tiredvpn0", ipv6Policy: IPv6PolicyBlock}
+	if !dev.wantsIPv6Block() {
+		t.Error("-tun-ipv6=block stopped blocking")
+	}
+}
+
+// --- the call sites ---
+
+// TestEnableDualStackReadsTheSpec is the test that survives the mistake this
+// change is most likely to make: a spec parsed correctly, stored correctly,
+// covered by its own tests, and then not consulted by the one function that
+// installs routes. Every assertion above would pass with EnableDualStack still
+// calling dualStackRouteNets() and putting ::/1 on the ruhop node.
+//
+// Installing routes for real needs netlink and root, so the binding is checked
+// in the source instead: the function must reach the destinations through
+// ipv6Routes and must not name the package-level constants.
+func TestEnableDualStackReadsTheSpec(t *testing.T) {
+	for _, c := range []struct {
+		file string
+		fn   string
+	}{
+		{"tun_linux.go", "EnableDualStack"},
+		{"tun_darwin.go", "EnableDualStack"},
+		// Install and delete have to agree about which destinations exist:
+		// re-deriving the list on teardown is how a delete ends up looking for
+		// a route that was never added.
+		{"tun_darwin.go", "DisableIPv6"},
+	} {
+		t.Run(c.file+"."+c.fn, func(t *testing.T) {
+			body := funcBodySource(t, c.file, c.fn)
+			if !strings.Contains(body, "routes6") && !strings.Contains(body, "ipv6Routes") {
+				t.Errorf("%s.%s does not consult the -tun-routes6 spec at all", c.file, c.fn)
+			}
+			for _, forbidden := range []string{"dualStackRouteNets", "dualStackRouteCIDRs"} {
+				if strings.Contains(body, forbidden) {
+					t.Errorf("%s.%s still reaches the routes through %s, so -tun-routes6 does not reach the kernel",
+						c.file, c.fn, forbidden)
+				}
+			}
+		})
+	}
+}
+
+// TestApplyIPv6ConfigCarriesTheRouteSpec closes the gap between the flag and
+// the device, the step that has been wrong before in this tree: a value parsed
+// correctly and then not passed on behaves exactly like a value never given.
+func TestApplyIPv6ConfigCarriesTheRouteSpec(t *testing.T) {
+	spec, err := ParseIPv6Routes("2001:db8::/32")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	dev := &TUNDevice{name: "tiredvpn0"}
+	applyIPv6BlockConfig(dev, VPNConfig{IPv6Policy: IPv6PolicyDual, IPv6Routes: spec})
+
+	nets, err := dev.ipv6Routes.Nets()
+	if err != nil {
+		t.Fatalf("Nets: %v", err)
+	}
+	if len(nets) != 1 || nets[0].String() != "2001:db8::/32" {
+		t.Errorf("device holds %v; the config's route spec did not reach it", nets)
+	}
+}
+
+// funcBodySource returns the source text of one top-level function or method
+// body, so a test can assert what it does and does not reference.
+func funcBodySource(t *testing.T, file, name string) string {
+	t.Helper()
+	fset := token.NewFileSet()
+	parsed, err := parser.ParseFile(fset, file, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", file, err)
+	}
+	for _, decl := range parsed.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != name || fn.Body == nil {
+			continue
+		}
+		src, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("read %s: %v", file, err)
+		}
+		start := fset.Position(fn.Body.Pos()).Offset
+		end := fset.Position(fn.Body.End()).Offset
+		return string(src[start:end])
+	}
+	t.Fatalf("%s not found in %s", name, file)
+	return ""
+}

--- a/internal/tun/ipv6block_linux.go
+++ b/internal/tun/ipv6block_linux.go
@@ -297,10 +297,18 @@ func (t *TUNDevice) v6BlockIsInstalled() bool {
 }
 
 // wantsIPv6Block reports whether this device should carry the leak block: the
-// policy asks for it and there is an interface to key the table on. An unnamed
-// device is either torn down or was never configured.
+// policy asks for it, there is an interface to key the table on, and the
+// operator has not taken IPv6 routing over themselves. An unnamed device is
+// either torn down or was never configured.
+//
+// The -tun-routes6 condition is not a convenience switch. The block rejects
+// every outbound IPv6 packet that is not the tunnel's, which is the correct
+// fallback precisely while the tunnel claims all of IPv6 — the half-defaults.
+// Once the operator has named the destinations, the rest of IPv6 is theirs by
+// construction and there is nothing there to leak; blocking it would only cut
+// the host's own connectivity.
 func (t *TUNDevice) wantsIPv6Block() bool {
-	return t.ipv6Policy.BlocksLeakedIPv6() && t.name != ""
+	return t.ipv6Policy.BlocksLeakedIPv6() && t.name != "" && !t.ipv6Routes.OperatorManaged()
 }
 
 // ApplyIPv6LeakBlock installs the block when the policy asks for it. Called

--- a/internal/tun/tun_darwin.go
+++ b/internal/tun/tun_darwin.go
@@ -73,6 +73,12 @@ type TUNDevice struct {
 	v6Enabled bool
 	localIP6  net.IP
 	remoteIP6 net.IP
+	// ipv6Routes is the -tun-routes6 spec; routes6 is what EnableDualStack
+	// actually installed from it. DisableIPv6 deletes routes6 rather than
+	// re-deriving the list, so a delete cannot go looking for a destination
+	// that was never added.
+	ipv6Routes IPv6RouteSpec
+	routes6    []string
 
 	// ipv6Policy is the full -tun-ipv6 policy. Its blocking half is not
 	// implemented on macOS (see ApplyIPv6LeakBlock); v6BlockWarned keeps that
@@ -93,6 +99,14 @@ func (t *TUNDevice) SetIPv6Policy(p IPv6Policy) {
 	t.dualStack = p.NegotiatesDualStack()
 }
 
+// SetIPv6Routes records the -tun-routes6 spec, read by EnableDualStack. Unlike
+// the block setters below this is not a no-op: route installation is
+// implemented here, so the flag has to reach it or it would silently do
+// nothing on macOS.
+func (t *TUNDevice) SetIPv6Routes(s IPv6RouteSpec) {
+	t.ipv6Routes = s
+}
+
 // SetIPv6BlockAllow is a no-op on macOS: there is no leak block to punch holes
 // in. Present so the platform-independent caller in vpn.go needs no build tag.
 func (t *TUNDevice) SetIPv6BlockAllow([]net.IP) {}
@@ -108,7 +122,11 @@ func (t *TUNDevice) SetIPv6BlockAllowList(IPv6AllowList) {}
 // hidden: on a dual-stack Mac whose exit cannot carry IPv6, applications keep
 // reaching the internet over IPv6 outside the tunnel.
 func (t *TUNDevice) ApplyIPv6LeakBlock() {
-	if !t.ipv6Policy.BlocksLeakedIPv6() || t.v6BlockWarned {
+	// -tun-routes6 means the operator routes IPv6 themselves, so IPv6 outside
+	// the tunnel is their arrangement rather than a leak, and warning about it
+	// would be wrong rather than merely noisy. Same gate as the Linux
+	// wantsIPv6Block.
+	if !t.ipv6Policy.BlocksLeakedIPv6() || t.ipv6Routes.OperatorManaged() || t.v6BlockWarned {
 		return
 	}
 	t.v6BlockWarned = true
@@ -151,11 +169,19 @@ func (t *TUNDevice) EnableDualStack(clientIP6, serverIP6 net.IP) error {
 	// DisableIPv6, whose guard is v6Enabled: recording late left a failed
 	// second route install with the address and the first half-default
 	// stranded on the interface.
+	// Which destinations this tunnel claims. Without -tun-routes6 this is the
+	// pair of half-defaults, exactly as before.
+	routes6, err := t.ipv6Routes.CIDRs()
+	if err != nil {
+		return err
+	}
+
 	t.localIP6 = clientIP6
 	t.remoteIP6 = serverIP6
+	t.routes6 = routes6
 	t.v6Enabled = true
 
-	for _, r := range dualStackRouteCIDRs {
+	for _, r := range routes6 {
 		if err := runRoute("add", "-inet6", r, "-iface", t.name); err == nil {
 			continue
 		}
@@ -164,8 +190,8 @@ func (t *TUNDevice) EnableDualStack(clientIP6, serverIP6 net.IP) error {
 		}
 	}
 
-	log.Info("utun %s dual-stack enabled: local=%s, peer=%s, routes=%v",
-		t.name, clientIP6, serverIP6, dualStackRouteCIDRs)
+	log.Info("utun %s dual-stack enabled: local=%s, peer=%s, routes=%s",
+		t.name, clientIP6, serverIP6, t.ipv6Routes)
 	return nil
 }
 
@@ -180,11 +206,12 @@ func (t *TUNDevice) DisableIPv6() {
 	if !t.v6Enabled {
 		return
 	}
-	for _, r := range dualStackRouteCIDRs {
+	for _, r := range t.routes6 {
 		if err := runRoute("delete", "-inet6", r, "-iface", t.name); err != nil {
 			log.Debug("route delete -inet6 %s failed: %v", r, err)
 		}
 	}
+	t.routes6 = nil
 	if t.localIP6 != nil {
 		if err := runIfconfig(t.name, "inet6", t.localIP6.String(), "-alias"); err != nil {
 			log.Debug("ifconfig inet6 -alias failed: %v", err)

--- a/internal/tun/tun_linux.go
+++ b/internal/tun/tun_linux.go
@@ -125,6 +125,11 @@ type TUNDevice struct {
 	// see ipv6block_linux.go. Left at IPv6PolicyOff on host-owned interfaces
 	// (Android), where filtering belongs to VpnService.
 	ipv6Policy IPv6Policy
+	// ipv6Routes is the -tun-routes6 spec: which IPv6 destinations
+	// EnableDualStack claims, and — because a blanket block only makes sense
+	// while the tunnel claims all of IPv6 — whether the leak block applies at
+	// all. The zero value is the half-defaults, i.e. the historical behaviour.
+	ipv6Routes IPv6RouteSpec
 	// v6BlockInstalled reports that the leak-block table exists, so teardown
 	// removes exactly what it created and re-installs are logged as such.
 	v6BlockInstalled bool
@@ -542,6 +547,13 @@ func (t *TUNDevice) Configure(localIP, remoteIP net.IP, routes []string) error {
 	return nil
 }
 
+// SetIPv6Routes records the -tun-routes6 spec. Must be called before
+// EnableDualStack, which reads it to decide what to install, and before the
+// leak block's gate, which reads it to decide whether it applies at all.
+func (t *TUNDevice) SetIPv6Routes(s IPv6RouteSpec) {
+	t.ipv6Routes = s
+}
+
 // EnableDualStack brings up the IPv6 side of the tunnel after the exit
 // negotiated dual-stack (handshake v0x04 with the dual-stack flag). It
 // installs the negotiated v6 address and the two v6 half-default routes
@@ -558,7 +570,9 @@ func (t *TUNDevice) EnableDualStack(clientIP6, serverIP6 net.IP) error {
 	if err != nil {
 		return err
 	}
-	routes6, err := dualStackRouteNets()
+	// Which destinations this tunnel claims. Without -tun-routes6 this is the
+	// pair of half-defaults, byte for byte what it always was.
+	routes6, err := t.ipv6Routes.Nets()
 	if err != nil {
 		return err
 	}
@@ -641,8 +655,11 @@ func (t *TUNDevice) EnableDualStack(clientIP6, serverIP6 net.IP) error {
 	// tunnel's own v6 the moment it started working.
 	t.RemoveIPv6LeakBlock()
 
-	log.Info("TUN device %s dual-stack enabled: local=%s, peer=%s, routes=%v",
-		t.name, clientIP6, serverIP6, dualStackRouteCIDRs)
+	// The spec, not the package constant: with -tun-routes6 the two differ, and
+	// a log naming ::/1 while the kernel holds something else is worse than no
+	// log at all.
+	log.Info("TUN device %s dual-stack enabled: local=%s, peer=%s, routes=%s",
+		t.name, clientIP6, serverIP6, t.ipv6Routes)
 	return nil
 }
 

--- a/internal/tun/vpn.go
+++ b/internal/tun/vpn.go
@@ -209,6 +209,13 @@ type VPNConfig struct {
 	// which is the block as it shipped.
 	IPv6Allow IPv6AllowList
 
+	// IPv6Routes is the parsed -tun-routes6 spec: which IPv6 destinations the
+	// tunnel claims once dual-stack is negotiated. The zero value is the
+	// ::/1 + 8000::/1 half-defaults, i.e. the full tunnel issue #55 asks for.
+	// Setting it hands IPv6 routing policy back to the operator, which also
+	// takes the blanket leak block out of play — see IPv6RouteSpec.
+	IPv6Routes IPv6RouteSpec
+
 	// DualStack is the pre-policy spelling of IPv6Policy == IPv6PolicyDual,
 	// kept for callers that have not moved over (macOS, benchmarks). Ignored
 	// when IPv6Policy is set to anything but its zero value.
@@ -337,6 +344,10 @@ func applyIPv6BlockConfig(dev *TUNDevice, cfg VPNConfig) {
 	// over IPv6 must not be caught by it.
 	dev.SetIPv6BlockAllow(serverIP6s(cfg))
 	dev.SetIPv6BlockAllowList(cfg.IPv6Allow)
+	// The route spec belongs here rather than next to Configure: it decides
+	// what EnableDualStack installs *and* whether the block applies at all, so
+	// it has to be on the device before either is consulted.
+	dev.SetIPv6Routes(cfg.IPv6Routes)
 }
 
 // NewVPNClient creates a new VPN client


### PR DESCRIPTION
A relay node lost all of its own IPv6 the moment tiredvpn clients came up on it. The interface was up, the address assigned, and every destination timed out.

## What was actually wrong

Not the leak block — that was the first guess and it was wrong twice over. The block is installed only from the client path (the server's `ConfigureSubnet` never touches it), and on this node it was not installed at all: the exits do return a v6 pool, so dual-stack was negotiated and `ipv6ActionFor` returns `EnableDual`, not `Block`.

The damage came from the routes. `dual` writes `::/1` and `8000::/1` into the main table unconditionally. Those two cover all of IPv6 and beat the host's own `::/0` on prefix length — metrics never enter the comparison. So the node's traffic went into a tunnel whose ULA source address nothing routes back:

```
::/1      dev tiredvpn-usa2   metric 849
8000::/1  dev tiredvpn-usa    metric 848
default   dev he6             metric 1024

ip -6 route get 2606:4700:4700::1111
  → dev tiredvpn-usa src fd00:8:100::a08:6402
```

IPv4 never had this problem, and the reason is instructive: an absent `-tun-routes` installs no route at all. That is what lets an operator keep the main table for the host and put each tunnel's default in a table of their own — which is exactly how this node is set up, with per-tunnel tables and `ip rule`. IPv6 offered no such lever, so the half-defaults trampled a routing policy that v4 respected. Worth noting what the node's own v6 tables held: nothing. IPv6 was not being routed into the tunnels at all, so the half-defaults were pure collateral.

## The lever

`-tun-routes6` mirrors `-tun-routes`:

- **unset** — half-defaults as before. A plain client is bit-for-bit unchanged, and issue #55 stays fixed.
- **`none`** — claim no destination. The operator owns IPv6 routing.
- **a prefix list** — claim exactly those.

Setting it also disables the blanket leak block, and that is deliberate rather than incidental: rejecting every outbound IPv6 packet is the right fallback only while the tunnel claims all of IPv6. Once the operator has named the destinations, a blanket block prevents no leak — there is nothing meant to be inside the tunnel to leak out of — it only kills the host's own IPv6.

## Verification

The two directions of failure are covered separately, because they are different bugs. Forcing `OperatorManaged` false reddens `TestRuhopConfigKeepsItsOwnDefault` — the node loses its default again. Forcing it true reddens `TestUserConfigStillLosesItsIPv6Default` and `TestBlockPolicyStillBlocksWithoutTheFlag` — a laptop stops sending IPv6 through the tunnel, which is the regression that would quietly reopen issue #55.

Gate clean: build, vet, `go test ./... -race -short`, `golangci-lint run` 0 issues. Wire format untouched. Docs updated alongside the flag.